### PR TITLE
fix: Remove unused Prefect deploy input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: sandbox
-      prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SANDBOX }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SANDBOX }}
@@ -96,7 +95,6 @@ jobs:
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: labs
-      prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_LABS }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_LABS }}
@@ -109,7 +107,6 @@ jobs:
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: staging
-      prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
@@ -122,7 +119,6 @@ jobs:
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: prod
-      prefect-workspace: ${{ vars.PREFECT_WORKSPACE }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}

--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -6,9 +6,6 @@ on:
       aws-env:
         required: true
         type: string
-      prefect-workspace:
-        required: true
-        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true


### PR DESCRIPTION
I believe this was made unused when switching to using the new approach for Prefect auth.
