### PR TITLE
Fix rare test flakiness

### DIFF
--- a/tests/common_strategies.py
+++ b/tests/common_strategies.py
@@ -13,7 +13,7 @@ concept_label_strategy = st.text(
     min_size=1,
     max_size=25,
     alphabet=st.characters(exclude_categories=("C", "Zl", "Zp", "P", "M", "S")),
-).filter(lambda x: x.strip())
+).map(lambda x: x.strip()).filter(lambda x: x)
 
 
 @st.composite


### PR DESCRIPTION
The `filter` method is a boolean check that removes items that are not truthy. The previous behavior would evaluate the example as a boolean after running `strip()`. Thus removing empty strings or just spaces. However, it didnt actually change the values, meaning examples with preceeding or trailing whitespace would be included because they'd be evaluated as True.

```
Example results:
"" becomes bool("") -> False
" " becomes bool("") -> False
"A " becomes bool("A") -> True (but still returned "A ")
```

To fix this and preserve the behavior, this runs map first then filters out anything that is now Falsey. So that last example returns: "A"