### PR TITLE
fix(indexing): Correct type annotations

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -16,7 +16,7 @@ from cpr_sdk.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
-from prefect.deployments import run_deployment
+from prefect.deployments.deployments import run_deployment
 from prefect.logging import get_logger, get_run_logger
 
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
@@ -815,17 +815,29 @@ async def index_by_s3(
 def split_large_concepts_updates(
     document_concepts: list[
         tuple[
-            # Text block (aka span) ID
+            # Object: Key
             str,
-            VespaConcept,
+            list[
+                tuple[
+                    # Text block (aka span) ID
+                    str,
+                    VespaConcept,
+                ]
+            ],
         ]
     ],
     max_concepts_in_partial_update: int,
 ) -> list[
     tuple[
-        # Text block (aka span) ID
+        # Object: Key
         str,
-        VespaConcept,
+        list[
+            tuple[
+                # Text block (aka span) ID
+                str,
+                VespaConcept,
+            ]
+        ],
     ]
 ]:
     """


### PR DESCRIPTION
Pyright was reporting on these. I think I missed them previously. They can faill through the gaps depending on when pre-commit is run.

**errors:**

```shell
$ poetry run pre-commit run pyright --files flows/index.py
pyright..................................................................Failed
- hook id: pyright
- exit code: 1

WARNING: there is a new pyright version available (v1.1.389 -> v1.1.392.post0).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

/Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/flows/index.py
  /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/flows/index.py:19:33 - error: "run_deployment" is not exported from module "prefect.deployments"
    Import from "prefect.deployments.deployments" instead (reportPrivateImportUsage)
  /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/flows/index.py:787:13 - error: Argument of type "list[tuple[str, list[tuple[str, Concept]]]]" cannot be assigned to parameter "document_concepts" of type "list[tuple[str, Concept]]" in function "split_large_concepts_updates"
    "list[tuple[str, list[tuple[str, Concept]]]]" is not assignable to "list[tuple[str, Concept]]"
      Type parameter "_T@list" is invariant, but "tuple[str, list[tuple[str, Concept]]]" is not the same as "tuple[str, Concept]"
      Consider switching from "list" to "Sequence" which is covariant (reportArgumentType)
  /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/flows/index.py:793:17 - error: Argument of type "Concept" cannot be assigned to parameter "document_concepts" of type "list[tuple[str, Concept]]" in function "run_partial_updates_of_concepts_for_document_passages_as"
    "Concept" is not assignable to "list[tuple[str, Concept]]" (reportArgumentType)
3 errors, 0 warnings, 0 informations
```

**testing:**

```
$ poetry run python
Python 3.10.14 (main, Jul 25 2024, 22:56:04) [Clang 18.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from prefect.deployments.deployments import run_deployment
>>>
```