### PR TITLE
Switch back to using "prod" for prefect deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     needs: [deploy_prefect_sandbox]
     uses: ./.github/workflows/prefect_deploy.yml
     with:
-      aws-env: production
+      aws-env: prod
       prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}

--- a/scripts/cloud.py
+++ b/scripts/cloud.py
@@ -29,12 +29,14 @@ class AwsEnv(str, Enum):
     labs = "labs"
     sandbox = "sandbox"
     staging = "staging"
-    production = "production"
+    production = "prod"
 
     @classmethod
     def _missing_(cls, value):
         if value == "dev":
             return cls.staging
+        if value == "production":
+            return cls.production
 
 
 def get_session(aws_env: AwsEnv) -> boto3.session.Session:

--- a/tests/__snapshots__/test_promote.ambr
+++ b/tests/__snapshots__/test_promote.ambr
@@ -22,7 +22,7 @@
 # ---
 # name: test_get_aliases[promotion5]
   list([
-    'production',
+    'prod',
   ])
 # ---
 # name: test_get_object_key[Q123-TestClassifier-version0]

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -198,7 +198,7 @@ def test_get_aliases(promotion, snapshot):
         (AwsEnv.labs, "cpr-labs-models"),
         (AwsEnv.sandbox, "cpr-sandbox-models"),
         (AwsEnv.staging, "cpr-staging-models"),
-        (AwsEnv.production, "cpr-production-models"),
+        (AwsEnv.production, "cpr-prod-models"),
     ],
 )
 def test_get_bucket_name_for_aws_env(aws_env, expected_bucket):

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -23,7 +23,7 @@ from src.identifiers import WikibaseID
         (AwsEnv.labs, "cpr-labs-models"),
         (AwsEnv.sandbox, "cpr-sandbox-models"),
         (AwsEnv.staging, "cpr-staging-models"),
-        (AwsEnv.production, "cpr-production-models"),
+        (AwsEnv.production, "cpr-prod-models"),
     ],
 )
 def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):


### PR DESCRIPTION
Prefect and W&B were using different references for prod. Previously we switched to prefer the wandb option, but this switches back the other way instead.