### PR TITLE
feat(index): Get all available classifiers, if none

### DIFF
--- a/scripts/cloud.py
+++ b/scripts/cloud.py
@@ -15,14 +15,21 @@ PROJECT_NAME = "knowledge-graph"
 
 
 class ClassifierSpec(BaseModel):
-    """Details for a classifier to run"""
+    """Details for a classifier to run."""
 
     name: str = Field(
-        description="The reference of the classifier in wandb. e.g. 'Q992'"
+        description="The reference of the classifier in wandb. e.g. 'Q992'",
+        min_length=1,
+        strip_whitespace=True,
     )
     alias: str = Field(
-        description="The alias tag for the version to use for inference. e.g 'latest' or 'v2'",
+        description=(
+            "The alias tag for the version to use for inference. "
+            "e.g 'latest' or 'v2'"
+        ),
         default="latest",
+        min_length=1,
+        strip_whitespace=True,
     )
 
 

--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -1,7 +1,7 @@
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 import wandb
@@ -10,7 +10,7 @@ from rich.console import Console
 from wandb.apis.public import ArtifactType
 from wandb.apis.public.artifacts import ArtifactCollection
 
-from scripts.cloud import AwsEnv
+from scripts.cloud import AwsEnv, ClassifierSpec
 from src.identifiers import WikibaseID
 
 console = Console()
@@ -32,6 +32,19 @@ def read_spec_file(aws_env: AwsEnv) -> list[str]:
     file_path = build_spec_file_path(aws_env)
     with open(file_path, "r") as file:
         return yaml.load(file, Loader=yaml.FullLoader)
+
+
+def parse_spec_file(aws_env: AwsEnv) -> List[ClassifierSpec]:
+    contents = read_spec_file(aws_env)
+    classifier_specs = []
+    for item in contents:
+        try:
+            name, alias = item.split(":")
+            classifier_specs.append(ClassifierSpec(name=name, alias=alias))
+        except ValueError:
+            raise ValueError(f"Invalid format in spec file: {item}")
+
+    return classifier_specs
 
 
 def write_spec_file(file_path: str, data: list[str]):


### PR DESCRIPTION
Again, we want to align the behaviour with inference, and this does that.

**note:** Where is the `AWS_ENV` set, for when this is run via an `Automation`? In the deployments script, we get the default [1] job variables, which includes `AWS_ENV` being set [2].

[1] https://github.com/climatepolicyradar/knowledge-graph/blob/5fe89da7e8f30446feab4716949b7444bb0b04c5/deployments.py#L36-L37
[2] 
![CleanShot 2024-11-21 at 10 29 30](https://github.com/user-attachments/assets/bd9ac34f-1dec-4d83-868b-86c6ffd6e854)

FIXES PLA-307
