### PR TITLE
fix(inference): Split listing and finding latest ingest document

### DIFF
--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -224,6 +224,18 @@ def test_get_latest_ingest_documents(
     assert set(doc_ids) == latest_docs
 
 
+def test_get_latest_ingest_documents_no_latest(
+    test_config,
+    # Setup the empty bucket
+    mock_bucket,
+):
+    with pytest.raises(
+        ValueError,
+        match="failed to find",
+    ):
+        get_latest_ingest_documents(test_config)
+
+
 @pytest.mark.parametrize(
     "data, expected_lengths",
     [


### PR DESCRIPTION
I ran the original code locally, and got `None`, as we're seeing in Prefect [1]. Looking around, and asking Claude, I've split it into 2 distinct steps: 1. list the relevant files and 2. sort them. This avoids potential limitations of JMESPath, and brings more control into Python.

This does mean that we're doing the sorting, instead of relying on it to happen server-side. As of right now, there are 121 files. If we have 1 every week, that's still just 52/year. I don't think this will be a performance issue, or not one that outweighs this working.

In the REPL snippet [2], you can see the big list of files with oldest→newest, and then latest correctly being the file from yesterday (2024-12-17).

FIXES PLA-374

[1] https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/96714986-69ea-401c-9ddf-f2960e872971?entity_id=f177e2f5-4219-43b0-806a-6b83ab9ca2fa
[2]
```
>>> page_iterator = get_bucket_paginator(cache_bucket="cpr-prod-data-pipeline-cache", bucket_region="eu-west-1", prefix="input", aws_profile="production")
>>> matching_files = list(page_iterator.search( "Contents[?contains(Key, '{}')]".format(file_name)))
>>> matching_files
[{'Key':
'input/2023-04-13T09.17.37.953810/new_and_updated_documents.json',
'LastModified': datetime.datetime(2024, 1, 23, 12, 28, 46,
tzinfo=tzutc()), 'ETag': '"7b872a887d5b8351f56b472ce64790b7"', 'Size':
6456875, 'StorageClass': 'STANDARD'}, {'Key':
'input/2023-04-13T12.54.08.414269/new_and_updated_documents.json',
'LastModified': datetime) .. , 'ETag': '"46535d517fad02fa0d9af83504466791"', 'Size': 513275, 'StorageClass': 'STANDARD'}, {'Key': 'input/2024-12-17T14.03.37.067400/new_and_updated_documents.json', 'LastModified': datetime.datetime(2024, 12, 17, 14, 8, 55, tzinfo=tzutc()), 'ETag': '"43c40a5caceefcee56bfdde13ab33a71"', 'Size': 815935, 'StorageClass': 'STANDARD'}]
>>> len(matching_files)
121
>>> latest = sorted(matching_files, key=lambda x: x['Key'])[-1]
>>> latest
{'Key': 'input/2024-12-17T14.03.37.067400/new_and_updated_documents.json', 'LastModified': datetime.datetime(2024, 12, 17, 14, 8, 55, tzinfo=tzutc()), 'ETag': '"43c40a5caceefcee56bfdde13ab33a71"', 'Size': 815935, 'StorageClass': 'STANDARD'}
```
