### PR TITLE
feat(indexing): Calculate and update concepts' counts on family documents

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -23,3 +23,35 @@ class RevisionNotFoundError(Exception):
         )
 
         super().__init__(self.message)
+
+
+class ConceptCountUpdateError(Exception):
+    """Exception raised when concept count updates fail"""
+
+    def __init__(self, document_id: str, status_code: int):
+        super().__init__(
+            f"Failed to update concept counts for document {document_id}. "
+            f"Received status code: {status_code}"
+        )
+        self.document_id = document_id
+        self.status_code = status_code
+
+
+class QueryError(Exception):
+    """Exception raised when concept count updates fail"""
+
+    def __init__(self, status_code: int):
+        super().__init__(f"Failed to query Vespa. Received status code: {status_code}")
+        self.status_code = status_code
+
+
+class PartialUpdateError(Exception):
+    """Exception raised when partial updates of concepts fail."""
+
+    def __init__(self, document_passage_id: str, status_code: int):
+        super().__init__(
+            f"Failed to update document passage `{document_passage_id}`. "
+            f"Received status code: {status_code}"
+        )
+        self.document_passage_id = document_passage_id
+        self.status_code = status_code

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -131,14 +131,17 @@ def vespa_app(
 
 def delete_all_documents(app):
     print("Deleting all documents...")
+    print("Search weights...")
     response = app.delete_all_docs(
         content_cluster_name="family-document-passage", schema="search_weights"
     )
     print(f"Delete response: {response}")
+    print("Family documents...")
     response = app.delete_all_docs(
         content_cluster_name="family-document-passage", schema="family_document"
     )
     print(f"Delete response: {response}")
+    print("Document passages...")
     response = app.delete_all_docs(
         content_cluster_name="family-document-passage", schema="document_passage"
     )
@@ -431,10 +434,10 @@ def example_vespa_concepts() -> list[VespaConcept]:
             id="1273",
             name="manufacturing sector",
             parent_concepts=[
-                {"name": "manufacturing", "id": "Q2"},
-                {"name": "processing industry", "id": "Q3"},
+                {"name": "manufacturing", "id": "Q200"},
+                {"name": "processing industry", "id": "Q300"},
             ],
-            parent_concept_ids_flat="Q2,Q3",
+            parent_concept_ids_flat="Q200,Q300",
             model="KeywordClassifier('manufacturing sector')",
             end=100,
             start=0,

--- a/tests/flows/fixtures/CCLW.executive.10014.4470.json
+++ b/tests/flows/fixtures/CCLW.executive.10014.4470.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": "0",
+        "id": "1570",
         "text": "National Council for Sustainable Development of the Kyrgyz Republic",
         "spans": [
             {
@@ -9,7 +9,7 @@
                 "end_index": 10,
                 "concept_id": "Q10014",
                 "labellers": [
-                    "Q10014-RuleBasedClassifier"
+                    "KeywordClassifier(\"professional services sector\")"
                 ],
                 "timestamps": [
                     "2021-09-29T14:00:00.000Z"
@@ -49,16 +49,65 @@
         }
     },
     {
-        "id": "1",
+        "id": "1273",
         "text": "The National Council for Sustainable Development of the Kyrgyz Republic is a consultative and advisory body under the President of the Kyrgyz Republic.",
         "spans": [
             {
                 "text": "National Council for Sustainable Development of the Kyrgyz Republic",
                 "start_index": 4,
                 "end_index": 14,
-                "concept_id": "Q10014",
+                "concept_id": "Q10015",
                 "labellers": [
-                    "Q10014-RuleBasedClassifier"
+                    "KeywordClassifier(\"professional services sector\")"
+                ],
+                "timestamps": [
+                    "2021-09-29T14:00:00.000Z"
+                ]
+            }
+        ],
+        "metadata": {
+            "concept": {
+                "preferred_label": "environmental hazards",
+                "alternative_labels": [
+                    "natural hazards",
+                    "environmental risk",
+                    "pollution",
+                    "climate hazards",
+                    "ecological risks",
+                    "environmental damage",
+                    "toxicity",
+                    "hazardous waste",
+                    "environmental contamination",
+                    "industrial pollution"
+                ],
+                "negative_labels": [],
+                "description": "Factors or events that pose potential harm to the environment and living organisms.",
+                "wikibase_id": "Q720855",
+                "subconcept_of": [
+                    "Q42689"
+                ],
+                "has_subconcept": [],
+                "related_concepts": [
+                    "Q5019",
+                    "Q198504",
+                    "Q11394"
+                ],
+                "definition": null,
+                "labelled_passages": []
+            }
+        }
+    },
+    {
+        "id": "1052",
+        "text": "The National Council for Sustainable Development of the Kyrgyz Republic is a consultative and advisory body under the President of the Kyrgyz Republic.",
+        "spans": [
+            {
+                "text": "National Council for Sustainable Development of the Kyrgyz Republic",
+                "start_index": 4,
+                "end_index": 14,
+                "concept_id": "Q10015",
+                "labellers": [
+                    "KeywordClassifier(\"professional services sector\")"
                 ],
                 "timestamps": [
                     "2021-09-29T14:00:00.000Z"

--- a/tests/flows/fixtures/CCLW.executive.4934.1571.json
+++ b/tests/flows/fixtures/CCLW.executive.4934.1571.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": "0",
+        "id": "197",
         "text": "Some random text on climate change.",
         "spans": [
             {
@@ -9,7 +9,7 @@
                 "end_index": 11,
                 "concept_id": "Q10014",
                 "labellers": [
-                    "Q10014-RuleBasedClassifier"
+                    "KeywordClassifier(\"professional services sector\")"
                 ],
                 "timestamps": [
                     "2021-09-29T14:00:00.000Z"
@@ -170,7 +170,7 @@
         }
     },
     {
-        "id": "1",
+        "id": "267",
         "text": "The National Council for Sustainable Development of the Kyrgyz Republic is a consultative and advisory body under the President of the Kyrgyz Republic.",
         "spans": [
             {
@@ -179,7 +179,7 @@
                 "end_index": 14,
                 "concept_id": "Q10014",
                 "labellers": [
-                    "Q10014-RuleBasedClassifier"
+                    "KeywordClassifier(\"professional services sector\")"
                 ],
                 "timestamps": [
                     "2021-09-29T14:00:00.000Z"

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -1,9 +1,9 @@
 import json
 import os
 import re
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Type
 from unittest.mock import patch
 
 import pytest
@@ -13,29 +13,26 @@ from cpr_sdk.search_adaptors import VespaSearchAdapter
 from prefect.logging import disable_run_logger
 
 from flows.index import (
+    CONCEPTS_COUNTS_PREFIX_DEFAULT,
     ClassifierSpec,
+    ConceptModel,
     Config,
-    convert_labelled_passages_to_concepts,
-    convert_labelled_passages_to_document_concepts,
-    dump_document_concepts,
+    DocumentImporter,
+    convert_labelled_passage_to_concepts,
+    get_document_passage_from_all_document_passages,
     get_document_passages_from_vespa,
     get_parent_concepts_from_concept,
-    get_passage_for_text_block,
     get_updated_passage_concepts,
     get_vespa_search_adapter_from_aws_secrets,
-    group_concepts_on_text_block,
     index_by_s3,
     index_labelled_passages_from_s3_to_vespa,
     iterate_batch,
-    labelled_passages_generator,
-    load_document_concepts,
     partial_update_text_block,
     run_partial_updates_of_concepts_for_document_passages,
     s3_obj_generator,
     s3_obj_generator_from_s3_paths,
     s3_obj_generator_from_s3_prefixes,
     s3_paths_or_s3_prefixes,
-    split_large_concepts_updates,
 )
 from scripts.cloud import AwsEnv
 from src.concept import Concept
@@ -50,7 +47,9 @@ DATA_ID_PATTERN = re.compile(r"[a-zA-Z]+.[a-zA-Z]+.\d+.\d+.\d+")
 
 
 def test_vespa_search_adapter_from_aws_secrets(
-    create_vespa_params, mock_vespa_credentials, tmp_path
+    create_vespa_params,
+    mock_vespa_credentials,
+    tmp_path,
 ) -> None:
     """Test that we can successfully instantiate the VespaSearchAdpater from ssm params."""
     vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
@@ -86,26 +85,22 @@ def test_s3_obj_generator_from_s3_prefixes(
     labelled_passage_fixture_files,
 ) -> None:
     """Test the s3 object generator."""
-    with disable_run_logger():
-        s3_gen = s3_obj_generator_from_s3_prefixes(
-            [
-                os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages),
-                os.path.join("s3://", mock_bucket_b, s3_prefix_labelled_passages),
-            ],
+    gen = s3_obj_generator_from_s3_prefixes(
+        [
+            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages),
+            os.path.join("s3://", mock_bucket_b, s3_prefix_labelled_passages),
+        ],
+    )
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{b}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
         )
-        s3_files = list(s3_gen)
-        assert len(s3_files) == len(labelled_passage_fixture_files * 2)
-
-        expected_keys = [
-            f"{s3_prefix_labelled_passages}/{Path(f).stem}"
-            for f in labelled_passage_fixture_files
-        ] + [
-            f"{s3_prefix_labelled_passages}/{Path(f).stem}"
-            for f in labelled_passage_fixture_files
-        ]
-        s3_files_keys = [file[0].replace(".json", "") for file in s3_files]
-
-        assert sorted(s3_files_keys) == sorted(expected_keys)
+        for b in [mock_bucket, mock_bucket_b]
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
 
 
 def test_s3_obj_generator_from_s3_paths(
@@ -115,46 +110,20 @@ def test_s3_obj_generator_from_s3_paths(
     labelled_passage_fixture_files,
 ) -> None:
     """Test the s3 object generator."""
-    with disable_run_logger():
-        s3_paths = {
-            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
-            for f in labelled_passage_fixture_files
-        } | {"gibberish"}
-        s3_gen = s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
-        s3_files = list(s3_gen)
-        assert len(s3_files) == len(labelled_passage_fixture_files)
-
-        expected_keys = [
-            f"{s3_prefix_labelled_passages}/{Path(f).stem}"
-            for f in labelled_passage_fixture_files
-        ]
-        s3_files_keys = [file[0].replace(".json", "") for file in s3_files]
-
-        assert sorted(s3_files_keys) == sorted(expected_keys)
-
-
-def test_labelled_passages_generator(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-    s3_prefix_labelled_passages,
-    labelled_passage_fixture_files,
-) -> None:
-    """Test that the document concepts generator yields the correct objects."""
-    s3_gen = s3_obj_generator_from_s3_prefixes(
-        [os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)]
-        + ["gibberish"]
-    )
-    labelled_passages_gen = labelled_passages_generator(generator_func=s3_gen)
-    labelled_passages_files = list(labelled_passages_gen)
-    expected_keys = [
-        f"{s3_prefix_labelled_passages}/{Path(f).stem}.json"
+    s3_paths = [
+        os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
         for f in labelled_passage_fixture_files
     ]
-
-    assert len(labelled_passages_files) == len(labelled_passage_fixture_files)
-    for s3_key, labelled_passages in labelled_passages_files:
-        assert all([type(i) is LabelledPassage for i in labelled_passages])
-        assert s3_key in expected_keys
+    gen = s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
+        )
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
 
 
 @pytest.mark.vespa
@@ -209,132 +178,78 @@ def test_get_document_passages_from_vespa(
 @pytest.mark.vespa
 async def test_run_partial_updates_of_concepts_for_document_passages(
     local_vespa_search_adapter: VespaSearchAdapter,
-    example_vespa_concepts: list[VespaConcept],
     vespa_app,
-    caplog: pytest.LogCaptureFixture,
+    mock_bucket,
+    s3_prefix_labelled_passages,
+    labelled_passage_fixture_files,
+    mock_bucket_labelled_passages,
+    mock_s3_client,
 ) -> None:
     """Test that we can run partial updates of concepts for document passages."""
-    with disable_run_logger():
-        document_import_id = "CCLW.executive.10014.4470"
+    document_fixture = labelled_passage_fixture_files[0]
+    document_import_id = Path(document_fixture).stem
+    document_object_uri = (
+        f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{document_fixture}"
+    )
 
-        # Confirm that the example concepts are not in the document passages
-        initial_passages = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
+    # Confirm that the example concepts are not in the document passages
+    initial_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+    initial_concepts = [
+        concept
+        for _, passage in initial_passages
+        if passage.concepts
+        for concept in passage.concepts
+    ]
+    assert len(initial_concepts) == 3660
+
+    # Confirm that we can add the example concepts to the document passages
+
+    test_counts = Counter(
+        {
+            ConceptModel(
+                wikibase_id=WikibaseID("Q10015"),
+                model_name='KeywordClassifier("professional services sector")',
+            ): 2,
+            ConceptModel(
+                wikibase_id=WikibaseID("Q10014"),
+                model_name='KeywordClassifier("professional services sector")',
+            ): 1,
+        }
+    )
+
+    assert (
+        test_counts
+        == await run_partial_updates_of_concepts_for_document_passages.fn(
+            document_importer=(document_import_id, document_object_uri),
             vespa_search_adapter=local_vespa_search_adapter,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
         )
-        initial_concepts = [
-            concept
-            for _, passage in initial_passages
-            if passage.concepts
-            for concept in passage.concepts
-        ]
+    )
+    updated_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+    updated_concepts = [
+        concept
+        for _, passage in updated_passages
+        if passage.concepts
+        for concept in passage.concepts
+    ]
 
-        assert len(initial_passages) > 0
-        assert all(
-            concept not in initial_concepts for concept in example_vespa_concepts
-        )
+    # Original + fixture (.tests/flows/fixtures/CCLW.executive.10014.4470.json)
+    assert len(updated_concepts) == 3663
 
-        document_concepts = [(c.id, c) for c in example_vespa_concepts]
+    test_counts_serialised = {str(k): v for k, v in test_counts.items()}
 
-        # Add a clear failure
-        fake_id = "99999999"
-        document_concepts.append(
-            (
-                fake_id,
-                Concept(
-                    id=fake_id,
-                    name="wood industry",
-                    parent_concepts=[
-                        {"name": "forestry sector", "id": "Q788"},
-                        {"name": "lumber", "id": "Q789"},
-                    ],
-                    parent_concept_ids_flat="Q788,Q789",
-                    model='KeywordClassifier("wood industry")',
-                    end=100,
-                    start=0,
-                    timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                    preferred_label="x",
-                ),
-            )
-        )
-
-        # Confirm that we can add the example concepts to the document passages
-        await run_partial_updates_of_concepts_for_document_passages.fn(
-            document_import_id=document_import_id,
-            document_concepts=document_concepts,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-
-        # Verify error was logged for the failed update
-        error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert any(
-            f"No passages found for text block: {fake_id}" in r.message
-            for r in error_logs
-        )
-
-        updated_passages = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-        updated_concepts = [
-            concept
-            for _, passage in updated_passages
-            if passage.concepts
-            for concept in passage.concepts
-        ]
-
-        assert len(updated_passages) > 0
-        assert len(updated_concepts) != len(initial_concepts)
-        assert all(
-            [
-                any([new_vespa_concept == c for c in updated_concepts])
-                for new_vespa_concept in example_vespa_concepts
-            ]
-        )
-
-        # Confirm we remove existing concepts and add new ones based on the model field
-        modified_example_vespa_concepts = [
-            (concept.id, concept.model_copy()) for concept in example_vespa_concepts * 2
-        ]
-        for idx, concept in enumerate(modified_example_vespa_concepts):
-            # Make a change to the concept but keep the same model, this triggers removal
-            # of the existing concepts with the same model
-            concept[1].end = idx
-
-        await run_partial_updates_of_concepts_for_document_passages.fn(
-            document_import_id=document_import_id,
-            document_concepts=modified_example_vespa_concepts,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-
-        second_updated_passages = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-        second_updated_concepts = [
-            concept
-            for _, passage in second_updated_passages
-            if passage.concepts
-            for concept in passage.concepts
-        ]
-
-        assert len(second_updated_passages) > 0
-        assert len(second_updated_concepts) != len(updated_concepts)
-        # Assert that the number of concepts after a second update in vespa is correct.
-        # This is equal to:
-        #   (all existing concepts in vespa)
-        #   - (minus concepts that have the same model as the new updates)
-        #   + (new updates)
-        #   This is as we remove old concepts for a model and replace them with the new ones.
-        assert len(second_updated_concepts) == (
-            len(updated_concepts)
-            + len(modified_example_vespa_concepts)
-            - len(example_vespa_concepts)
-        )
-        for _, new_vespa_concept in modified_example_vespa_concepts:
-            assert new_vespa_concept in second_updated_concepts
-        for example_vespa_concept in example_vespa_concepts:
-            assert example_vespa_concept not in second_updated_concepts
+    result = mock_s3_client.get_object(
+        Bucket=mock_bucket,
+        Key="concepts_counts/Q788/latest/CCLW.executive.10014.4470.json",
+    )
+    assert test_counts_serialised == json.loads(result["Body"].read().decode("utf-8"))
 
 
 @pytest.mark.asyncio
@@ -343,6 +258,10 @@ async def test_run_partial_updates_of_concepts_for_document_passages_task_failur
     local_vespa_search_adapter: VespaSearchAdapter,
     example_vespa_concepts: list[VespaConcept],
     vespa_app,
+    mock_bucket,
+    s3_prefix_labelled_passages,
+    labelled_passage_fixture_files,
+    mock_bucket_labelled_passages,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that we can continue on errors."""
@@ -350,24 +269,35 @@ async def test_run_partial_updates_of_concepts_for_document_passages_task_failur
     def mock_update_data(schema, namespace, data_id, fields):
         raise Exception("Forced update failure")
 
-    with disable_run_logger(), patch.object(
+    with patch.object(
         local_vespa_search_adapter.client, "update_data", side_effect=mock_update_data
     ):
-        document_import_id = "CCLW.executive.10014.4470"
-
-        document_concepts = [(c.id, c) for c in example_vespa_concepts]
+        document_fixture = labelled_passage_fixture_files[0]
+        document_import_id = Path(document_fixture).stem
+        document_object_uri = (
+            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{document_fixture}"
+        )
 
         # Run the update
-        await run_partial_updates_of_concepts_for_document_passages.fn(
-            document_import_id=document_import_id,
-            document_concepts=document_concepts,
-            vespa_search_adapter=local_vespa_search_adapter,
+        assert (
+            Counter()
+            == await run_partial_updates_of_concepts_for_document_passages.fn(
+                document_importer=(document_import_id, document_object_uri),
+                vespa_search_adapter=local_vespa_search_adapter,
+                cache_bucket=mock_bucket,
+                concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            )
         )
 
         # Verify error was logged for the failed update
         error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
         assert any(
-            "failed to do partial update for concept `1273`: Forced update failure"
+            "failed to do partial update for text block `1273`: Forced update failure"
+            == str(r.message)
+            for r in error_logs
+        )
+        assert any(
+            "failed to do partial update for text block `1052`: Forced update failure"
             == str(r.message)
             for r in error_logs
         )
@@ -398,6 +328,8 @@ async def test_index_by_s3_with_s3_prefixes(
         s3_prefixes=[os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)],
         s3_paths=None,
         as_subflow=False,
+        cache_bucket=mock_bucket,
+        concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
     )
 
     final_passages_response = local_vespa_search_adapter.client.query(
@@ -408,50 +340,8 @@ async def test_index_by_s3_with_s3_prefixes(
     )
 
     assert initial_concepts_count < final_concepts_count
-    assert initial_concepts_count + len(labelled_passage_fixture_files) == (
-        final_concepts_count
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.vespa
-async def test_index_by_s3_task_failure(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-    s3_prefix_labelled_passages,
-    labelled_passage_fixture_files,
-    local_vespa_search_adapter: VespaSearchAdapter,
-    vespa_app,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that index_by_s3 handles task failures gracefully."""
-
-    async def mock_run_partial_updates_of_concepts_for_document_passages_as(
-        *args, **kwargs
-    ):
-        raise Exception("Forced update failure")
-
-    with disable_run_logger(), patch(
-        "flows.index.run_partial_updates_of_concepts_for_document_passages_as",
-        side_effect=mock_run_partial_updates_of_concepts_for_document_passages_as,
-    ):
-        await index_by_s3(
-            aws_env=AwsEnv.sandbox,
-            vespa_search_adapter=local_vespa_search_adapter,
-            s3_prefixes=[
-                os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)
-            ],
-            s3_paths=None,
-            as_subflow=False,
-        )
-
-        # Verify error was logged for the failed update
-        error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
-        assert any(
-            "failed to process document for S3 key" in r.message
-            and "Forced update failure" in r.message
-            for r in error_logs
-        ), "Expected error log for failed document update not found"
+    # Original + fixture (.tests/flows/fixtures/*.json)
+    assert final_concepts_count == 3933
 
 
 @pytest.mark.asyncio
@@ -484,6 +374,8 @@ async def test_index_by_s3_with_s3_paths(
         s3_prefixes=None,
         s3_paths=s3_paths,
         as_subflow=False,
+        cache_bucket=mock_bucket,
+        concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
     )
 
     final_passages_response = local_vespa_search_adapter.client.query(
@@ -494,9 +386,51 @@ async def test_index_by_s3_with_s3_paths(
     )
 
     assert initial_concepts_count < final_concepts_count
-    assert initial_concepts_count + len(labelled_passage_fixture_files) == (
-        final_concepts_count
-    )
+    # Original + fixture (.tests/flows/fixtures/*.json)
+    assert final_concepts_count == 3933
+
+
+@pytest.mark.asyncio
+@pytest.mark.vespa
+async def test_index_by_s3_task_failure(
+    mock_bucket,
+    mock_bucket_labelled_passages,
+    s3_prefix_labelled_passages,
+    labelled_passage_fixture_files,
+    local_vespa_search_adapter: VespaSearchAdapter,
+    vespa_app,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that index_by_s3 handles task failures gracefully."""
+
+    async def mock_run_partial_updates_of_concepts_for_document_passages_as(
+        *args, **kwargs
+    ):
+        raise Exception("Forced update failure")
+
+    with patch(
+        "flows.index.run_partial_updates_of_concepts_for_document_passages_as",
+        side_effect=mock_run_partial_updates_of_concepts_for_document_passages_as,
+    ):
+        await index_by_s3(
+            aws_env=AwsEnv.sandbox,
+            vespa_search_adapter=local_vespa_search_adapter,
+            s3_prefixes=[
+                os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)
+            ],
+            s3_paths=None,
+            as_subflow=False,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+        )
+
+        # Verify error was logged for the failed update
+        error_logs = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert any(
+            "failed to process document" in r.message
+            and "Forced update failure" in r.message
+            for r in error_logs
+        ), "Expected error log for failed document update not found"
 
 
 @pytest.mark.asyncio
@@ -506,78 +440,75 @@ async def test_partial_update_text_block(
     vespa_app,
     example_vespa_concepts: list[VespaConcept],
 ):
-    with disable_run_logger():
-        document_import_id = "CCLW.executive.10014.4470"
+    document_import_id = "CCLW.executive.10014.4470"
 
-        concept_a, concept_b = example_vespa_concepts
+    concept_a, concept_b = example_vespa_concepts
 
-        # Confirm that the example concepts are not in the document passages
-        initial_passages = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-        initial_concepts = [
-            concept
-            for _, passage in initial_passages
-            if passage.concepts
-            for concept in passage.concepts
-        ]
+    # Confirm that the example concepts are not in the document passages
+    initial_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+    initial_concepts = [
+        concept
+        for _, passage in initial_passages
+        if passage.concepts
+        for concept in passage.concepts
+    ]
 
-        assert len(initial_passages) > 0, "fixture data wasn't loaded in"
-        assert all(
-            concept not in initial_concepts for concept in example_vespa_concepts
-        )
+    assert len(initial_passages) > 0, "fixture data wasn't loaded in"
+    assert all(concept not in initial_concepts for concept in example_vespa_concepts)
 
-        text_block_id = "1401"
+    text_block_id = "1401"
 
-        assert concept_a not in initial_concepts
+    assert concept_a not in initial_concepts
 
-        result_a = await partial_update_text_block(
-            text_block_id,
-            initial_passages,
-            local_vespa_search_adapter,
-            [concept_a],
-        )
+    result_a = await partial_update_text_block(
+        text_block_id,
+        initial_passages,
+        [concept_a],
+        local_vespa_search_adapter,
+    )
 
-        assert result_a is None
+    assert result_a is None
 
-        passages_a = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-        concepts_a = [
-            concept
-            for _, passage in passages_a
-            if passage.concepts
-            for concept in passage.concepts
-        ]
+    passages_a = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+    concepts_a = [
+        concept
+        for _, passage in passages_a
+        if passage.concepts
+        for concept in passage.concepts
+    ]
 
-        assert concept_a in concepts_a
+    assert concept_a in concepts_a
 
-        assert concept_b not in concepts_a
+    assert concept_b not in concepts_a
 
-        result_b = await partial_update_text_block(
-            text_block_id,
-            initial_passages,
-            local_vespa_search_adapter,
-            [concept_b],
-        )
+    result_b = await partial_update_text_block(
+        text_block_id,
+        initial_passages,
+        [concept_b],
+        local_vespa_search_adapter,
+    )
 
-        assert result_b is None
+    assert result_b is None
 
-        passages_b = get_document_passages_from_vespa(
-            document_import_id=document_import_id,
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
-        concepts_b = [
-            concept
-            for _, passage in passages_b
-            if passage.concepts
-            for concept in passage.concepts
-        ]
+    passages_b = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+    concepts_b = [
+        concept
+        for _, passage in passages_b
+        if passage.concepts
+        for concept in passage.concepts
+    ]
 
-        assert concept_a in concepts_a
-        assert concept_b in concepts_b
+    assert concept_a in concepts_a
+    assert concept_b in concepts_b
 
 
 @pytest.mark.parametrize("text_block_id", ["1457", "p_2_b_120"])
@@ -586,7 +517,7 @@ def test_get_passage_for_text_block(
 ) -> None:
     """Test that we can retrieve the relevant passage for a text block."""
     relevant_passage = (
-        "doc_id_1",
+        "id:doc_search:document_passage::CCLW.executive.00000.0000.001",
         VespaPassage(
             text_block="test text",
             text_block_id=text_block_id,
@@ -594,7 +525,7 @@ def test_get_passage_for_text_block(
         ),
     )
     irrelevant_passage = (
-        "doc_id_2",
+        "id:doc_search:document_passage::CCLW.executive.00000.0000.002",
         VespaPassage(
             text_block="test text",
             text_block_id="wrong_id",
@@ -605,14 +536,12 @@ def test_get_passage_for_text_block(
     for concept in example_vespa_concepts:
         concept.id = text_block_id
 
-        data_id, passage_id, passage = get_passage_for_text_block(
+        data_id, passage = get_document_passage_from_all_document_passages(
             text_block_id=text_block_id,
             document_passages=[relevant_passage, irrelevant_passage],
         )
-        assert data_id is not None
         data_id_pattern_match = DATA_ID_PATTERN.match(data_id) is not None
         assert data_id_pattern_match is not None
-        assert passage_id == relevant_passage[0]
         assert passage == relevant_passage[1]
 
 
@@ -626,42 +555,40 @@ async def test_index_labelled_passages_from_s3_to_vespa_with_document_ids_with_c
     local_vespa_search_adapter: VespaSearchAdapter,
     vespa_app,
 ) -> None:
-    with disable_run_logger():
-        initial_passages_response = local_vespa_search_adapter.client.query(
-            yql="select * from document_passage where true"
-        )
-        initial_concepts_count = sum(
-            len(hit["fields"]["concepts"]) for hit in initial_passages_response.hits
-        )
+    initial_passages_response = local_vespa_search_adapter.client.query(
+        yql="select * from document_passage where true"
+    )
+    initial_concepts_count = sum(
+        len(hit["fields"]["concepts"]) for hit in initial_passages_response.hits
+    )
 
-        classifier_spec = ClassifierSpec(name="Q788", alias="latest")
-        document_ids = [
-            Path(labelled_passage_fixture_file).stem
-            for labelled_passage_fixture_file in labelled_passage_fixture_files
-        ]
-        config = Config(
-            cache_bucket=mock_bucket,
-            vespa_search_adapter=local_vespa_search_adapter,
-            as_subflow=False,
-        )
+    classifier_spec = ClassifierSpec(name="Q788", alias="latest")
+    document_ids = [
+        Path(labelled_passage_fixture_file).stem
+        for labelled_passage_fixture_file in labelled_passage_fixture_files
+    ]
+    config = Config(
+        cache_bucket=mock_bucket,
+        vespa_search_adapter=local_vespa_search_adapter,
+        as_subflow=False,
+    )
 
-        await index_labelled_passages_from_s3_to_vespa(
-            classifier_specs=[classifier_spec],
-            document_ids=document_ids,
-            config=config,
-        )
+    await index_labelled_passages_from_s3_to_vespa(
+        classifier_specs=[classifier_spec],
+        document_ids=document_ids,
+        config=config,
+    )
 
-        final_passages_response = local_vespa_search_adapter.client.query(
-            yql="select * from document_passage where true"
-        )
-        final_concepts_count = sum(
-            len(hit["fields"]["concepts"]) for hit in final_passages_response.hits
-        )
+    final_passages_response = local_vespa_search_adapter.client.query(
+        yql="select * from document_passage where true"
+    )
+    final_concepts_count = sum(
+        len(hit["fields"]["concepts"]) for hit in final_passages_response.hits
+    )
 
-        assert initial_concepts_count < final_concepts_count
-        assert initial_concepts_count + len(labelled_passage_fixture_files) == (
-            final_concepts_count
-        )
+    assert initial_concepts_count < final_concepts_count
+    # Original + fixture (.tests/flows/fixtures/*.json)
+    assert final_concepts_count == 3933
 
 
 @pytest.mark.asyncio
@@ -704,10 +631,9 @@ async def test_index_labelled_passages_from_s3_to_vespa_with_document_ids_with_d
             len(hit["fields"]["concepts"]) for hit in final_passages_response.hits
         )
 
-        assert initial_concepts_count < final_concepts_count
-        assert initial_concepts_count + len(labelled_passage_fixture_files) == (
-            final_concepts_count
-        )
+    assert initial_concepts_count < final_concepts_count
+    # Original + fixture (.tests/flows/fixtures/*.json)
+    assert final_concepts_count == 3933
 
 
 def test_get_updated_passage_concepts(
@@ -718,13 +644,13 @@ def test_get_updated_passage_concepts(
         # Test we can add a concept to the passage concepts that doesn't already
         # exist.
         updated_passage_concepts = get_updated_passage_concepts(
-            concepts=[concept],
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
                 text_block_type="Text",
                 concepts=[],
             ),
+            concepts=[concept],
         )
         assert len(updated_passage_concepts) == 1
         assert updated_passage_concepts[0] == concept.model_dump(mode="json")
@@ -732,7 +658,6 @@ def test_get_updated_passage_concepts(
         # Test that we can remove old model concepts from the passage concepts and
         # add the new one.
         updated_passage_concepts = get_updated_passage_concepts(
-            concepts=[concept],
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
@@ -750,13 +675,13 @@ def test_get_updated_passage_concepts(
                     )
                 ],
             ),
+            concepts=[concept],
         )
         assert len(updated_passage_concepts) == 1
         assert updated_passage_concepts[0] == concept.model_dump(mode="json")
 
         # Test that we can add new concepts and retain concepts from other models
         updated_passage_concepts = get_updated_passage_concepts(
-            concepts=[concept],
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
@@ -774,6 +699,7 @@ def test_get_updated_passage_concepts(
                     )
                 ],
             ),
+            concepts=[concept],
         )
         assert len(updated_passage_concepts) == 2
         assert concept.model_dump(mode="json") in updated_passage_concepts
@@ -783,14 +709,8 @@ def test_convert_labelled_passges_to_concepts(
     example_labelled_passages: list[LabelledPassage],
 ) -> None:
     """Test that we can correctly convert labelled passages to concepts."""
-    with disable_run_logger():
-        concepts = convert_labelled_passages_to_concepts(example_labelled_passages)
-        assert all(
-            [
-                (isinstance(text_block_id, str) and isinstance(concept, VespaConcept))
-                for text_block_id, concept in concepts
-            ]
-        )
+    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
+    assert all([isinstance(concept, VespaConcept) for concept in concepts])
 
 
 def test_convert_labelled_passges_to_concepts_raises_error(
@@ -798,45 +718,37 @@ def test_convert_labelled_passges_to_concepts_raises_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that we correctly log errors when a Span has no concept ID or timestamps."""
-    with disable_run_logger():
-        # Add a span without concept_id
-        example_labelled_passages[0].spans.append(
-            Span(
-                text="Test text.",
-                start_index=0,
-                end_index=8,
-                concept_id=None,
-                labellers=[],
-            )
+    # Add a span without concept_id
+    example_labelled_passages[0].spans.append(
+        Span(
+            text="Test text.",
+            start_index=0,
+            end_index=8,
+            concept_id=None,
+            labellers=[],
         )
-        # Add a span without timestamps
-        example_labelled_passages[0].spans.append(
-            Span(
-                text="Test text.",
-                start_index=0,
-                end_index=8,
-                concept_id="Q123",
-                labellers=[],
-                timestamps=[],  # Empty timestamps
-            )
+    )
+    # Add a span without timestamps
+    example_labelled_passages[0].spans.append(
+        Span(
+            text="Test text.",
+            start_index=0,
+            end_index=8,
+            concept_id="Q123",
+            labellers=[],
+            timestamps=[],  # Empty timestamps
         )
+    )
 
-        concepts = convert_labelled_passages_to_concepts(example_labelled_passages)
+    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
 
-        # Check that appropriate error messages were logged
-        error_messages = [r.message for r in caplog.records if r.levelname == "ERROR"]
-        assert any("span concept ID is missing" in msg for msg in error_messages)
-        assert any("span timestamps are missing" in msg for msg in error_messages)
+    # Check that appropriate error messages were logged
+    error_messages = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert any("span concept ID is missing" in msg for msg in error_messages)
+    assert any("span timestamps are missing" in msg for msg in error_messages)
 
-        # Verify that the problematic spans were skipped but valid ones were processed
-        assert len(concepts) == len(
-            [
-                span
-                for passage in example_labelled_passages
-                for span in passage.spans
-                if span.concept_id is not None and span.timestamps
-            ]
-        )
+    # Verify that the problematic spans were skipped but valid one was processed
+    assert len(concepts) == 1
 
 
 def test_get_parent_concepts_from_concept() -> None:
@@ -854,541 +766,21 @@ def test_get_parent_concepts_from_concept() -> None:
     ) == ([{"id": "Q4470", "name": ""}], "Q4470,")
 
 
-def test_group_concepts_on_text_block(
-    example_vespa_concepts: list[VespaConcept],
-) -> None:
-    """
-    Test that we can successfully group concepts on the relevant text block.
-
-    Args:
-        example_vespa_concepts (List[VespaConcept]): List of example Vespa concepts.
-    """
-    text_block_one_concept_count = 2
-    text_block_one_concepts = [
-        ("text_block_1", example_vespa_concepts[0])
-    ] * text_block_one_concept_count
-
-    text_block_two_concept_count = 11
-    text_block_two_concepts = [
-        ("text_block_2", example_vespa_concepts[0])
-    ] * text_block_two_concept_count
-
-    all_concepts = text_block_one_concepts + text_block_two_concepts
-    grouped_concepts = group_concepts_on_text_block(all_concepts)
-
-    assert isinstance(grouped_concepts, dict)
-    for text_block_id, concepts in grouped_concepts.items():
-        assert isinstance(text_block_id, str)
-        assert all(isinstance(concept, VespaConcept) for concept in concepts)
-
-    assert len(grouped_concepts) == 2
-    assert set(grouped_concepts.keys()) == {"text_block_1", "text_block_2"}
-    assert len(grouped_concepts["text_block_1"]) == text_block_one_concept_count
-    assert len(grouped_concepts["text_block_2"]) == text_block_two_concept_count
-
-
-@pytest.mark.asyncio
-async def test_convert_labelled_passages_to_document_concepts(
-    example_labelled_passages: list[LabelledPassage],
-) -> None:
-    """Test conversion of labelled passages to document concepts."""
-    with disable_run_logger():
-
-        def mock_generator():
-            yield "s3://bucket/path1.json", example_labelled_passages[:2]
-            yield "s3://bucket/path2.json", example_labelled_passages[2:]
-
-        result = await convert_labelled_passages_to_document_concepts(mock_generator())
-
-        assert len(result) == 2
-        assert isinstance(result[0][0], str)
-        assert isinstance(result[0][1], list)
-        assert all(isinstance(concept, tuple) for concept in result[0][1])
-        assert all(isinstance(concept[1], VespaConcept) for concept in result[0][1])
-
-
-def test_dump_document_concepts(example_vespa_concepts: list[VespaConcept]):
-    """Test dumping document concepts to JSON strings."""
-    # Create test input with text block IDs and VespaConcepts
-    document_concepts = [
-        ("block_1", example_vespa_concepts[0]),
-        ("block_2", example_vespa_concepts[1]),
-    ]
-
-    # Dump to JSON strings
-    dumped = dump_document_concepts(document_concepts)
-
-    # Verify structure and types
-    assert len(dumped) == len(document_concepts)
-    for (orig_id, orig_concept), (dumped_id, dumped_json) in zip(
-        document_concepts, dumped
-    ):
-        assert dumped_id == orig_id
-        assert isinstance(dumped_json, str)
-        # Verify the JSON string can be loaded back into an equivalent object
-        loaded_concept = VespaConcept.model_validate_json(dumped_json)
-        assert loaded_concept == orig_concept
-
-
-def test_load_document_concepts(example_vespa_concepts: list[VespaConcept]):
-    """Test loading document concepts from JSON strings."""
-    # Create test input with text block IDs and JSON strings
-    document_concepts = [
-        ("block_1", example_vespa_concepts[0].model_dump_json()),
-        ("block_2", example_vespa_concepts[1].model_dump_json()),
-    ]
-
-    # Load from JSON strings
-    loaded = load_document_concepts(document_concepts)
-
-    # Verify structure and types
-    assert len(loaded) == len(document_concepts)
-    for (orig_id, orig_json), (loaded_id, loaded_concept) in zip(
-        document_concepts, loaded
-    ):
-        assert loaded_id == orig_id
-        assert isinstance(loaded_concept, VespaConcept)
-        # Verify the loaded object matches the original
-        original_concept = VespaConcept.model_validate_json(orig_json)
-        assert loaded_concept == original_concept
-
-
-def test_dump_load_document_concepts_roundtrip(
-    example_vespa_concepts: list[VespaConcept],
-):
-    """Test that dumping and loading document concepts preserves data."""
-    # Create test input
-    original = [
-        ("block_1", example_vespa_concepts[0]),
-        ("block_2", example_vespa_concepts[1]),
-    ]
-
-    # Round trip through dump and load
-    dumped = dump_document_concepts(original)
-    loaded = load_document_concepts(dumped)
-
-    # Verify nothing was lost
-    assert len(loaded) == len(original)
-    for (orig_id, orig_concept), (loaded_id, loaded_concept) in zip(original, loaded):
-        assert loaded_id == orig_id
-        assert loaded_concept == orig_concept
-
-
-@pytest.mark.parametrize(
-    "document_concepts, batch_size, expected",
-    [
-        # Test case 1: No splitting needed
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 10,
-                )
-            ],
-            400,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 10,
-                )
-            ],
-        ),
-        # Test case 2: Single batch needs splitting
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 5,
-                )
-            ],
-            4,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 4,
-                ),
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 1,
-                ),
-            ],
-        ),
-        # Test case 3: Multiple batches, some need splitting
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 300,
-                ),
-                (
-                    "block2",
-                    [
-                        VespaConcept(
-                            id="2",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 500,
-                ),
-                (
-                    "block3",
-                    [
-                        VespaConcept(
-                            id="3",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 100,
-                ),
-            ],
-            400,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 300,
-                ),
-                (
-                    "block2",
-                    [
-                        VespaConcept(
-                            id="2",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                ),
-                (
-                    "block2",
-                    [
-                        VespaConcept(
-                            id="2",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 100,
-                ),
-                (
-                    "block3",
-                    [
-                        VespaConcept(
-                            id="3",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 100,
-                ),
-            ],
-        ),
-        # Test case 4: Empty input
-        ([], 400, []),
-        # Test case 5: Single concept that doesn't need splitting
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ],
-                )
-            ],
-            400,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ],
-                )
-            ],
-        ),
-        # Test case 6: Exact batch size
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                )
-            ],
-            400,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                )
-            ],
-        ),
-        # Test case 7: Multiple batches with exact sizes
-        (
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                ),
-                (
-                    "block2",
-                    [
-                        VespaConcept(
-                            id="2",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                ),
-            ],
-            400,
-            [
-                (
-                    "block1",
-                    [
-                        VespaConcept(
-                            id="1",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                ),
-                (
-                    "block2",
-                    [
-                        VespaConcept(
-                            id="2",
-                            name="test",
-                            parent_concepts=[],
-                            parent_concept_ids_flat="",
-                            model="model",
-                            start=0,
-                            end=1,
-                            timestamp=datetime(2025, 1, 15, 16, 17, 21, 362785),
-                        )
-                    ]
-                    * 400,
-                ),
-            ],
-        ),
-    ],
-)
-def test_split_large_concepts_updates(
-    document_concepts,
-    batch_size,
-    expected,
-):
-    """Test that large concept updates are split correctly."""
-    # Create test input in the format the function expects
-    input_data = [(block_id, concepts) for block_id, concepts in document_concepts]
-
-    result = split_large_concepts_updates(input_data, batch_size)
-
-    # Verify the output
-    assert len(result) == len(expected)
-
-    for (result_block_id, result_concepts), (
-        expected_block_id,
-        expected_concepts,
-    ) in zip(result, expected):
-        assert result_block_id == expected_block_id
-        assert len(result_concepts) == len(expected_concepts)
-        assert all(
-            actual == expected
-            for actual, expected in zip(result_concepts, expected_concepts)
-        )
-
-
 def test_s3_paths_or_s3_prefixes_no_classifier(
     mock_bucket,
     mock_bucket_labelled_passages,
 ):
     """Test s3_paths_or_s3_prefixes returns base prefix when no classifier spec provided."""
-    with disable_run_logger():
-        config = Config(cache_bucket=mock_bucket)
+    config = Config(cache_bucket=mock_bucket)
 
-        paths, prefixes = s3_paths_or_s3_prefixes(
-            classifier_specs=None,
-            document_ids=None,
-            config=config,
-        )
+    paths, prefixes = s3_paths_or_s3_prefixes(
+        classifier_specs=None,
+        document_ids=None,
+        config=config,
+    )
 
-        assert prefixes == [f"s3://{mock_bucket}/labelled_passages"]
-        assert paths is None
+    assert prefixes == [f"s3://{mock_bucket}/labelled_passages"]
+    assert paths is None
 
 
 def test_s3_paths_or_s3_prefixes_no_classifier_and_docs(
@@ -1419,22 +811,21 @@ def test_s3_paths_or_s3_prefixes_with_classifier_no_docs(
     mock_bucket,
 ):
     """Test s3_paths_or_s3_prefixes returns classifier-specific prefix when no document IDs provided."""
-    with disable_run_logger():
-        config = Config(cache_bucket=mock_bucket)
-        classifier_spec_q788 = ClassifierSpec(name="Q788", alias="latest")
-        classifier_spec_q699 = ClassifierSpec(name="Q699", alias="latest")
+    config = Config(cache_bucket=mock_bucket)
+    classifier_spec_q788 = ClassifierSpec(name="Q788", alias="latest")
+    classifier_spec_q699 = ClassifierSpec(name="Q699", alias="latest")
 
-        paths, prefixes = s3_paths_or_s3_prefixes(
-            classifier_specs=[classifier_spec_q788, classifier_spec_q699],
-            document_ids=None,
-            config=config,
-        )
+    paths, prefixes = s3_paths_or_s3_prefixes(
+        classifier_specs=[classifier_spec_q788, classifier_spec_q699],
+        document_ids=None,
+        config=config,
+    )
 
-        assert prefixes == [
-            f"s3://{mock_bucket}/labelled_passages/Q788/latest",
-            f"s3://{mock_bucket}/labelled_passages/Q699/latest",
-        ]
-        assert paths is None
+    assert prefixes == [
+        f"s3://{mock_bucket}/labelled_passages/Q788/latest",
+        f"s3://{mock_bucket}/labelled_passages/Q699/latest",
+    ]
+    assert paths is None
 
 
 def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
@@ -1445,23 +836,22 @@ def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
     s3_prefix_mock_bucket_labelled_passages,
 ):
     """Test s3_paths_or_s3_prefixes returns specific paths when both classifier and document IDs provided."""
-    with disable_run_logger():
-        config = Config(cache_bucket=mock_bucket)
-        classifier_spec = ClassifierSpec(name="Q788", alias="latest")
+    config = Config(cache_bucket=mock_bucket)
+    classifier_spec = ClassifierSpec(name="Q788", alias="latest")
 
-        expected_paths = [
-            f"{s3_prefix_mock_bucket_labelled_passages}/{labelled_passage_fixture_file}"
-            for labelled_passage_fixture_file in labelled_passage_fixture_files
-        ]
+    expected_paths = [
+        f"{s3_prefix_mock_bucket_labelled_passages}/{labelled_passage_fixture_file}"
+        for labelled_passage_fixture_file in labelled_passage_fixture_files
+    ]
 
-        paths, prefixes = s3_paths_or_s3_prefixes(
-            classifier_specs=[classifier_spec],
-            document_ids=labelled_passage_fixture_ids,
-            config=config,
-        )
+    paths, prefixes = s3_paths_or_s3_prefixes(
+        classifier_specs=[classifier_spec],
+        document_ids=labelled_passage_fixture_ids,
+        config=config,
+    )
 
-        assert prefixes is None
-        assert sorted(paths) == sorted(expected_paths)
+    assert prefixes is None
+    assert sorted(paths) == sorted(expected_paths)
 
 
 @pytest.mark.parametrize(
@@ -1483,22 +873,22 @@ def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
         ),
         # Invalid types - should raise error
         (
-            "invalid",
-            "invalid",
+            None,
+            None,
             ValueError,
-            r"Unexpected types: `s3_prefixes=<class 'str'>`, `s3_paths=<class 'str'>`",
+            "Either s3_prefix or s3_paths must be provided.",
         ),
     ],
 )
 def test_s3_obj_generator_errors(
-    s3_prefixes: Optional[List[str]],
-    s3_paths: Optional[List[str]],
-    expected_error: Type[Exception],
+    s3_prefixes: list[str] | None,
+    s3_paths: list[str] | None,
+    expected_error: type[Exception],
     error_match: str,
 ) -> None:
     """Test s3_obj_generator error cases."""
     with pytest.raises(expected_error, match=error_match), disable_run_logger():
-        s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
+        _ = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
 
 
 @pytest.mark.parametrize(
@@ -1510,33 +900,30 @@ def test_s3_obj_generator_valid_cases(
     mock_bucket: str,
     mock_bucket_labelled_passages: None,
     s3_prefix_labelled_passages: str,
-    labelled_passage_fixture_files: List[str],
+    labelled_passage_fixture_files: list[str],
     use_prefixes: bool,
 ) -> None:
     """Test s3_obj_generator with valid inputs using either prefixes or paths."""
-    with disable_run_logger():
-        if use_prefixes:
-            s3_prefixes = [
-                os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)
-            ]
-            s3_paths = None
-        else:
-            s3_prefixes = None
-            s3_paths = [
-                os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
-                for f in labelled_passage_fixture_files
-            ]
-
-        gen = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
-        s3_files = list(gen)
-
-        assert len(s3_files) == len(labelled_passage_fixture_files)
-        expected_keys = [
-            f"{s3_prefix_labelled_passages}/{Path(f).stem}"
+    if use_prefixes:
+        s3_prefixes = [os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)]
+        s3_paths = None
+    else:
+        s3_prefixes = None
+        s3_paths = [
+            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
             for f in labelled_passage_fixture_files
         ]
-        s3_files_keys = [file[0].replace(".json", "") for file in s3_files]
-        assert sorted(s3_files_keys) == sorted(expected_keys)
+
+    gen = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
+        )
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Update**

I've built upon the first version, and refactored it to loop over documents, and then in the separate flow runs, do everything for that document self-contained in the flow run aka function.

It now also uploads the concepts counts to S3, to be used in a subsequent pipeline. That subsequent pipeline is to read each summary JSON file, sum the concepts together, to get the document's total concepts count.

This is quite a big rewrite, though, it is much more simple. I've removed some unnecessary transformations, I've added more type (aliases), I've refactored existing transformations into more useful data structures, etc.

_Testing_

Deployment: https://github.com/climatepolicyradar/knowledge-graph/actions/runs/13032154602/job/36353690209
Flow run: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/e3642555-aee7-42fb-8017-f52f1c9b3e59?entity_id=6af0c3dd-3895-4cff-8f20-34ffac33df57
Data in S3:
![CleanShot 2025-01-29 at 13 29 02](https://github.com/user-attachments/assets/08aa9400-6683-4531-8f90-740e12381b81)
Sample from S3: `aws s3 cp --profile staging s3://cpr-staging-data-pipeline-cache/concepts_counts/Q368/v2/CCLW.document.i00001513.n0000.json .`
`{"Q368:marine risk": 9}`

**Previously**

Since the generators are deterministic, and go document × passages, we can accumulate the concepts during the batches, document by document, and then do the update.

The important part is where we track which document we're on, and the accumulation of concepts' counts.

There's a few hairy parts of this, but I think it's sufficient for now.

CLOSES PLA-414
