### PR TITLE
fix(indexing): Skip missing timestamps in spans

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -347,9 +347,20 @@ def convert_labelled_passages_to_concepts(
 
         logger.info(f"converting {len(labelled_passage.spans)} spans to concepts")
 
-        for span in labelled_passage.spans:
+        for span_idx, span in enumerate(labelled_passage.spans):
             if span.concept_id is None:
-                raise ValueError("concept ID is missing")
+                # Include the Span index since Span's don't have IDs
+                logger.error(
+                    f"span concept ID is missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+                )
+                continue
+
+            if not span.timestamps:
+                logger.error(
+                    f"span timestamps are missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+                )
+                continue
+
             concepts.append(
                 (
                     text_block_id,
@@ -361,8 +372,8 @@ def convert_labelled_passages_to_concepts(
                         model=get_model_from_span(span),
                         end=span.end_index,
                         start=span.start_index,
-                        # these timestamps _should_ all be the same, but just in case,
-                        # take the latest
+                        # these timestamps _should_ all be the same,
+                        # but just in case, take the latest
                         timestamp=max(span.timestamps),
                     ),
                 )


### PR DESCRIPTION
This otherwise took down the whole deployment [1]. This change makes the deployment more resilient.

I switched to error logs, which are more visible and filterable, and don't need to be rescued, and would otherwise probably log when rescuing the exception.

[1] https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/641a87ef-e380-491d-bac6-4e1c91fc1557?entity_id=3600310b-1860-43b0-b479-c529a5f3a159

FIXES PLA-392
