### PR TITLE
Clearer typing for inference classifier spec

### DIFF
--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -6,6 +6,7 @@ import pytest
 from prefect.testing.utilities import prefect_test_harness
 
 from flows.inference import (
+    ClassifierSpec,
     _stringify,
     classifier_inference,
     determine_document_ids,
@@ -141,7 +142,7 @@ async def test_classifier_inference(
     doc_ids = [Path(doc_file).stem for doc_file in mock_bucket_documents]
     with prefect_test_harness():
         await classifier_inference(
-            classifier_spec=[("Q788", "latest")],
+            classifier_specs=[ClassifierSpec(name="Q788", alias="latest")],
             document_ids=doc_ids,
             config=test_config,
         )


### PR DESCRIPTION
Changes the classifier spec to use a pydantic model. Meaning we get some nice documentation in the prefect user interface and less serialisation challenges from the tuple based input. This should be useful for cli usage (more to follow), and also for webapp usage, see example:

![image](https://github.com/user-attachments/assets/fe057fe2-4909-4795-8d1d-a4ab2a8c80fd)
