### PR TITLE
only use labellers' most recent annotations from argilla

### DIFF
--- a/src/labelled_passage.py
+++ b/src/labelled_passage.py
@@ -37,16 +37,12 @@ class LabelledPassage(BaseModel):
         return self
 
     @classmethod
-    def from_argilla_record(
-        cls, record: FeedbackRecord, filter_for_submitted: bool = True
-    ) -> "LabelledPassage":
+    def from_argilla_record(cls, record: FeedbackRecord) -> "LabelledPassage":
         """
         Create a LabelledPassage object from an Argilla record
 
         :param FeedbackRecord record: The Argilla record to create the LabelledPassage
         object from
-        :param bool filter_for_submitted: Whether to filter for only submitted records,
-        defaults to True
         :return LabelledPassage: The created LabelledPassage object
         """
         text = html.unescape(record.fields.get("text", ""))


### PR DESCRIPTION
We spotted a weird bug where labellers' old, outdated labels were still appearing in our eval dataset span visualisations. After a bit of digging we discovered that these situations occur when labellers have submitted the same passage twice. 

Labellers expected that old annotations would be overwritten by the new submission (as did I!), but apparently that's not the case.

For example, there's an outdated label from `user_id` `38ac9824...` in the data below, with a span from `start=0, end=38` (4th response in the list). It should be superseded by the span from `start=22, end=38` from the same `user_id` (2nd response in the list)

```
[RemoteResponseSchema(id=None, client=None, user_id=UUID('ef871878-5684-44a0-adc5-edaabf11cc00'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=22, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 8, 28, 9, 29, 3, 137076), updated_at=datetime.datetime(2024, 8, 28, 9, 29, 3, 137076)),
 RemoteResponseSchema(id=None, client=None, user_id=UUID('38ac9824-1776-4fa2-a71c-7cf05890e9da'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=22, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 9, 4, 10, 53, 35, 997042), updated_at=datetime.datetime(2024, 10, 3, 10, 35, 45, 806080)),
 RemoteResponseSchema(id=None, client=None, user_id=UUID('ef871878-5684-44a0-adc5-edaabf11cc00'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=22, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 8, 28, 12, 16, 14, 690079), updated_at=datetime.datetime(2024, 8, 28, 12, 16, 14, 690079)),
 RemoteResponseSchema(id=None, client=None, user_id=UUID('38ac9824-1776-4fa2-a71c-7cf05890e9da'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=0, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 9, 4, 13, 33, 39, 384898), updated_at=datetime.datetime(2024, 9, 4, 13, 33, 39, 384898))]
 ```

The changes in this PR mean that we get a filtered list of annotations from the response, with one set of entities per annotator:

```
[RemoteResponseSchema(id=None, client=None, user_id=UUID('38ac9824-1776-4fa2-a71c-7cf05890e9da'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=22, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 9, 4, 10, 53, 35, 997042), updated_at=datetime.datetime(2024, 10, 3, 10, 35, 45, 806080)),
 RemoteResponseSchema(id=None, client=None, user_id=UUID('ef871878-5684-44a0-adc5-edaabf11cc00'), values={'entities': ValueSchema(value=[SpanValueSchema(label='Q973', start=22, end=38, score=None)])}, status=<ResponseStatus.submitted: 'submitted'>, inserted_at=datetime.datetime(2024, 8, 28, 12, 16, 14, 690079), updated_at=datetime.datetime(2024, 8, 28, 12, 16, 14, 690079))]
 ```