### PR TITLE
feat(indexing): Use concurrency across containers

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -13,7 +13,10 @@ from prefect.blocks.system import JSON
 from prefect.deployments.runner import DeploymentImage
 from prefect.flows import Flow
 
-from flows.index import index_labelled_passages_from_s3_to_vespa
+from flows.index import (
+    index_labelled_passages_from_s3_to_vespa,
+    run_partial_updates_of_concepts_for_document_passages,
+)
 from flows.inference import (
     classifier_inference,
     run_classifier_inference_on_batch_of_documents,
@@ -58,6 +61,7 @@ def create_deployment(
 
 
 # Inference
+
 create_deployment(
     flow=classifier_inference,
     description="Run concept classifier inference on document passages",
@@ -68,7 +72,6 @@ create_deployment(
     },
 )
 
-# Inference - Batch of Documents
 create_deployment(
     flow=run_classifier_inference_on_batch_of_documents,
     description="Run concept classifier inference on a batch of documents",
@@ -80,9 +83,20 @@ create_deployment(
 )
 
 # Index
+
+create_deployment(
+    flow=run_partial_updates_of_concepts_for_document_passages,
+    description="Co-ordinate updating inference results for concepts in Vespa",
+    flow_variables={
+        "cpu": MEGABYTES_PER_GIGABYTE * 4,
+        "memory": MEGABYTES_PER_GIGABYTE * 16,
+        "ephemeralStorage": {"sizeInGiB": 50},
+    },
+)
+
 create_deployment(
     flow=index_labelled_passages_from_s3_to_vespa,
-    description="Run partial updates of labelled passages stored in s3 into Vespa",
+    description="Run partial updates of labelled passages stored in S3 into Vespa",
     flow_variables={
         "cpu": MEGABYTES_PER_GIGABYTE * 4,
         "memory": MEGABYTES_PER_GIGABYTE * 16,

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -20,7 +20,13 @@ from prefect.task_runners import ConcurrentTaskRunner
 from pydantic import SecretStr
 from wandb.sdk.wandb_run import Run
 
-from scripts.cloud import AwsEnv, ClassifierSpec, get_prefect_job_variable
+from scripts.cloud import (
+    AwsEnv,
+    ClassifierSpec,
+    function_to_flow_name,
+    generate_deployment_name,
+    get_prefect_job_variable,
+)
 from scripts.update_classifier_spec import parse_spec_file
 from src.classifier import Classifier
 from src.labelled_passage import LabelledPassage
@@ -34,7 +40,6 @@ BLOCKED_BLOCK_TYPES: Final[set[BlockType]] = {
     BlockType.FIGURE,
 }
 DOCUMENT_TARGET_PREFIX_DEFAULT: str = "labelled_passages"
-AWS_ENV = os.environ["AWS_ENV"]
 
 DocumentRunIdentifier: TypeAlias = Tuple[str, str, str]
 
@@ -396,7 +401,10 @@ def iterate_batch(data: list[str], batch_size: int = 400) -> Generator:
 
 @flow
 async def run_classifier_inference_on_batch_of_documents(
-    batch: list[str], config_json: dict, classifier_name: str, classifier_alias: str
+    batch: list[str],
+    config_json: dict,
+    classifier_name: str,
+    classifier_alias: str,
 ) -> None:
     """
     Run classifier inference on a batch of documents.
@@ -490,13 +498,17 @@ async def classifier_inference(
         f"{len(classifier_specs)} classifiers"
     )
 
+    flow_name = function_to_flow_name(run_classifier_inference_on_batch_of_documents)
+    deployment_name = generate_deployment_name(
+        flow_name=flow_name, aws_env=config.aws_env
+    )
+
     for classifier_spec in classifier_specs:
         batches = iterate_batch(validated_document_ids, batch_size)
 
         tasks = [
             run_deployment(
-                "run-classifier-inference-on-batch-of-documents/"
-                f"knowledge-graph-run-classifier-inference-on-batch-of-documents-{AWS_ENV}",
+                name=f"{flow_name}/{deployment_name}",
                 parameters={
                     "batch": batch,
                     "config_json": config.to_json(),

--- a/scripts/cloud.py
+++ b/scripts/cloud.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Callable
 from enum import Enum
 from typing import Optional
 
@@ -85,6 +86,10 @@ def validate_transition(from_aws_env: AwsEnv, to_aws_env: AwsEnv) -> None:
 
 def generate_deployment_name(flow_name: str, aws_env: AwsEnv):
     return f"{PROJECT_NAME}-{flow_name}-{aws_env}"
+
+
+def function_to_flow_name(fn: Callable) -> str:
+    return fn.__name__.replace("_", "-")
 
 
 def get_session(aws_env: AwsEnv) -> boto3.session.Session:

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -4,7 +4,11 @@ import botocore
 import pytest
 from moto import mock_aws
 
-from scripts.cloud import AwsEnv, is_logged_in, parse_aws_env
+from scripts.cloud import AwsEnv, function_to_flow_name, is_logged_in, parse_aws_env
+
+
+def test_function_to_flow_name():
+    assert function_to_flow_name(is_logged_in) == "is-logged-in"
 
 
 def test_init_awsenv():


### PR DESCRIPTION
We've faced the same problem as when doing inference. This changeset means that we can either run the partial updates themselves as deployments (default) or as functions.

This optionality was primarily done so that we can have increased test coverage, without Prefect trying to actually run the deployments, for the functions that do that. Still, I've needed to skip 1 test.

The function layout perhaps isn't amazing, but, there were many ways to do this all, and this was one of them.

TOWARDS PLA-390
