### PR TITLE
Pass actual value of wandb api key to wand login

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -113,7 +113,7 @@ def download_classifier_from_wandb_to_local(
     to both the s3 bucket via iam in your environment and WanDB via
     the api key.
     """
-    wandb.login(key=config.wandb_api_key)
+    wandb.login(key=config.wandb_api_key.get_secret_value())
     run = wandb.init(
         entity=config.wandb_entity, project=classifier_name, job_type="download_model"
     )

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -15,6 +15,7 @@ from cpr_sdk.parser_models import (
     PDFTextBlock,
 )
 from moto import mock_aws
+from pydantic import SecretStr
 
 from flows.inference import Config
 from src.identifiers import WikibaseID
@@ -28,7 +29,7 @@ def test_config():
         cache_bucket="test_bucket",
         wandb_model_registry="test_wandb_model_registry",
         wandb_entity="test_entity",
-        wandb_api_key="test_wandb_api_key",
+        wandb_api_key=SecretStr("test_wandb_api_key"),
     )
 
 


### PR DESCRIPTION
SecretStr inherits from str so probably would have been valid, however wandb is quite strict about it. See [wandb sdk](https://github.com/wandb/wandb/blob/main/wandb/sdk/wandb_settings.py#L571-L572).

Our error message:
```
Failed('Task run encountered an exception SettingsValidationError: Invalid value for property api_key: **********.')
```

As a bonus this may also solve some linting issues seen in some local setup!