### PR TITLE
Keyword expansion with claude

### DIFF
--- a/src/classifier/__init__.py
+++ b/src/classifier/__init__.py
@@ -2,8 +2,6 @@ import importlib
 
 from src.classifier.classifier import Classifier
 from src.classifier.keyword import KeywordClassifier
-from src.classifier.keyword_expansion import KeywordExpansionClassifier
-from src.classifier.llm import LLMClassifier
 from src.classifier.rules_based import RulesBasedClassifier
 from src.concept import Concept
 
@@ -32,8 +30,6 @@ __all__ = [
     "RulesBasedClassifier",
     "EmbeddingClassifier",  # type: ignore
     "StemmedKeywordClassifier",  # type: ignore
-    "KeywordExpansionClassifier",  # type: ignore
-    "LLMClassifier",  # type: ignore
 ]
 
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -42,6 +42,10 @@ def positive_text_strategy(
         ).filter(
             lambda x: x.strip()
             and all(label.lower() not in x.lower() for label in labels)
+            and all(
+                not any(word in label.lower() for word in x.lower().split())
+                for label in labels
+            )  # Prevent extra partial matches
             and (
                 negative_labels is None
                 or all(
@@ -62,6 +66,10 @@ def positive_text_strategy(
             lambda x: x.strip()
             and x != pre_text
             and all(label.lower() not in x.lower() for label in labels)
+            and all(
+                not any(word in label.lower() for word in x.lower().split())
+                for label in labels
+            )  # Prevent extra partial matches
             and (
                 negative_labels is None
                 or all(


### PR DESCRIPTION
I'm being silly with LLMs over the weekend again 🤡

This PR adds a new `KeywordExpansionClassifier` to our toolkit. When `.fit()` is called, the model prompts an LLM to expand the list of stored keywords for its concept. When `.predict()` is called, regular old regex-based keyword matching is used with the expanded list of terms. If expansion fails, the classifier should fall back on the original concept's keywords. 

I can't imagine there are many concepts where we'd be happy to run this without a bit of auditing (and maybe this idea would be better suited to a human-in-the-loop, concept-store-editing context like the concept store librarian), but this idea was very easy to implement and share, and might provide a foundation for us to iterate from.

Here's an example of it being used:

```py
from rich.console import Console
from rich.panel import Panel

from src.classifier.keyword_expansion import KeywordExpansionClassifier
from src.concept import Concept

console = Console()

concept = Concept(
    wikibase_id="Q123",
    preferred_label="horse",
    alternative_labels=[
        "horses",
        "equine",
        "mare",
    ],
    negative_labels=[
        "seahorse",
        "horsepower",
        "hobby horse",
        "horse chestnut",
        "horse radish",
    ],
    definition="A large plant-eating domesticated mammal with solid hooves and flowing mane and tail",
    description="A domesticated one-toed hoofed mammal used for riding, racing, and to carry and pull loads.",
)


classifier = KeywordExpansionClassifier(concept)
classifier.fit()
expanded_concept = classifier.concept

old_positive_labels = concept.all_labels
new_positive_labels = expanded_concept.all_labels

console.print(
    Panel.fit(
        f"[bold cyan]Original Labels:[/]\n{old_positive_labels}\n\n"
        f"[bold green]Expanded Labels:[/]\n{new_positive_labels}\n\n"
        f"[bold yellow]New Labels Added:[/]\n{set(new_positive_labels) - set(old_positive_labels)}"
    )
)

old_negative_labels = concept.negative_labels
new_negative_labels = expanded_concept.negative_labels

console.print(
    Panel.fit(
        f"[bold red]Original Negative Labels:[/]\n{old_negative_labels}\n\n"
        f"[bold magenta]Expanded Negative Labels:[/]\n{new_negative_labels}\n\n"
        f"[bold orange3]New Negative Labels Added:[/]\n{set(new_negative_labels) - set(old_negative_labels)}"
    )
)
```

```
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Original Labels:                                                                                                                               │
│ ['horses', 'horse', 'mare', 'equine']                                                                                                          │
│                                                                                                                                                │
│ Expanded Labels:                                                                                                                               │
│ ['mare', 'equid', 'thoroughbred', 'racehorse', 'horse', 'filly', 'horses', 'equidae', 'workhorse', 'quarter horse', 'Equus caballus',          │
│ 'gelding', 'draft horse', 'equine', 'equine species', 'domesticated equine', 'steed', 'riding horse', 'mount', 'stallion', 'foal', 'colt',     │
│ 'mustang', 'arabian horse', 'equestrian animal', 'equestrian', 'pony']                                                                         │
│                                                                                                                                                │
│ New Labels Added:                                                                                                                              │
│ {'domesticated equine', 'steed', 'riding horse', 'mount', 'stallion', 'equid', 'thoroughbred', 'racehorse', 'filly', 'foal', 'equidae',        │
│ 'colt', 'mustang', 'workhorse', 'quarter horse', 'Equus caballus', 'arabian horse', 'gelding', 'draft horse', 'equine species', 'equestrian    │
│ animal', 'equestrian', 'pony'}                                                                                                                 │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Original Negative Labels:                                                                                                                      │
│ ['hobby horse', 'horse radish', 'horsepower', 'seahorse', 'horse chestnut']                                                                    │
│                                                                                                                                                │
│ Expanded Negative Labels:                                                                                                                      │
│ ['horseshoe crab', 'chess horse', 'seahorse', 'horsehair', 'flying horse statue', 'horseback', 'horsepower', 'wild horse figurine', 'rocking   │
│ horse', 'horse riding gear', 'horse feed', 'wooden horse', 'hobby horse', 'toy horse', 'horse chestnut', 'carousel horse', 'horse trailer',    │
│ 'horse radish', 'hobby horse toy']                                                                                                             │
│                                                                                                                                                │
│ New Negative Labels Added:                                                                                                                     │
│ {'horseback', 'horseshoe crab', 'wooden horse', 'horse trailer', 'chess horse', 'toy horse', 'hobby horse toy', 'horsehair', 'flying horse     │
│ statue', 'wild horse figurine', 'rocking horse', 'carousel horse', 'horse riding gear', 'horse feed'}                                          │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```