### PR TITLE
extend the list of alternative labels on an item in wikibase

### DIFF
--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -448,16 +448,14 @@ class WikibaseSession:
             },
         ).json()
 
-        if (
-            "entities" in response
-            and wikibase_id in response["entities"]
-            and "aliases" in response["entities"][wikibase_id]
-            and language in response["entities"][wikibase_id]["aliases"]
-        ):
-            return [
-                alias["value"]
-                for alias in response["entities"][wikibase_id]["aliases"][language]
-            ]
+        aliases = (
+            response.get("entities", {})
+            .get(wikibase_id, {})
+            .get("aliases", {})
+            .get(language, [])
+        )
+        if aliases:
+            return [alias["value"] for alias in aliases]
         return []
 
     def add_alternative_labels(
@@ -467,15 +465,12 @@ class WikibaseSession:
         language: str = "en",
     ):
         """Add a list of alternative labels to a Wikibase item, preserving existing ones"""
-        # Get existing aliases
         existing_alternative_labels = self.get_alternative_labels(wikibase_id, language)
 
-        # Combine existing and new aliases, removing duplicates
         all_alternative_labels = list(
             set(existing_alternative_labels + alternative_labels)
         )
 
-        # Update with combined aliases
         response = self.session.post(
             url=self.api_url,
             data={


### PR DESCRIPTION
To actually upload the new labels, I exported the CSVs from [this spreadsheet](https://docs.google.com/spreadsheets/d/1Cn0VbVso4_K3atBcShfkNgoFrzoYBl2pAaP7099zlDQ/edit?gid=178880702#gid=178880702) and ran the following code:

```py
wikibase = WikibaseSession()
for wikibase_id in ["Q1368", "Q1369", "Q1370", "Q1371"]:
    path = (
        Path(f"~/Downloads/Finance actors for upload - {wikibase_id}.csv")
        .expanduser()
        .resolve()
    )

    console.print(f"Processing {wikibase_id}", style="bold")
    df = pd.read_csv(path)
    console.print(f'✅ loaded "{path}"', style="green")

    # every cell in the table is a potential label. look for any non-empty cells
    # and add them as alternative labels
    alternative_labels = [
        cell for cell in df.values.flatten() if cell and not pd.isna(cell)
    ]
    console.print(
        f"✅ Found {len(alternative_labels)} alternative labels", style="green"
    )

    with console.status("Pushing new alternative labels to Wikibase..."):
        wikibase.add_alternative_labels(wikibase_id, alternative_labels)
    console.print("✅ Pushed new alternative labels to Wikibase", style="green")
```

Don't feel a need to add it to the scripts directory as it's a one-off