### PR TITLE
Fix prefect prod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     needs: [deploy_prefect_sandbox]
     uses: ./.github/workflows/prefect_deploy.yml
     with:
-      aws-env: production
+      aws-env: prod
       prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import typer
 from prefect.deployments import run_deployment
 from prefect.settings import PREFECT_UI_URL
@@ -5,10 +7,18 @@ from rich.console import Console
 from typing_extensions import Annotated
 
 from flows.inference import ClassifierSpec
-from scripts.cloud import AwsEnv
 
 app = typer.Typer()
 console = Console()
+
+
+class AwsEnv(str, Enum):
+    """The only available AWS environments."""
+
+    labs = "labs"
+    sandbox = "sandbox"
+    staging = "staging"
+    production = "prod"
 
 
 def convert_classifier_specs(requested_classifiers: list[str]) -> list[ClassifierSpec]:


### PR DESCRIPTION
We have some inconsistency in prod naming between prefect and other contexts. I've done this as the quickest fix for now because I don't know the full implications of changing the original enum, it seemed likely it would be a short fix anyway didn't want to get distracted by making sure of that and then risk holding everything up.

Added a ticket to revisit this: https://linear.app/climate-policy-radar/issue/PLA-281/use-consistent-prod-naming-across-kg-repo