### PR TITLE
Add initial mock test coverage for WikibaseSession

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,12 @@ pulumi-aws = "^6.66.2"
 
 
 [tool.pytest.ini_options]
-env = ["AWS_ENV=sandbox"]
+env = [
+  "AWS_ENV=sandbox",
+  "WIKIBASE_USERNAME=test_username",
+  "WIKIBASE_PASSWORD=test_password",
+  "WIKIBASE_URL=https://test.test.test"
+]
 markers = ["vespa", "flaky_on_ci"]
 
 [build-system]

--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -277,7 +277,7 @@ class WikibaseSession:
                 params={
                     "action": "query",
                     "format": "json",
-                    "list": "allpages",
+                    "list": "allpages",  # See https://www.mediawiki.org/wiki/API:Allpages
                     "apnamespace": 120,
                     "aplimit": limit or "max",
                     "apfilterredir": "nonredirects",  # Only fetch non-redirect pages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import json
 import os
 import subprocess
+import traceback
 from pathlib import Path
+from urllib.parse import parse_qs
 
+import httpx
 import pandas as pd
 import pytest
 from prefect.testing.utilities import prefect_test_harness
@@ -10,6 +13,7 @@ from prefect.testing.utilities import prefect_test_harness
 from scripts.config import get_git_root
 from src.classifier import Classifier
 from src.concept import Concept
+from src.wikibase import WikibaseSession
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -69,3 +73,171 @@ def run_just_command():
         return result
 
     return _run_command
+
+
+@pytest.fixture
+def mock_wikibase_url():
+    # See pyproject.toml for where this is set
+    return "https://test.test.test"
+
+
+@pytest.fixture
+def mock_wikibase_token_json():
+    return {
+        "query": {
+            "tokens": {
+                "logintoken": "token",
+                "csrftoken": "token",
+            }
+        }
+    }
+
+
+@pytest.fixture
+def mock_wikibase_properties_json():
+    return {
+        "batchcomplete": "",
+        "limits": {"allpages": 5000},
+        "query": {
+            "allpages": [
+                {"pageid": 1, "ns": 122, "title": "Property:P1"},
+                {"pageid": 1596, "ns": 122, "title": "Property:P10"},
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def mock_wikibase_entities_json():
+    return {
+        "entities": {
+            "Q10": {
+                "pageid": 14,
+                "ns": 120,
+                "title": "Item:Q10",
+                "lastrevid": 3785,
+                "modified": "2024-06-12T10:09:34Z",
+                "type": "item",
+                "id": "Q10",
+            }
+        },
+        "success": 1,
+    }
+
+
+@pytest.fixture
+def mock_wikibase_items_json():
+    return {
+        "batchcomplete": "",
+        "continue": {"apcontinue": "Q1003", "continue": "-||"},
+        "query": {
+            "allpages": [
+                {"pageid": 14, "ns": 120, "title": "Item:Q10"},
+                {"pageid": 104, "ns": 120, "title": "Item:Q100"},
+                {"pageid": 1022, "ns": 120, "title": "Item:Q1000"},
+                {"pageid": 1023, "ns": 120, "title": "Item:Q1001"},
+                {"pageid": 1024, "ns": 120, "title": "Item:Q1002"},
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def mock_wikibase_revisions_json():
+    return {
+        "continue": {"rvcontinue": "20240612100926|3784", "continue": "||"},
+        "query": {
+            "pages": {
+                "14": {
+                    "pageid": 14,
+                    "ns": 120,
+                    "title": "Item:Q10",
+                    "revisions": [
+                        {
+                            "slots": {
+                                "main": {
+                                    "contentmodel": "wikibase-item",
+                                    "contentformat": "application/json",
+                                    "*": '{"type":"item","id":"Q10","labels":{"en":{"language":"en","value":"tropical forests"}},"descriptions":{"en":{"language":"en","value":"generic forest in the tropics"}},"aliases":{"en":[{"language":"en","value":"tropical forests"}]},"claims":{"P2":[{"mainsnak":{"snaktype":"value","property":"P2","hash":"44c11d9ab91c8c3cf203033599eebcb8d1be97ce","datavalue":{"value":{"entity-type":"item","numeric-id":5,"id":"Q5"},"type":"wikibase-entityid"}},"type":"statement","id":"Q10$DB660D9E-8D6C-4ED6-8060-D51161A88382","rank":"normal"}]},"sitelinks":[]}',
+                                }
+                            }
+                        }
+                    ],
+                }
+            }
+        },
+    }
+
+
+class MockedWikibaseException(Exception):
+    """
+    Exception raised by the mocked Wikibase API.
+
+    Means that `MockedWikibaseSession` is not configured properly for what is
+    being tested. There might be some misconfiguration or a missing scenario.
+    """
+
+    pass
+
+
+@pytest.fixture
+def MockedWikibaseSession(
+    mock_wikibase_url,
+    mock_wikibase_token_json,
+    mock_wikibase_properties_json,
+    mock_wikibase_items_json,
+    mock_wikibase_revisions_json,
+    mock_wikibase_entities_json,
+):
+    def mock_request_handler(request):
+        if not httpx.URL(mock_wikibase_url).host == request.url.host:
+            raise MockedWikibaseException(f"Non-test endpoint used: {request.url}")
+
+        if not request.url.path == "/w/api.php":
+            raise MockedWikibaseException(f"Expected Api path not used: {request.url}")
+
+        # Define request scenarios to catch here:
+        if request.url.params:
+            action = request.url.params.get("action")
+        else:
+            action = parse_qs(request.content.decode())["action"][0]
+        match action:
+            case "query":
+                # _login
+                if request.url.params.get("meta") == "tokens":
+                    return httpx.Response(200, json=mock_wikibase_token_json)
+                # get_concept
+                if request.url.params.get("prop") == "revisions":
+                    return httpx.Response(200, json=mock_wikibase_revisions_json)
+
+                if request.url.params.get("list") == "allpages":
+                    apnamespace = request.url.params.get("apnamespace")
+                    # get_properties
+                    if apnamespace == "122":
+                        return httpx.Response(200, json=mock_wikibase_properties_json)
+                    # get_concepts
+                    if apnamespace == "120":
+                        return httpx.Response(200, json=mock_wikibase_items_json)
+            #  _login
+            case "login":
+                return httpx.Response(200)
+            # get_concept
+            case "wbgetentities":
+                return httpx.Response(200, json=mock_wikibase_entities_json)
+            # get_statements
+            case "wbgetclaims":
+                return httpx.Response(200, json={"claims": {}})
+            # add_statement
+            case "wbcreateclaim":
+                return httpx.Response(200, json={})
+
+        raise MockedWikibaseException(f"Unhandled test endpoint: {request.url}")
+
+    mock_transport = httpx.MockTransport(mock_request_handler)
+    with httpx.Client(transport=mock_transport) as client:
+        WikibaseSession.session = client
+        try:
+            yield WikibaseSession
+        except MockedWikibaseException:
+            exc_info = traceback.format_exc()
+            pytest.fail(f"Wikibase test failed because of an exception:\n {exc_info}")

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -1,0 +1,45 @@
+import pytest
+
+from src.concept import Concept
+from src.identifiers import WikibaseID
+
+
+def test_wikibase___login(MockedWikibaseSession):
+    MockedWikibaseSession()._login()
+
+
+def test_wikibase__get_all_properties(MockedWikibaseSession):
+    MockedWikibaseSession().get_all_properties()
+
+
+def test_wikibase__get_concept(MockedWikibaseSession):
+    wikibase = MockedWikibaseSession()
+    concept = wikibase.get_concept(wikibase_id=WikibaseID("Q10"))
+    assert isinstance(concept, Concept)
+    assert concept.wikibase_id == "Q10"
+
+
+def test_wikibase__get_concepts(MockedWikibaseSession):
+    wikibase = MockedWikibaseSession()
+    result = wikibase.get_concepts()
+    ids = set([r.wikibase_id for r in result])
+    assert ids == {"Q10", "Q1000", "Q1002", "Q100", "Q1001"}
+
+
+def test_wikibase__get_subconcepts(MockedWikibaseSession):
+    wikibase = MockedWikibaseSession()
+    wikibase.get_subconcepts(wikibase_id="Q10")
+
+
+@pytest.mark.skip(reason="Not implemented")
+def test_wikibase__get_statements(MockedWikibaseSession):
+    raise NotImplementedError(
+        "The test_wikibase__get_statements test is not implemented yet."
+    )
+
+
+@pytest.mark.skip(reason="Not implemented")
+def test_wikibase__add_statement(MockedWikibaseSession):
+    raise NotImplementedError(
+        "The test_wikibase__add_statement test is not implemented yet."
+    )


### PR DESCRIPTION
I was keen to have this in order to write tests for the flow that will copy concepts from wikibase to S3. It's a relatively light touch mock interface that could be improved, particularly around:

1. What the fixture data looks like, for this initial implementation I just ran each query and used part of the response.
2. Whats actually being tested, I wanted to add something for `get_concept` and `get_concepts` as this is what I'm going to build on, but for now these are light touch. Other endpoints are even lighter but I'm hoping this adds some foundation that could be built on.