### PR TITLE
fix bug in attribution for spans labelled by rules based classifiers

### DIFF
--- a/src/classifier/rules_based.py
+++ b/src/classifier/rules_based.py
@@ -61,4 +61,10 @@ class RulesBasedClassifier(Classifier):
                 match.overlaps(negative_match) for negative_match in negative_matches
             )
         ]
+
+        # Update the labeller name on each span from KeywordClassifier to
+        # RulesBasedClassifier
+        for match in filtered_matches:
+            match.labellers = [str(self)]
+
         return filtered_matches


### PR DESCRIPTION
Because the `RulesBasedClassifier` is comprised of two internal `KeywordClassifier`s, the `labeller` attributes of the spans in the resulting labelled passages were set as `KeywordClassifier`! 

This PR relabels the resulting spans with the name of the `RulesBasedClassifier` instead.