### PR TITLE
feat(inference): Report progress as Prefect artifact

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -311,6 +311,7 @@ async def report_documents_runs(
         await artifacts.create_table_artifact(
             table=all_rows,
             description="# Document Processing Status",
+            key="classifier-inference-document-processing-status",
         )
     except Exception:
         # Do nothing, not even log. It'll be too noisy.


### PR DESCRIPTION
We want _some_ insight into the progress. This uses the readily available Prefect artifacts functionality [1].

I've deliberately not set a `key`, since there may be more than 1 `classifier_inference` running at a time, and thus thought the associated Artifacts tab is sufficient [2].

[1] https://docs-2.prefect.io/latest/concepts/artifacts/#create-table-artifacts
[2] > Without a key, the artifact will only be visible in the Artifacts tab of the associated flow run or task run.
