### PR TITLE
refactor(index): Don't fail all documents on 1 failure

### DIFF
--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -110,7 +110,7 @@ def test_s3_obj_generator_from_s3_paths(
     s3_paths = {
         os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
         for f in labelled_passage_fixture_files
-    }
+    } | {"gibberish"}
     s3_gen = s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
     s3_files = list(s3_gen)
     assert len(s3_files) == len(labelled_passage_fixture_files)
@@ -133,6 +133,7 @@ def test_labelled_passages_generator(
     """Test that the document concepts generator yields the correct objects."""
     s3_gen = s3_obj_generator_from_s3_prefixes(
         [os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)]
+        + ["gibberish"]
     )
     labelled_passages_gen = labelled_passages_generator(generator_func=s3_gen)
     labelled_passages_files = list(labelled_passages_gen)


### PR DESCRIPTION
I was trying a run [1] which threw an exception since there hadn't been inference done on the document ID I passed in.

Stuff happens, so instead of failing a whole flow run, just log the error, and continue on.

[1] https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/1569cbf8-7432-4888-9f46-2cb924788f31?entity_id=2edfa4f1-3fac-4133-b1c1-9f0a61794f36

TOWARDS PLA-250