### PR TITLE
fix: Install dev dependencies group

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ set dotenv-load
 
 # install dependencies and set up the project
 install:
-    poetry install
+    poetry install --with dev
     poetry run pre-commit install
     poetry run ipython kernel install --user
 


### PR DESCRIPTION
Otherwise, `pytest` and others will be missing.

TOWARDS PLA-206
