### PR TITLE
Add option to run on latest new_and_updated_docs

### DIFF
--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 from io import BytesIO
 from pathlib import Path
@@ -76,6 +77,43 @@ def mock_bucket_documents(mock_s3_client, mock_bucket):
             Bucket=mock_bucket, Key=key, Body=body, ContentType="application/json"
         )
     yield fixture_files
+
+
+def create_mock_new_and_updated_documents_json(
+    mock_s3_client, mock_bucket, doc_names: tuple[str, str], timestamp: str
+):
+    first_doc, second_doc = doc_names
+    content = {
+        "new_documents": [
+            {"import_id": first_doc},
+        ],
+        "updated_documents": {second_doc: []},
+    }
+    data = BytesIO(json.dumps(content).encode("utf-8"))
+    key = os.path.join("input", timestamp, "new_and_updated_documents.json")
+    mock_s3_client.put_object(
+        Bucket=mock_bucket, Key=key, Body=data, ContentType="application/json"
+    )
+
+
+@pytest.fixture
+def mock_bucket_new_and_updated_documents_json(mock_s3_client, mock_bucket):
+    previous_docs = {"Previous.document.0.2", "Previous.document.0.1"}
+    create_mock_new_and_updated_documents_json(
+        mock_s3_client,
+        mock_bucket,
+        doc_names=previous_docs,
+        timestamp="2023-01-1T01.01.01.000001",
+    )
+
+    latest_docs = {"Latest.document.0.2", "Latest.document.0.1"}
+    create_mock_new_and_updated_documents_json(
+        mock_s3_client,
+        mock_bucket,
+        doc_names=latest_docs,
+        timestamp="2023-01-1T01.01.01.000001",
+    )
+    yield previous_docs, latest_docs
 
 
 @pytest.fixture

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -13,6 +13,7 @@ from flows.inference import (
     determine_document_ids,
     document_passages,
     download_classifier_from_wandb_to_local,
+    get_latest_ingest_documents,
     list_bucket_doc_ids,
     load_classifier,
     load_document,
@@ -46,17 +47,21 @@ def test_list_bucket_doc_ids(test_config, mock_bucket_documents):
         (None, ["1"], ["1"]),
     ],
 )
-def test_determine_document_ids(doc_ids, bucket_ids, expected):
+def test_determine_document_ids(test_config, doc_ids, bucket_ids, expected):
     got = determine_document_ids(
+        config=test_config,
+        use_new_and_updated=False,
         requested_document_ids=doc_ids,
         current_bucket_ids=bucket_ids,
     )
     assert got == expected
 
 
-def test_determine_document_ids__error():
+def test_determine_document_ids__error(test_config):
     with pytest.raises(ValueError):
         determine_document_ids(
+            config=test_config,
+            use_new_and_updated=False,
             requested_document_ids=["1", "2"],
             current_bucket_ids=["3", "4"],
         )
@@ -177,3 +182,11 @@ async def test_classifier_inference(
         # Some spans where identified
         with_spans = [d for d in data if len(d["spans"]) > 0]
         assert len(with_spans) > 0
+
+
+def test_get_latest_ingest_documents(
+    test_config, mock_bucket_new_and_updated_documents_json
+):
+    _, latest_docs = mock_bucket_new_and_updated_documents_json
+    doc_ids = get_latest_ingest_documents(test_config)
+    assert set(doc_ids) == latest_docs


### PR DESCRIPTION
The main pipeline run uses this json file to track what documents need preprocessing. Here we add a flag that when used will base inference on the documents in the latest copy of this file. This allows us to run this flow as part of the main pipeline run.