### PR TITLE
refactor(promote): Use single concept hierarchy

### DIFF
--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -323,7 +323,7 @@ def main(
     Promote a model from one account to another.
 
     Optionally as the primary model. If a W&B model registry
-    collection doesn't exist for the concept-classifier, it'll
+    collection doesn't exist for the concept, it'll
     automatically be made as part of this script.
     """
     log.info("Starting model promotion process")
@@ -411,12 +411,15 @@ def main(
             to_bucket = get_bucket_name_for_aws_env(promotion.value)
             to_object_key = get_object_key(wikibase_id, classifier, version)
 
-    collection_name = f"{wikibase_id}-{classifier}"
-
     aliases = get_aliases(promotion)
 
-    # This magic value was from the W&B webapp
-    # This is the hierarchy we use: CPR / {concept}-{classifier}
+    collection_name = wikibase_id
+
+    # This magic value was from the W&B webapp.
+    #
+    # This is the hierarchy we use: CPR / {concept} / {model architecture}(s)
+    #
+    # The concept aka Wikibase ID is the collection name.
     #
     # > W&B automatically creates a collection with the name you specify
     # > in the target path if you try to link an artifact to a collection


### PR DESCRIPTION
Instead of a collection per concept-classifier combination, we'll now have a collection per concept. Within that concept, each version will be linked to a classifier model, for the concept's W&B project. These classifier models vary from each other by having different model architectures.

**Testing**

I ran the scripts, and they succeeded.

1. `$ just train Q787 --track --upload --aws-env labs`
2. `$ just promote Q787 --classifier RulesBasedClassifier --version v0 --within-aws-env labs --primary`
3. Screenshots:

![CleanShot 2024-11-11 at 10 46 42](https://github.com/user-attachments/assets/70fdd75e-43f9-4ef4-bddd-85feaaa6962c)
![CleanShot 2024-11-11 at 10 46 32](https://github.com/user-attachments/assets/6d8f789b-2ab3-4dd1-95fe-f07db2d017ab)


FIXES PLA-260
