### PR TITLE
Add pagination to WikibaseSession id lookup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def mock_wikibase_entities_json():
 
 
 @pytest.fixture
-def mock_wikibase_items_json():
+def mock_wikibase_items_first_page_json():
     return {
         "batchcomplete": "",
         "continue": {"apcontinue": "Q1003", "continue": "-||"},
@@ -139,6 +139,22 @@ def mock_wikibase_items_json():
                 {"pageid": 1022, "ns": 120, "title": "Item:Q1000"},
                 {"pageid": 1023, "ns": 120, "title": "Item:Q1001"},
                 {"pageid": 1024, "ns": 120, "title": "Item:Q1002"},
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def mock_wikibase_items_last_page_json():
+    return {
+        "batchcomplete": "",
+        "query": {
+            "allpages": [
+                {"pageid": 1031, "ns": 120, "title": "Item:Q1003"},
+                {"pageid": 1026, "ns": 120, "title": "Item:Q1004"},
+                {"pageid": 1028, "ns": 120, "title": "Item:Q1005"},
+                {"pageid": 1029, "ns": 120, "title": "Item:Q1006"},
+                {"pageid": 1030, "ns": 120, "title": "Item:Q1007"},
             ]
         },
     }
@@ -187,7 +203,8 @@ def MockedWikibaseSession(
     mock_wikibase_url,
     mock_wikibase_token_json,
     mock_wikibase_properties_json,
-    mock_wikibase_items_json,
+    mock_wikibase_items_first_page_json,
+    mock_wikibase_items_last_page_json,
     mock_wikibase_revisions_json,
     mock_wikibase_entities_json,
 ):
@@ -219,7 +236,16 @@ def MockedWikibaseSession(
                         return httpx.Response(200, json=mock_wikibase_properties_json)
                     # get_concepts
                     if apnamespace == "120":
-                        return httpx.Response(200, json=mock_wikibase_items_json)
+                        # Requests get continue details from the response,
+                        # so the first request won't have continue params
+                        if "continue" not in request.url.params:
+                            return httpx.Response(
+                                200, json=mock_wikibase_items_first_page_json
+                            )
+                        else:
+                            return httpx.Response(
+                                200, json=mock_wikibase_items_last_page_json
+                            )
             #  _login
             case "login":
                 return httpx.Response(200)

--- a/tests/flows/test_wikibase_to_s3.py
+++ b/tests/flows/test_wikibase_to_s3.py
@@ -67,6 +67,11 @@ def test_wikibase_to_s3(
             "Q1000",
             "Q1001",
             "Q1002",
+            "Q1003",
+            "Q1004",
+            "Q1005",
+            "Q1006",
+            "Q1007",
         ]
     )
     assert "Extras: ['Q20', 'Q30']" in caplog.text

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -35,14 +35,36 @@ def test_wikibase__get_concept(MockedWikibaseSession):
 def test_wikibase__get_concept_ids(MockedWikibaseSession):
     wikibase = MockedWikibaseSession()
     ids = wikibase.get_concept_ids()
-    assert set(ids) == {"Q10", "Q1000", "Q1002", "Q100", "Q1001"}
+    assert set(ids) == {
+        "Q1000",
+        "Q1003",
+        "Q1007",
+        "Q1001",
+        "Q100",
+        "Q1002",
+        "Q1004",
+        "Q10",
+        "Q1006",
+        "Q1005",
+    }
 
 
 def test_wikibase__get_concepts(MockedWikibaseSession):
     wikibase = MockedWikibaseSession()
     result = wikibase.get_concepts()
     ids = set([r.wikibase_id for r in result])
-    assert ids == {"Q10", "Q1000", "Q1002", "Q100", "Q1001"}
+    assert ids == {
+        "Q1000",
+        "Q1003",
+        "Q1007",
+        "Q1001",
+        "Q100",
+        "Q1002",
+        "Q1004",
+        "Q10",
+        "Q1006",
+        "Q1005",
+    }
 
 
 def test_wikibase__get_subconcepts(MockedWikibaseSession):


### PR DESCRIPTION
Resolves the todo comment that highlighted the need for pagination at 5000 concepts. We where someway off this at a little over 1000, but now that we are building a data transfer using this it also seems like the best time.

See the wikibase documentation for more details on the parameters, particularly: https://www.mediawiki.org/wiki/API:Continue#Example_3:_Python_code_for_iterating_through_all_results