### PR TITLE
Labelling librarian improvements

### DIFF
--- a/static_sites/labelling_librarian/__main__.py
+++ b/static_sites/labelling_librarian/__main__.py
@@ -48,7 +48,7 @@ def main():
         check_whether_span_border_is_in_word,
         check_whether_spans_have_high_non_alphabetical_ratio,
     ]:
-        for dataset in track(datasets, "Checking datasets for issues..."):
+        for dataset in track(datasets[:5], "Checking datasets for issues..."):
             issues.extend(check(dataset))
 
     console.log(f"Found {len(issues)} issues in {len(datasets)} datasets")

--- a/static_sites/labelling_librarian/__main__.py
+++ b/static_sites/labelling_librarian/__main__.py
@@ -48,7 +48,7 @@ def main():
         check_whether_span_border_is_in_word,
         check_whether_spans_have_high_non_alphabetical_ratio,
     ]:
-        for dataset in track(datasets[:5], "Checking datasets for issues..."):
+        for dataset in track(datasets, "Checking datasets for issues..."):
             issues.extend(check(dataset))
 
     console.log(f"Found {len(issues)} issues in {len(datasets)} datasets")

--- a/static_sites/labelling_librarian/templates/dataset.html
+++ b/static_sites/labelling_librarian/templates/dataset.html
@@ -77,7 +77,13 @@
       <a href="index.html" class="inline-block mb-6 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline">
         ← Back to all issues
       </a>
-
+      
+      <div class="bg-white dark:bg-gray-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 md:p-6 mb-6">
+        <h2 class="text-xl md:text-2xl font-semibold text-slate-800 dark:text-slate-100">
+          {{ dataset_name }} - {{ preferred_label }}
+        </h2>
+      </div>
+      
       <div class="bg-white dark:bg-gray-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 md:p-6 mb-6">
         <h1 class="text-2xl md:text-3xl font-semibold text-slate-800 dark:text-slate-100 mb-4">
           Dataset Issues

--- a/static_sites/labelling_librarian/templates/index.html
+++ b/static_sites/labelling_librarian/templates/index.html
@@ -36,10 +36,16 @@
       function filterDatasets() {
         const selectedTypes = Array.from(document.querySelectorAll('.issue-button.selected'))
           .map(button => button.getAttribute('data-issue-type'));
+        const filterValue = document.getElementById('dataset-filter').value.toLowerCase();
         const datasets = document.querySelectorAll('.dataset-card');
         datasets.forEach(dataset => {
           const issueTypes = dataset.getAttribute('data-issue-types').split(',');
-          if (selectedTypes.some(type => issueTypes.includes(type))) {
+          const datasetName = dataset.querySelector('a').textContent.toLowerCase();
+
+          const matchesIssueType = selectedTypes.length === 0 || selectedTypes.some(type => issueTypes.includes(type));
+          const matchesText = datasetName.includes(filterValue) && filterValue.length > 0;
+
+          if (matchesIssueType && matchesText) {
             dataset.classList.remove('hidden');
           } else {
             dataset.classList.add('hidden');
@@ -50,7 +56,6 @@
       function toggleButton(button) {
         const buttons = document.querySelectorAll('.issue-button');
         const allSelected = Array.from(buttons).every(btn => btn.classList.contains('selected'));
-        
         // if all buttons are selected, deselect all first (this is for users who want to filter when all are selected)
         if (allSelected) {
           deselectAll();
@@ -83,18 +88,30 @@
     <div class="max-w-7xl mx-auto p-6">
       <h1 class="text-2xl font-bold mb-4">Datasets and Issues</h1>
       <div class="bg-white dark:bg-gray-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 md:p-6 mb-6">
-        <div class="flex flex-wrap gap-2 mb-4">
-          <button class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors" onclick="selectAll()">
-            All
-          </button>
-          <button class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-md transition-colors" onclick="deselectAll()">
-            None
-          </button>
-          {% for issue_type, count in total_issue_counts.items() %}
-          <button class="issue-button px-4 py-2 text-white rounded-md transition-colors selected" data-issue-type="{{ issue_type }}" onclick="toggleButton(this)">
-            {{ issue_type }} ({{ count }})
-          </button>
-          {% endfor %}
+        <div class="grid grid-cols-5 gap-4 mb-4">
+          <div class="col-span-1">
+            <input
+              type="text"
+              id="dataset-filter"
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-md"
+              placeholder="Filter datasets..."
+              oninput="filterDatasets()"
+            />
+          </div>
+
+          <div class="col-span-4 flex flex-wrap gap-2">
+            <button class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors" onclick="selectAll()">
+              All
+            </button>
+            <button class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-md transition-colors" onclick="deselectAll()">
+              None
+            </button>
+            {% for issue_type, count in total_issue_counts.items() %}
+            <button class="issue-button px-4 py-2 text-white rounded-md transition-colors selected" data-issue-type="{{ issue_type }}" onclick="toggleButton(this)">
+              {{ issue_type }} ({{ count }})
+            </button>
+            {% endfor %}
+          </div>
         </div>
       </div>
       <div class="space-y-4">

--- a/static_sites/labelling_librarian/templates/index.html
+++ b/static_sites/labelling_librarian/templates/index.html
@@ -43,7 +43,7 @@
           const datasetName = dataset.querySelector('a').textContent.toLowerCase();
 
           const matchesIssueType = selectedTypes.length === 0 || selectedTypes.some(type => issueTypes.includes(type));
-          const matchesText = datasetName.includes(filterValue) && filterValue.length > 0;
+          const matchesText = datasetName.includes(filterValue) || filterValue.length === 0;
 
           if (matchesIssueType && matchesText) {
             dataset.classList.remove('hidden');
@@ -88,30 +88,27 @@
     <div class="max-w-7xl mx-auto p-6">
       <h1 class="text-2xl font-bold mb-4">Datasets and Issues</h1>
       <div class="bg-white dark:bg-gray-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 md:p-6 mb-6">
-        <div class="grid grid-cols-5 gap-4 mb-4">
-          <div class="col-span-1">
-            <input
-              type="text"
-              id="dataset-filter"
-              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-md"
-              placeholder="Filter datasets..."
-              oninput="filterDatasets()"
-            />
-          </div>
-
-          <div class="col-span-4 flex flex-wrap gap-2">
-            <button class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors" onclick="selectAll()">
-              All
-            </button>
-            <button class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-md transition-colors" onclick="deselectAll()">
-              None
-            </button>
-            {% for issue_type, count in total_issue_counts.items() %}
-            <button class="issue-button px-4 py-2 text-white rounded-md transition-colors selected" data-issue-type="{{ issue_type }}" onclick="toggleButton(this)">
-              {{ issue_type }} ({{ count }})
-            </button>
-            {% endfor %}
-          </div>
+        <div class="mb-4">
+          <input
+            type="text"
+            id="dataset-filter"
+            class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-md"
+            placeholder="Filter datasets..."
+            oninput="filterDatasets()"
+          />
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <button class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-md transition-colors" onclick="selectAll()">
+            All
+          </button>
+          <button class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-md transition-colors" onclick="deselectAll()">
+            None
+          </button>
+          {% for issue_type, count in total_issue_counts.items() %}
+          <button class="issue-button px-4 py-2 text-white rounded-md transition-colors selected" data-issue-type="{{ issue_type }}" onclick="toggleButton(this)">
+            {{ issue_type }} ({{ count }})
+          </button>
+          {% endfor %}
         </div>
       </div>
       <div class="space-y-4">

--- a/static_sites/labelling_librarian/templates/index.html
+++ b/static_sites/labelling_librarian/templates/index.html
@@ -101,7 +101,7 @@
         {% for dataset_name, metadata in dataset_info.items() %}
         <div class="dataset-card bg-white dark:bg-gray-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4" data-issue-types="{{ ','.join(metadata.issue_types) }}">
           <a href="/{{ dataset_name }}.html" class="text-xl font-semibold text-blue-600 dark:text-blue-400 hover:underline">
-            {{ dataset_name }}
+            {{ dataset_name }} - {{ metadata.preferred_label }}
           </a>
           <p class="text-slate-700 dark:text-slate-200">Dataset issues: {{ metadata.dataset_issue_count }}, passage issues: {{ metadata.passage_issue_count }}</p>
         </div>


### PR DESCRIPTION
## What this PR does
Adding some new features upon request from the policy team:
- datasets alsos show the concept's `preferred_label` now both on the landing page and the dataset pages
- dataset pages have the dataset name showing (this was missing in a previous version)
- datasets in the landing page are filterable by text (both on the preferred label and the qID)

## How was this tested
- inspecting and trying the new functionality
- deploying the tool