### PR TITLE
Feature/pla 311 add concurrency limits to the inference flows

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -307,16 +307,14 @@ async def run_classifier_inference_on_document(
         document = load_document(config, document_id)
         print(f"Loaded document with ID {document_id}")
 
-        futures = []
-
-        for text, block_id in document_passages(document):
-            futures.append(
-                text_block_inference.submit(
-                    classifier=classifier, block_id=block_id, text=text
-                )
+        subflows = [
+            text_block_inference.submit(
+                classifier=classifier, block_id=block_id, text=text
             )
+            for text, block_id in document_passages(document)
+        ]
 
-        doc_labels = [future.wait() for future in futures]
+        doc_labels = await asyncio.gather(*subflows)
 
         store_labels(
             config=config,

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -147,7 +147,7 @@ async def test_text_block_inference(
 
     text = "I love fishing. Aquaculture is the best."
     block_id = "fish_block"
-    labels = text_block_inference.fn(
+    labels = await text_block_inference.fn(
         classifier=classifier, block_id=block_id, text=text
     )
 


### PR DESCRIPTION
This Pull Request: 
---
- Adds concurrency context limits via context manager for the `text_block_inference` and `load_classifier` sub flows / tasks. 

**Note:** 

Reading around in the documentation and rate limit does look like a viable option as well if this doesn't work, avoiding this for now as this is a bigger change where we have to create a persistent rate limit block in prefect cloud using a command like below (which would require an IAC update in the orcestrator repo): 
- https://docs-3.prefect.io/v3/develop/global-concurrency-limits#using-rate-limit
- https://docs-3.prefect.io/v3/tutorials/pipelines#avoid-getting-rate-limited

```shell 
# GitHub has a rate limit of 60 unauthenticated requests per hour (~0.016 requests per second)
prefect gcl create github-api --limit 60 --slot-decay-per-second 0.016
```