### PR TITLE
Librarian check for graph depth and node descendants

### DIFF
--- a/static_sites/concept_librarian/__main__.py
+++ b/static_sites/concept_librarian/__main__.py
@@ -56,7 +56,7 @@ def get_affected_concept_ids(issues: list[ConceptStoreIssue]) -> Set[WikibaseID]
 @app.command()
 def main():
     wikibase = WikibaseSession()
-    concepts: list[Concept] = []
+    concepts: list[Concept | EmptyConcept] = []
     concept_ids = wikibase.get_concept_ids()
     for wikibase_id in track(
         concept_ids,

--- a/static_sites/concept_librarian/__main__.py
+++ b/static_sites/concept_librarian/__main__.py
@@ -22,10 +22,10 @@ from static_sites.concept_librarian.checks import (
     ensure_positive_and_negative_labels_dont_overlap,
     validate_alternative_label_uniqueness,
     validate_circular_hierarchical_relationships,
+    validate_concept_depth_and_descendant_balance,
     validate_concept_label_casing,
     validate_hierarchical_relationship_symmetry,
     validate_related_relationship_symmetry,
-    validate_concept_depth_and_descendant_balance,
 )
 from static_sites.concept_librarian.template import (
     create_concept_page,

--- a/static_sites/concept_librarian/__main__.py
+++ b/static_sites/concept_librarian/__main__.py
@@ -25,6 +25,7 @@ from static_sites.concept_librarian.checks import (
     validate_concept_label_casing,
     validate_hierarchical_relationship_symmetry,
     validate_related_relationship_symmetry,
+    validate_concept_depth_and_descendant_balance,
 )
 from static_sites.concept_librarian.template import (
     create_concept_page,
@@ -83,6 +84,7 @@ def main():
         validate_circular_hierarchical_relationships,
         check_for_unconnected_concepts,
         validate_concept_label_casing,
+        validate_concept_depth_and_descendant_balance,
     ]:
         issues.extend(check(concepts))
         console.log(f'Ran "{check.__name__}"')

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -46,15 +46,17 @@ class MultiConceptIssue(ConceptStoreIssue):
 
 
 def format_concept_link(concept: Concept | EmptyConcept) -> str:
-    """Format a concept as an HTML link"""
-    style = "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline underline-offset-4"
-    display_text = (
-        concept.wikibase_id if isinstance(concept, EmptyConcept) else str(concept)
-    )
-    wikibase_url = concept.wikibase_url if isinstance(concept, Concept) else ""
-    return (
-        f"<a href='{wikibase_url}' target='_blank' class='{style}'>{display_text}</a>"
-    )
+    """
+    Format a concept as an HTML link
+
+    If the concept is an EmptyConcept, it will be formatted as a plain string.
+    """
+    if isinstance(concept, EmptyConcept):
+        return concept.wikibase_id
+    else:
+        style = "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline underline-offset-4"
+        display_text = str(concept)
+        return f"<a href='{concept.wikibase_url}' target='_blank' class='{style}'>{display_text}</a>"
 
 
 def validate_related_relationship_symmetry(

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -347,14 +347,14 @@ def validate_concept_label_casing(
 
 def validate_concept_depth_and_descendant_balance(
     concepts: list[Concept],
-) -> list[Concept]:
+) -> list[ConceptIssue]:
     """
     Finds concepts that are too deep in the hierarchy with many descendants.
 
     This can suggest, that the concept has a spurious "subconcept of" relationship.
     This has happened previously when "Adaptation" got added below "Public Sector".
     """
-    issues: list[Concept] = []
+    issues: list[ConceptIssue] = []
     concepts_by_id = {
         concept.wikibase_id: concept
         for concept in concepts
@@ -373,7 +373,13 @@ def validate_concept_depth_and_descendant_balance(
         n_descendants = number_of_descendants_map[id]
 
         if depth != 0 and 200 / depth < n_descendants:
-            issues.append(concept)
+            issues.append(
+                ConceptIssue(
+                    concept=concept,
+                    issue_type="concept_depth_and_descendant_balance",
+                    message=f"{format_concept_link(concept)} is too deep in the hierarchy with {n_descendants} descendants",
+                )
+            )
 
     return issues
 

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -1,5 +1,4 @@
 import logging
-
 from collections import defaultdict, deque
 from string import punctuation
 from typing import MutableSequence, Optional
@@ -7,7 +6,6 @@ from typing import MutableSequence, Optional
 from pydantic import BaseModel
 
 from src.concept import Concept, WikibaseID
-
 
 # Create logger
 logger = logging.getLogger(__name__)
@@ -400,7 +398,7 @@ def _longest_concept_depth(
 
 
 def _build_number_of_descendants_map(
-    concept_map: dict[WikibaseID, Concept]
+    concept_map: dict[WikibaseID, Concept],
 ) -> dict[WikibaseID, int]:  # type: ignore
     """
     Build a map of concept ID to number of all descendants (at any level)

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -372,6 +372,10 @@ def validate_concept_depth_and_descendant_balance(
         depth = longest_depths[id]
         n_descendants = number_of_descendants_map[id]
 
+        # This threshold is somewhat arbitrary: I've come up with it be looking at the upper
+        # limit of this ratio for well-behaving concepts, which seemed to be bounded by
+        # n_descendants = 200 / depth, meaning that we're expecting e.g. max 200 descendants
+        # for a concept at level 1, and 40 for one at level 5.
         if depth != 0 and 200 / depth < n_descendants:
             issues.append(
                 ConceptIssue(

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -12,6 +12,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+class EmptyConcept(BaseModel):
+    """A concept which comes from Wikibase but is missing key data"""
+
+    wikibase_id: WikibaseID
+    preferred_label: Optional[str] = None
+
+
 class ConceptStoreIssue(BaseModel):
     """Issue raised by concept store checks"""
 
@@ -29,7 +36,7 @@ class RelationshipIssue(ConceptStoreIssue):
     """Issue raised by concept store checks"""
 
     from_concept: Concept
-    to_concept: Concept
+    to_concept: Concept | EmptyConcept
 
 
 class MultiConceptIssue(ConceptStoreIssue):
@@ -38,20 +45,16 @@ class MultiConceptIssue(ConceptStoreIssue):
     concepts: list[Concept]
 
 
-class EmptyConcept(Concept):
-    """A concept which comes from Wikibase but is missing key data"""
-
-    wikibase_id: WikibaseID  # type: ignore
-    preferred_label: Optional[str] = None  # type: ignore
-
-
-def format_concept_link(concept: Concept) -> str:
+def format_concept_link(concept: Concept | EmptyConcept) -> str:
     """Format a concept as an HTML link"""
     style = "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline underline-offset-4"
     display_text = (
         concept.wikibase_id if isinstance(concept, EmptyConcept) else str(concept)
     )
-    return f"<a href='{concept.wikibase_url}' target='_blank' class='{style}'>{display_text}</a>"
+    wikibase_url = concept.wikibase_url if isinstance(concept, Concept) else ""
+    return (
+        f"<a href='{wikibase_url}' target='_blank' class='{style}'>{display_text}</a>"
+    )
 
 
 def validate_related_relationship_symmetry(

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict, deque
 from string import punctuation
-from typing import MutableSequence, Optional
+from typing import MutableSequence, Optional, Union
 
 from pydantic import BaseModel
 
@@ -36,7 +36,7 @@ class RelationshipIssue(ConceptStoreIssue):
     """Issue raised by concept store checks"""
 
     from_concept: Concept
-    to_concept: Concept | EmptyConcept
+    to_concept: Union[EmptyConcept, Concept]
 
 
 class MultiConceptIssue(ConceptStoreIssue):
@@ -78,7 +78,8 @@ def validate_related_relationship_symmetry(
             issues.append(
                 RelationshipIssue(
                     issue_type="asymmetric_related_relationship",
-                    message=f"{format_concept_link(from_concept)} is related to {format_concept_link(to_concept)}, but {format_concept_link(to_concept)} is not related to {format_concept_link(from_concept)}",
+                    message=f"{format_concept_link(from_concept)} is related to {format_concept_link(to_concept)}, "
+                    f"but {format_concept_link(to_concept)} is not related to {format_concept_link(from_concept)}",
                     from_concept=from_concept,
                     to_concept=to_concept,
                 )

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -347,11 +347,11 @@ def validate_concept_label_casing(
     return issues
 
 
-def validate_concept_with_spurious_parent(
+def validate_concept_depth_and_descendant_balance(
     concepts: list[Concept],
 ) -> list[Concept]:
     """
-    Finds concepts that are too deep in the hierarchy with many children.
+    Finds concepts that are too deep in the hierarchy with many descendants.
 
     This can suggest, that the concept has a spurious "subconcept of" relationship.
     This has happened previously when "Adaptation" got added below "Public Sector".

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -1,3 +1,5 @@
+import logging
+
 from collections import defaultdict, deque
 from string import punctuation
 from typing import MutableSequence, Optional
@@ -5,6 +7,11 @@ from typing import MutableSequence, Optional
 from pydantic import BaseModel
 
 from src.concept import Concept, WikibaseID
+
+
+# Create logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class ConceptStoreIssue(BaseModel):
@@ -396,10 +403,10 @@ def _build_number_of_descendants_map(
     concept_map: dict[WikibaseID, Concept]
 ) -> dict[WikibaseID, int]:  # type: ignore
     """
-    Build a map of concept ID to number of children
+    Build a map of concept ID to number of all descendants (at any level)
 
-    Traverses the hierarchy, counting the number of children each concept has.
-    It starts with those nodes, that have no children (these will return 0). Then continues
+    Traverses the hierarchy, counting the number of descendants each concept has.
+    It starts with those nodes, that have no descendants (these will return 0). Then continues
     by processing those nodes, that only have processed children, etc.
     """
     queue: MutableSequence[Concept] = deque()
@@ -432,7 +439,7 @@ def _build_number_of_descendants_map(
                 queue.append(parent)
 
     skipped_values = list(set(concept_map.keys()) - set(children_map.keys()))
-    print("Missing values:", skipped_values)
+    logger.info(f"Missing values: {skipped_values}")
 
     return children_map
 

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -41,8 +41,8 @@ class MultiConceptIssue(ConceptStoreIssue):
 class EmptyConcept(Concept):
     """A concept which comes from Wikibase but is missing key data"""
 
-    wikibase_id: WikibaseID
-    preferred_label: Optional[str] = None
+    wikibase_id: WikibaseID  # type: ignore
+    preferred_label: Optional[str] = None  # type: ignore
 
 
 def format_concept_link(concept: Concept) -> str:

--- a/static_sites/concept_librarian/checks.py
+++ b/static_sites/concept_librarian/checks.py
@@ -437,7 +437,7 @@ def _build_number_of_descendants_map(
                 queue.append(parent)
 
     skipped_values = list(set(concept_map.keys()) - set(children_map.keys()))
-    logger.info(f"Missing values: {skipped_values}")
+    logger.warning(f"Missing values: {skipped_values}")
 
     return children_map
 

--- a/static_sites/concept_librarian/template.py
+++ b/static_sites/concept_librarian/template.py
@@ -7,6 +7,7 @@ from src.concept import Concept, WikibaseID
 from static_sites.concept_librarian.checks import (
     ConceptIssue,
     ConceptStoreIssue,
+    EmptyConcept,
     MultiConceptIssue,
     RelationshipIssue,
 )
@@ -61,9 +62,11 @@ def create_index_page(issues: list[ConceptStoreIssue]) -> str:
     )
 
 
-def create_concept_page(concept: Concept, all_issues: list[ConceptStoreIssue]) -> str:
+def create_concept_page(
+    concept: Concept | EmptyConcept, all_issues: list[ConceptStoreIssue]
+) -> str:
     """Create an HTML page for a specific concept's issues"""
-    concept_issues = get_issues_for_concept(all_issues, concept.wikibase_id)
+    concept_issues = get_issues_for_concept(all_issues, concept.wikibase_id)  # type: ignore
     return env.get_template("concept.html").render(
         issues=concept_issues,
         concept=concept,


### PR DESCRIPTION
## What this PR does?
- adds a new check for validating the depth - descendant balance of a concept
- adds traversal methods to the graph, e.g. finding the longest depth, aggregating the number of descendants

The idea came from an issue whereby "Adaptation" got added below "Public Sector" resulting in way too many descendants for some concepts and bloating them. This check is meant to find these spurious links, by checking the depth / descendants ratio. 

![image](https://github.com/user-attachments/assets/fba6221c-0bfc-44bd-9e33-9816ad9c9d18)

NOTE: I've also fixed an issue with `EmptyConcept`. Its inheritence from `Concept` was breaking some downstream functions, so I've made various changes to get this working.

## How was this tested?
By running on all concepts in the concept store, and inspecting results -- it picks up the above example, but nothing else.

Furthermore, by regenerating the librarian locally, and incepting results.