### PR TITLE
Only import `EmbeddingClassifier` when called

### DIFF
--- a/src/classifier/__init__.py
+++ b/src/classifier/__init__.py
@@ -7,7 +7,23 @@ from src.concept import Concept
 
 
 def __getattr__(name):
-    """Only import embeddings when we want it"""
+    """
+    Only import embeddings when we want it
+
+    This adds a special case for embeddings because they rely on very large external
+    libraries. Importing these libraries is very slow and having them installed
+    requires much more disc space, so we gave them a distinct group in the
+    pyproject.toml file (see: f53a404).
+
+    This makes it so we only import them when we explicitly want to. So the following
+    import statments will both work, but only the second requires the embeddings group
+    to have been installed with poetry:
+
+    ```
+    from src.classifier import Classifier
+    from src.classifier import EmbeddingClassifier
+    ```
+    """
     if name == "EmbeddingClassifier":
         module = importlib.import_module(".embedding", __package__)
         return getattr(module, name)


### PR DESCRIPTION
We previously made it possible to install dependencies without embeddings libraries, but missed updating the module import behaviour. The previous version would have imported the `EmbeddingClassifier` and therefore also `sentence_transformers` from that file. Here we change the module behaviour, so that we only actually import the `EmbeddingClassifier` when we are explicitly using it.

This approach makes sure both of the below import statments still work. The latter requiring the `embeddings` group to have been installed with poetry:
```
from src.classifier import Classifier
from src.classifier import EmbeddingClassifier
```

This has the added bonus of saving a few seconds of start up time for anything not using it (as sentence_transformers can take 5-30 seconds to import).