### PR TITLE
Add setup for local test wikibase instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ scratch/
 
 
 *.DS_Store
+tests/local_wikibase/config/*
+!tests/local_wikibase/config/.gitkeep

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 set dotenv-load
 export WANDB_DIR := "./data/wandb"
 import "tests/local_vespa/local_vespa.just"
+import "tests/local_wikibase/local_wikibase.just"
 
 # Set the default command to list all available commands
 default:

--- a/tests/local_wikibase/README.md
+++ b/tests/local_wikibase/README.md
@@ -1,0 +1,14 @@
+# Local Wikibase
+
+## Setup for tests
+
+This folder has the config for a local wikibase instance that is used for testing.
+
+## Reference
+
+This was setup based on an adaption of the advice found [here](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md), and through adapting the [linked dockerfile](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/docker-compose.yml). These adaptations where done to make it easier to use from a purely test perspective.
+
+### What adaptations where made?
+
+1. To remove the need to get an ssl certificate when spinning up the stack. Our use for this instance is very much a local & ci instance, being able to access it without needing a secure connection means we don't need to bother letsencrypt for certificates every run (which likely would have rate limited us).
+2. Portable domain resolution. The [guidance on local setup](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md#can-i-host-wbs-deploy-locally) suggests making changes on the host machine to resolve the domains. But making it so we can skip this step makes it easier to spin up on different machines and contexts.

--- a/tests/local_wikibase/README.md
+++ b/tests/local_wikibase/README.md
@@ -30,6 +30,25 @@ http://wdqs-frontend.localhost/
 
 http://quickstatements.localhost/
 
+### Programmatic Access
+
+```python
+
+from src.wikibase import WikibaseSession
+
+wikibase = WikibaseSession(
+    username="admin",
+    password="test123456",
+    url="http://localhost",
+    )
+
+properties = wikibase.get_all_properties()
+
+print(properties)
+
+```
+
+
 ## Reference
 
 This was setup based on an adaption of the advice found [here](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md), and through adapting the [linked dockerfile](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/docker-compose.yml). These adaptations where done to make it easier to use from a purely test perspective.

--- a/tests/local_wikibase/README.md
+++ b/tests/local_wikibase/README.md
@@ -4,6 +4,32 @@
 
 This folder has the config for a local wikibase instance that is used for testing.
 
+You can spin the stack up with:
+
+```bash
+just up-local-wikibase
+```
+
+And bring it down again when you are done:
+
+```bash
+just down-local-wikibase
+```
+
+When up, you can access the various frontends at:
+
+### Main Page
+
+http://localhost/wiki/Main_Page
+
+### Sparql Query UI
+
+http://wdqs-frontend.localhost/
+
+### Quickstatements
+
+http://quickstatements.localhost/
+
 ## Reference
 
 This was setup based on an adaption of the advice found [here](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md), and through adapting the [linked dockerfile](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/docker-compose.yml). These adaptations where done to make it easier to use from a purely test perspective.

--- a/tests/local_wikibase/README.md
+++ b/tests/local_wikibase/README.md
@@ -40,14 +40,13 @@ wikibase = WikibaseSession(
     username="admin",
     password="test123456",
     url="http://localhost",
-    )
+)
 
 properties = wikibase.get_all_properties()
 
 print(properties)
 
 ```
-
 
 ## Reference
 

--- a/tests/local_wikibase/docker-compose.dev.yml
+++ b/tests/local_wikibase/docker-compose.dev.yml
@@ -1,0 +1,198 @@
+name: wbs-deploy
+
+services:
+  # --------------------------------------------------
+  # A. CORE WIKIBASE SUITE SERVICES
+  # --------------------------------------------------
+
+  wikibase:
+    image: wikibase/wikibase:3
+    depends_on:
+      mysql:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wikibase.rule=Host(`localhost`) || Host(`wikibase.localhost`)"
+      - "traefik.http.routers.wikibase.entrypoints=web"
+      - "traefik.http.services.wikibase.loadbalancer.server.port=80"
+    volumes:
+      - ./config:/config
+      - wikibase-image-data:/var/www/html/images
+      - quickstatements-data:/quickstatements/data
+    env_file:
+      - ./wikibase_test.env
+    environment:
+      MW_WG_SERVER: http://localhost
+      DB_SERVER: mysql:3306
+      ELASTICSEARCH_HOST: elasticsearch
+      QUICKSTATEMENTS_PUBLIC_URL: http://localhost/quickstatements
+    healthcheck:
+      test: curl --silent --fail localhost/wiki/Main_Page
+      interval: 10s
+      start_period: 5m
+
+  wikibase-jobrunner:
+    image: wikibase/wikibase:3
+    command: /jobrunner-entrypoint.sh
+    depends_on:
+      wikibase:
+        condition: service_healthy
+    restart: unless-stopped
+    volumes_from:
+      - wikibase
+
+  mysql:
+    image: mariadb:10.11
+    restart: unless-stopped
+    volumes:
+      - mysql-data:/var/lib/mysql
+    env_file:
+      - ./wikibase_test.env
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+    healthcheck:
+      test: healthcheck.sh --connect --innodb_initialized
+      start_period: 1m
+      interval: 20s
+      timeout: 5s
+
+  # --------------------------------------------------
+  # B. EXTRA WIKIBASE SUITE SERVICES
+  # --------------------------------------------------
+
+  # To disable Elasticsearch and use default MediaWiki search functionality remove
+  # the elasticsearch service, and the MW_ELASTIC_* vars from wikibase_variables
+  # at the top of this file.
+  elasticsearch:
+    image: wikibase/elasticsearch:1
+    restart: unless-stopped
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+    healthcheck:
+      test: curl --silent --fail localhost:9200
+      interval: 10s
+      start_period: 2m
+
+  wdqs:
+    image: wikibase/wdqs:2
+    command: /runBlazegraph.sh
+    depends_on:
+      wikibase:
+        condition: service_healthy
+    restart: unless-stopped
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
+    volumes:
+      - wdqs-data:/wdqs/data
+    healthcheck:
+      test: curl --silent --fail localhost:9999/bigdata/namespace/wdq/sparql
+      interval: 10s
+      start_period: 2m
+
+  wdqs-updater:
+    image: wikibase/wdqs:2
+    command: /runUpdate.sh
+    depends_on:
+      wdqs:
+        condition: service_healthy
+    restart: unless-stopped
+    # Set number of files ulimit high enough, otherwise blazegraph will abort with:
+    # library initialization failed - unable to allocate file descriptor table - out of memory
+    # Appeared on Docker 24.0.5, containerd 1.7.9, Linux 6.6.6, NixOS 23.11
+    ulimits:
+      nofile:
+        soft: 32768
+        hard: 32768
+    environment:
+      WIKIBASE_CONCEPT_URI: http://wikibase.localhost
+
+  wdqs-proxy:
+    image: wikibase/wdqs-proxy:1
+    depends_on:
+      wdqs:
+        condition: service_healthy
+    restart: unless-stopped
+
+  wdqs-frontend:
+    image: wikibase/wdqs-frontend:1
+    depends_on:
+      - wdqs-proxy
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wdqs-frontend.rule=Host(`localhost`) && PathPrefix(`/query`) || Host(`wdqs-frontend.localhost`)"
+      - "traefik.http.routers.wdqs-frontend.entrypoints=web"
+      - "traefik.http.services.wdqs-frontend.loadbalancer.server.port=80"
+    environment:
+      WDQS_HOST: wdqs-proxy
+    healthcheck:
+      test: curl --silent --fail localhost
+      interval: 10s
+      start_period: 2m
+
+  quickstatements:
+    image: wikibase/quickstatements:1
+    depends_on:
+      wikibase:
+        condition: service_healthy
+    restart: unless-stopped
+    volumes:
+      - quickstatements-data:/quickstatements/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.quickstatements.rule=Host(`localhost`) && PathPrefix(`/quickstatements`) || Host(`quickstatements.localhost`)"
+      - "traefik.http.routers.quickstatements.entrypoints=web"
+      - "traefik.http.services.quickstatements.loadbalancer.server.port=80"
+    environment:
+      QUICKSTATEMENTS_PUBLIC_URL: http://localhost/quickstatements
+      WIKIBASE_PUBLIC_URL: http://localhost
+    healthcheck:
+      test: curl --silent --fail localhost
+      interval: 10s
+      start_period: 2m
+
+  # --------------------------------------------------
+  # C. REVERSE PROXY AND SSL SERVICES
+  # --------------------------------------------------
+
+  traefik:
+    image: traefik:3.1
+    command:
+      # Basic setup
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      # http endpoint
+      - "--entrypoints.web.address=:80"
+      # Enable Traefik dashboard
+      - "--api.insecure=true"
+      - "--api.dashboard=true"
+    restart: unless-stopped
+    ports:
+      - 80:80
+      - 8080:8080  # Traefik dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dashboard.rule=Host(`localhost`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+      - "traefik.http.routers.dashboard.service=api@internal"
+      - "traefik.http.routers.dashboard.entrypoints=web"
+volumes:
+  # A. CORE WIKIBASE SUITE SERVICES DATA
+  wikibase-image-data:
+  mysql-data:
+  # B. EXTRA WIKIBASE SUITE SERVICES DATA
+  wdqs-data:
+  elasticsearch-data:
+  quickstatements-data:

--- a/tests/local_wikibase/local_wikibase.just
+++ b/tests/local_wikibase/local_wikibase.just
@@ -1,0 +1,7 @@
+# Bring up the local wikibase stack
+up-local-wikibase:
+	docker compose --file tests/local_wikibase/docker-compose.dev.yml up --detach --wait
+
+# Bring down the local wikibase stack
+down-local-wikibase:
+	docker compose --file tests/local_wikibase/docker-compose.dev.yml down

--- a/tests/local_wikibase/wikibase_test.env
+++ b/tests/local_wikibase/wikibase_test.env
@@ -1,0 +1,17 @@
+# Public hostname configuration.
+WIKIBASE_PUBLIC_HOST=wikibase.localhost
+WDQS_FRONTEND_PUBLIC_HOST=wdqs-frontend.localhost
+QUICKSTATEMENTS_PUBLIC_HOST=quickstatements.localhost
+
+# MediaWiki / Wikibase user configuration.
+MW_ADMIN_NAME=admin
+MW_ADMIN_EMAIL=admin@wikibase.example
+MW_ADMIN_PASS=test123456
+
+# MediaWiki / Wikibase database configuration.
+DB_NAME=my_wiki
+DB_USER=sqluser
+DB_PASS=test123456
+MYSQL_DATABASE=${DB_NAME}
+MYSQL_USER=${DB_USER}
+MYSQL_PASSWORD=${DB_PASS}


### PR DESCRIPTION
Docker compose file with config and just commands for spinning up a test instance of wikibase. Resulting in this locally:

![image](https://github.com/user-attachments/assets/38840433-6a3c-46de-93d7-714419cdfd31)

No data or tests against it yet, but this seemed like a good point to share back.

## Reference

This was setup based on an adaption of the advice found [here](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md), and through adapting the [linked dockerfile](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/docker-compose.yml). These adaptations where done to make it easier to use from a purely test perspective.

### What adaptations where made?

1. To remove the need to get an ssl certificate when spinning up the stack. Our use for this instance is very much a local & ci instance, being able to access it without needing a secure connection means we don't need to bother letsencrypt for certificates every run (which likely would have rate limited us).
2. Portable domain resolution. The [guidance on local setup](https://github.com/wmde/wikibase-release-pipeline/blob/main/deploy/README.md#can-i-host-wbs-deploy-locally) suggests making changes on the host machine to resolve the domains. But making it so we can skip this step makes it easier to spin up on different machines and contexts.