### PR TITLE
store labeller usernames from argilla instead of opaque ids

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -156,7 +156,7 @@ def main(
         # take a range of thresholds to get a sense of how the model performs at
         # different levels of agreement (with 0 allowing for any overlap between model
         # and human, and 1 setting a requirement for an exact match)
-        span_level_agreement_thresholds = [0, 0.5, 0.9, 1]
+        span_level_agreement_thresholds = [0, 0.5, 0.9, 0.99]
         for threshold in span_level_agreement_thresholds:
             confusion_matrices[group][f"Span level ({threshold})"] = (
                 count_span_level_metrics(
@@ -192,7 +192,6 @@ def main(
     console.log(table)
 
     metrics_path = processed_data_dir / "classifier_performance" / f"{wikibase_id}.json"
-
     df.to_json(metrics_path, orient="records", indent=2)
     console.log(f"📄 Saved performance metrics to {metrics_path}")
 

--- a/src/labelled_passage.py
+++ b/src/labelled_passage.py
@@ -1,6 +1,6 @@
 import html
 
-from argilla import FeedbackRecord
+from argilla import FeedbackRecord, User
 from pydantic import BaseModel, Field, model_validator
 
 from src.identifiers import generate_identifier
@@ -49,7 +49,7 @@ class LabelledPassage(BaseModel):
         spans = []
 
         for response in record.responses or []:
-            user_id = str(response.user_id)
+            user_name = User.from_id(response.user_id).username
             try:
                 for entity in response.values["entities"].value:
                     spans.extend(
@@ -59,7 +59,7 @@ class LabelledPassage(BaseModel):
                                 start_index=entity.start,
                                 end_index=entity.end,
                                 concept_id=entity.label,
-                                labellers=[user_id],
+                                labellers=[user_name],
                             )
                         ]
                     )


### PR DESCRIPTION
Policy team requested to see human-readable usernames when running inter-annotator-agreement checks, instead of opaque UUIDs. Rerunning the `analyse-classifier` recipe with the change to `src/labelled_passage.py` gives us the intended result, eg

![Screenshot 2024-10-02 at 12 09 08](https://github.com/user-attachments/assets/067bcd08-55f3-425e-b0d9-7fc150c14b42)

--- 

Additional mini bugfix in `scripts/evaluate.py` to make sure we calculate actual values for span-level exact match metrics