### PR TITLE
Feature/pla 238 add extra fields to stored labels

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -216,7 +216,6 @@ def text_block_inference(
         spans=spans,
         metadata={
             "concept": classifier.concept.model_dump(),
-            "text_block_id": block_id,
             "inference_timestamp": datetime.now().isoformat(),
         },
     )

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -135,7 +135,6 @@ async def test_text_block_inference(
     assert labels.id == block_id
     assert labels.metadata != {}
     assert labels.metadata["concept"] == classifier.concept.model_dump()
-    assert labels.metadata["text_block_id"] == block_id
     datetime.fromisoformat(labels.metadata["inference_timestamp"])
 
 


### PR DESCRIPTION
This Pull Request: 
---
- Adds extra data to the labelled passages stored in s3.
- Parent concept is the only field that we need to add at this point in the process. 
- It was decided to use the metadata field to avoid requiring a schema update. 


Note: Updated to add the entire concept and added the text block id. 