### PR TITLE
fix get-concept when there is no labelled data in argilla

### DIFF
--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -28,18 +28,17 @@ def main(
     concept = wikibase.get_concept(wikibase_id)
     console.log(f'🔍 Fetched metadata for "{concept.preferred_label}" from wikibase')
 
-    labelled_passages = get_labelled_passages_from_argilla(concept)
-    if labelled_passages:
+    try:
+        labelled_passages = get_labelled_passages_from_argilla(concept)
         console.log(
             f"🏷️ Fetched {len(labelled_passages)} labelled passages for {wikibase_id} from Argilla"
         )
-    else:
+        concept.labelled_passages = labelled_passages
+    except ValueError:
         console.log(
             f"⚠️ No labelled passages found for {wikibase_id} in Argilla",
             style="yellow",
         )
-
-    concept.labelled_passages = labelled_passages
 
     # Save the concept to disk
     output_path = concept_dir / f"{wikibase_id}.json"

--- a/src/argilla.py
+++ b/src/argilla.py
@@ -173,14 +173,17 @@ def get_labelled_passages_from_argilla(
                 "No datasets were found in Argilla, "
                 "you may need to be granted access to the workspace(s)"
             )
-        for dataset in datasets:
+        matching_datasets = []
+        for _dataset in datasets:
             try:
-                # If the dataset.name ends with our wikibase_id, then it's one we want
-                # to process
-                if dataset_name_to_wikibase_id(dataset.name) == concept.wikibase_id:
-                    break
+                wikibase_id = dataset_name_to_wikibase_id(_dataset.name)
+                if wikibase_id == concept.wikibase_id:
+                    matching_datasets.append(_dataset)
             except ValueError:
                 continue
+
+        if matching_datasets:
+            dataset = matching_datasets[0]
 
     if not dataset:
         raise ValueError(


### PR DESCRIPTION
This code had a bug where it would just get the labelled data for the last dataset it looked at in Argilla, even if that didn't match the wikibase ID provided to `just get-concept`.

**Related:** have there been conversations about being able to write tests against a version of the concept store and Argilla? This is the second drive-by fix I've had to do in two tasks on this repo, and conscious that this is soon-to-be production code. At the moment I'm a bit concerned the best we can do on PRs is a 'LGTM' without the ability to detect regressions using tests.