### PR TITLE
use the revisions api to get old versions of concepts from the concept store

### DIFF
--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -141,7 +141,8 @@ class WikibaseSession:
         if not page_id:
             raise ValueError(f"Could not find entity with ID: {wikibase_id}")
 
-        # Get revision using the pageid
+        # Use the pageid to get the latest revision before the supplied timestamp
+        # https://www.mediawiki.org/wiki/API:Revisions
         revisions_response = self.session.get(
             url=self.api_url,
             params={
@@ -157,7 +158,7 @@ class WikibaseSession:
             },
         ).json()
 
-        # Extract content from revision
+        # Extract useful content from the revision response
         pages = revisions_response.get("query", {}).get("pages", {})
         if not pages:
             raise ValueError(f"No page found for ID: {wikibase_id}")


### PR DESCRIPTION
I've added an optional timestamp parameter to `WikibaseSession().get_concept()`, which should allow us to see what a concept looked like when a labelling project began, before any updates were made as a result of what the team learned during labelling. This should give us a more honest reflection of the classifier performance, negating any overfitting to the eval set.

As an example, a bunch of updates have been made to [air pollution risk (Q412)](https://climatepolicyradar.wikibase.cloud/wiki/Item:Q412) recently, removing unnecessary positive and negative keywords. We can see those changes by adding the timestamp parameter:

```py
from datetime import datetime

from src.wikibase import WikibaseSession

session = WikibaseSession()
old_concept = session.get_concept("Q412", timestamp=datetime(2024, 11, 1))
new_concept = session.get_concept("Q412")


print("Old Concept:")
print(f"  Name: {old_concept}")
print(f"  All Labels: {old_concept.all_labels}")
print(f"  Negative Labels: {old_concept.negative_labels}", end="\n\n")

print("New Concept:")
print(f"  Name: {new_concept}")
print(f"  All Labels: {new_concept.all_labels}")
print(f"  Negative Labels: {new_concept.negative_labels}")
```

```
Old Concept:
  Name: air pollution risk (Q412)
  All Labels: ['poor air quality', 'air contamination', 'heavy particulate pollution', 'air pollution from point sources', 'point source air pollution', 'fumes', 'air pollution risk', 'air-pollution', 'particulate matter', 'air pollution', 'point source of air pollution', 'particulate emissions', 'decreased air quality']
  Negative Labels: ['sea fog', 'fog of applicants']

New Concept:
  Name: air pollution risk (Q412)
  All Labels: ['air pollution risk', 'air contamination', 'air-pollution', 'air pollution']
  Negative Labels: []
 ```