### PR TITLE
feat(demote): Add new script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ _or_
 just promote Q992 --classifier RulesBasedClassifier --version v7 --within-aws-env staging --no-primary
 ```
 
+You can also demote (aka disable) a promoted model version in an AWS account/environment, for a concept.
+
+```bash
+just demote Q787 labs
+```
+
 You can see the full list of commands by running:
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -47,6 +47,10 @@ evaluate id +OPTS="":
 promote id +OPTS="":
     poetry run promote --wikibase-id {{id}} {{OPTS}}
 
+# demote a model for a specific wikibase ID
+demote id aws_env:
+    poetry run demote --wikibase-id {{id}} --aws-env {{aws_env}}
+
 # run a model for a specific wikibase ID on a supplied string
 label id string:
     poetry run python scripts/label.py --wikibase-id {{id}} --input-string {{string}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ priority = "explicit"
 [tool.poetry.scripts]
 train = "scripts.train:app"
 promote = "scripts.promote:app"
+demote = "scripts.demote:app"
 evaluate = "scripts.evaluate:app"
 infer = "scripts.infer:app"
 

--- a/scripts/demote.py
+++ b/scripts/demote.py
@@ -1,0 +1,118 @@
+"""A script for model demotion."""
+
+import logging
+import os
+from typing import Annotated
+
+import typer
+import wandb
+from rich.logging import RichHandler
+
+from scripts.cloud import AwsEnv, is_logged_in
+from src.identifiers import WikibaseID
+
+logging.basicConfig(
+    level="INFO",
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[
+        RichHandler(rich_tracebacks=True),
+    ],
+)
+
+log = logging.getLogger("rich")
+
+ORG_ENTITY = "climatepolicyradar_UZODYJSN66HCQ"
+REGISTRY_NAME = "model"
+ENTITY = "climatepolicyradar"
+JOB_TYPE = "demote_model"
+
+REGION_NAME = "eu-west-1"
+
+
+def throw_not_logged_in(aws_env: AwsEnv):
+    """Raise a typer.BadParameter exception for a not logged in AWS environment."""
+    raise typer.BadParameter(
+        f"you're not logged into {aws_env.value}. "
+        f"Do `aws sso --login {aws_env.value}`"
+    )
+
+
+def validate_login(
+    aws_env: AwsEnv,
+    use_aws_profiles: bool,
+) -> None:
+    """Validate that the user is logged in to the necessary AWS environment."""
+    if not is_logged_in(aws_env, use_aws_profiles):
+        throw_not_logged_in(aws_env)
+
+
+app = typer.Typer()
+
+
+def parse_aws_env(value: str) -> str:
+    """
+    Parse a string a string as a possible enum value.
+
+    We rely on a somewhat custom enum, to allow `"dev"`|`"staging"` for
+    `staging`.
+    """
+    try:
+        # This would convert `"dev"` to `AwsEnv.staging`.
+        #
+        # The raw value is returned, since we can't return an `AwsEnv` from
+        # this function.
+        return AwsEnv(value).value
+    except ValueError as e:
+        if "is not a valid AwsEnv" in str(e):
+            valid = ", ".join([f"'{env.value}'" for env in AwsEnv])
+            raise typer.BadParameter(f"'{value}' is not one of {valid}.")
+        else:
+            raise typer.BadParameter(str(e))
+
+
+@app.command()
+def main(
+    wikibase_id: Annotated[
+        WikibaseID,
+        typer.Option(
+            help="Wikibase ID of the concept",
+            parser=WikibaseID,
+        ),
+    ],
+    aws_env: Annotated[
+        AwsEnv,
+        typer.Option(
+            help="AWS environment to demote the model artifact in",
+            parser=parse_aws_env,
+        ),
+    ],
+):
+    """
+    Demote a model within an AWS environment.
+
+    This removes the environment alias from the specified version, effectively
+    making it no longer the primary version for that environment.
+    """
+    log.info("Starting model demotion process")
+
+    use_aws_profiles = os.environ.get("USE_AWS_PROFILES", "true").lower() == "true"
+
+    log.info("Validating AWS login...")
+    validate_login(aws_env, use_aws_profiles)
+
+    collection_name = wikibase_id
+
+    target_path = f"wandb-registry-{REGISTRY_NAME}/{collection_name}:{aws_env}"
+
+    api = wandb.Api()
+
+    model = api.artifact(target_path)
+    model.aliases.remove(aws_env.value)
+    model.save()
+
+    log.info("Model demoted")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
You can now demote a primary model version for a concept, per AWS environment. This is important as our automatic classifier inference looks for an AWS environment alias, to indicate a primary model version that should be automatically used.

**Testing**

Ran locally, and it worked. I refreshed the W&B UI and the alias was gone. I ran the promotion script again (`$ just promote Q787 --classifier RulesBasedClassifier --version v0 --within-aws-env labs --primary`) and the alias was added back!

```bash
just demote Q787 labs
poetry run demote --wikibase-id Q787 --aws-env labs
[14:20:09] INFO     Starting model demotion process                         demote.py:100
           INFO     Validating AWS login...                                 demote.py:104
           INFO     Loading cached SSO token for work                       tokens.py:305
[14:20:12] INFO     Model demoted                                           demote.py:139
```

FIXES PLA-283
