### PR TITLE
Add default property relationship values

### DIFF
--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -23,11 +23,15 @@ class WikibaseSession:
 
     session = httpx.Client()
 
-    has_subconcept_property_id = os.getenv("WIKIBASE_HAS_SUBCONCEPT_PROPERTY_ID")
-    subconcept_of_property_id = os.getenv("WIKIBASE_SUBCONCEPT_OF_PROPERTY_ID")
-    related_concept_property_id = os.getenv("WIKIBASE_RELATED_CONCEPT_PROPERTY_ID")
-    negative_labels_property_id = os.getenv("WIKIBASE_NEGATIVE_LABELS_PROPERTY_ID")
-    definition_property_id = os.getenv("WIKIBASE_DEFINITION_PROPERTY_ID")
+    has_subconcept_property_id = os.getenv("WIKIBASE_HAS_SUBCONCEPT_PROPERTY_ID", "P1")
+    subconcept_of_property_id = os.getenv("WIKIBASE_SUBCONCEPT_OF_PROPERTY_ID", "P2")
+    related_concept_property_id = os.getenv(
+        "WIKIBASE_RELATED_CONCEPT_PROPERTY_ID", "P3"
+    )
+    negative_labels_property_id = os.getenv(
+        "WIKIBASE_NEGATIVE_LABELS_PROPERTY_ID", "P9"
+    )
+    definition_property_id = os.getenv("WIKIBASE_DEFINITION_PROPERTY_ID", "P7")
 
     def __init__(
         self,


### PR DESCRIPTION
These are defined in the env.example but where missed for the env variables when setting up the pipeline copying concepts from wikibase to s3, the result was that the cdn objects ended up without the relationships.

Adding the env variables to the pipeline was the most obvious option, but I figured having them as defaults on the interface client might save us from doing this again, while still allowing for flexibility in changing them by env variable.