### PR TITLE
Updating the default batch size for inference.

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -452,7 +452,7 @@ async def classifier_inference(
     document_ids: Optional[list[str]] = None,
     use_new_and_updated: bool = False,
     config: Optional[Config] = None,
-    batch_size: int = 400,
+    batch_size: int = 1000,
 ):
     """
     Flow to run inference on documents within a bucket prefix.


### PR DESCRIPTION
This Pull Request: 
---
- Updates the default size of the inference deployment from `400` to `1000`. 
- This is done to reduce errors due to api limits. 

How does this work? 
- If we have larger batches then we call less sub deployments of `run_classifier_inference_on_batch_of_documents` and following prefect sub flows, this means we also call `load_classifier` from weights and biases less as it's downloaded once per host. 

This was done in the following successful production run on all the data: 
- https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/fe94806a-a388-475a-bc48-0e32920c6ab2?entity_id=fe94806a-a388-475a-bc48-0e32920c6ab2