### PR TITLE
fix(index): Pass temporary directory as path

### DIFF
--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -134,11 +134,11 @@ def delete_all_documents(app):
 
 @pytest.fixture
 def local_vespa_search_adapter(
-    create_vespa_params, mock_vespa_credentials, tmpdir
+    create_vespa_params, mock_vespa_credentials, tmp_path
 ) -> VespaSearchAdapter:
     """VespaSearchAdapter instantiated from mocked ssm params."""
     adapter = get_vespa_search_adapter_from_aws_secrets(
-        cert_dir=tmpdir,
+        cert_dir=str(tmp_path),
         vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
         vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
     )
@@ -149,7 +149,8 @@ def local_vespa_search_adapter(
             "Can't connect to a local vespa instance. See guidance here: "
             "`tests/local_vespa/README.md`"
         )
-    return adapter
+
+    yield adapter
 
 
 @pytest.fixture


### PR DESCRIPTION
A class, instead of a string, was being passed [1]. This now explicitly passes the string.

[1]
```
Finished in state Failed('Flow run encountered an exception. FileNotFoundError: [Errno 2] No such file or directory: "<TemporaryDirectory \'/tmp/tmpqt4_b55p\'>/cert.pem"')
```

FIXES PLA-302
