### PR TITLE
Fix organisation identification for wandb

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -362,7 +362,7 @@ def get_all_available_classifiers(config) -> list[ClassifierSpec]:
     # Switch to a custom graphql query using the api module
     model_collections = api.artifact_collections(
         type_name="model",
-        project_name="wandb-registry-model",
+        project_name=config.wandb_model_registry,
     )
 
     classifier_specs = []


### PR DESCRIPTION
This aims to resolve the error in the deployment:

```
Finished in state Failed("Flow run encountered an exception. CommError:
Unable to find an organization under entity 'climatepolicyradar'.")
```

See [prefect deployment run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/2d0ebed4-4264-4e91-94f4-6117f48c81af?entity_id=5064e53e-b243-471f-adf1-58cda909d534)