### PR TITLE
Add recipe to label single text string

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,8 +31,8 @@ evaluate id:
     poetry run python scripts/evaluate.py --wikibase-id {{id}}
 
 # run a model for a specific wikibase ID on a supplied string
-label id string: (train id)
-    poetry run python scripts/label.py --wikibase-id {{id}} {{string}}
+label id string:
+    poetry run python scripts/label.py --wikibase-id {{id}} --input-string {{string}}
 
 # find instances of the concept in a set of passages for a specific wikibase ID
 predict id:

--- a/scripts/label.py
+++ b/scripts/label.py
@@ -1,0 +1,51 @@
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from scripts.config import classifier_dir
+from src.classifier import Classifier
+from src.identifiers import WikibaseID
+from src.labelled_passage import LabelledPassage
+
+console = Console()
+
+app = typer.Typer()
+
+
+@app.command()
+def main(
+    wikibase_id: Annotated[
+        WikibaseID,
+        typer.Option(
+            ...,
+            help="The Wikibase ID of the concept classifier to run",
+            parser=WikibaseID,
+        ),
+    ],
+    input_string: Annotated[str, typer.Option()],
+):
+    """Run a classifier on a supplied string"""
+    try:
+        classifier = Classifier.load(classifier_dir / wikibase_id)
+        console.log(f"Loaded {classifier} from {classifier_dir}")
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            f"Classifier for {wikibase_id} not found. \n"
+            "If you haven't already, you should run:\n"
+            f"  just train {wikibase_id}"
+        ) from e
+
+    spans = classifier.predict(input_string)
+    labelled_passage = LabelledPassage(
+        text=input_string,
+        spans=spans,
+    )
+    console.log(labelled_passage.get_highlighted_text())
+
+    console.log("Spans:")
+    console.log(spans)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
Illustrative script to run single model inference on a single piece of text. For example:

```
just label Q788 '"I love fishing"''
```

Will then output the spans the classifier has identified.