### PR TITLE
make the readme a bit more friendly for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,82 +2,95 @@
 
 This repo comprises the infrastructure, tools, and scripts for managing Climate Policy Radar's concept store and knowledge graph.
 
-Confused about those terms? See the [concept store vs knowledge graph](./docs/docs/developers/concept-store-vs-knowledge-graph.md) documentation for more information.
-
 ## Getting started
 
-### As a developer
-
-This repo is orchestrated with a [justfile](./justfile) (see [just](https://github.com/casey/just)) that wraps together a number of useful commands. Make sure you have `just` installed before you get started.
-
-Next, you'll need to install the project specific dependencies:
+This repo is orchestrated with a [justfile](./justfile) (see [just](https://github.com/casey/just)). To install the dependencies, run:
 
 ```bash
 just install
 ```
 
-Then you can run the tests:
-
-```bash
-just test
-```
-
-Or fetch everything we know about a concept from the concept store and argilla:
-
-```bash
-just get-concept Q123
-```
-
-You can then train a model, after logging in (with `aws sso login --profile labs`):
-
-```bash
-just train Q992
-```
-
-Or to also track in W&B and upload to S3:
-
-```bash
-just train Q992 --track --upload --aws-env labs
-```
-
-Afterwards, evaluate the trained model:
-
-```bash
-just evaluate Q992
-```
-
-Or to also track in W&B:
-
-```bash
-just evaluate Q992 --track
-```
-
-You can promote a model version from one AWS account/environment, to another. You can optionally promote that model to be the primary version that's used in that account.
-
-```bash
-poetry run promote Q992 --classifier RulesBasedClassifier --version v13 --from-aws-env labs --to-aws-env staging --primary
-```
-
-_or_
-
-```bash
-just promote Q992 --classifier RulesBasedClassifier --version v7 --within-aws-env staging --no-primary
-```
-
-You can also demote (aka disable) a promoted model version in an AWS account/environment, for a concept.
-
-```bash
-just demote Q787 labs
-```
-
-You can see the full list of commands by running:
+You can see the full list of `just` commands by running:
 
 ```bash
 just --list
 ```
 
-See the [docs](./docs) for more information on how to work with the knowledge graph.
+## Basics
 
-### As an editor
+### Concepts
 
-You can also explore and edit the graph directly through UI like the concept store. We've documented the process of getting started with the concept store and a style guide for how to structure the data in the [concept store documentation in notion](https://www.notion.so/climatepolicyradar/Concept-store-documentation-54b91a8359664cb3a9bbe3989efb7ca0?pvs=4).
+The knowledge graph is built from a collection of concepts. Concepts can have a preferred label, description, and alternative labels.
+
+```python
+from src.concept import Concept
+
+extreme_weather_concept = Concept(
+    preferred_label="extreme weather",
+    description="it's like weather, but too much!!",
+    alternative_labels=["extreme weather events", "rapid-onset events", "weather anomalies"],
+)
+```
+
+Most of CPR's concepts are defined in our [concept store](https://climatepolicyradar.wikibase.cloud), but you can always define your own in code.
+
+### Classifiers
+
+Classifiers are used to identify concepts in text. We use a variety of classifier architectures throughout our knowledge graph, from basic keyword matching to more sophisticated BERT-sized models, to optimised calls to third-party LLMs.
+
+Classifiers are single-class, ie there is a 1:1 mapping between a `Concept` and a `Classifier`. Calling the `predict` method on a classifier with some input text will return a list of `Spans` in which the concept is mentioned.
+
+```python
+from src.classifier import KeywordClassifier
+
+extreme_weather_classifier = KeywordClassifier(concept=extreme_weather_concept)
+
+predicted_spans = extreme_weather_classifier.predict("This is a passage of text about extreme weather")
+```
+
+```python
+[
+    Span(
+        text='This is a passage of text about extreme weather',
+        start_index=32,
+        end_index=47,
+        concept_id=None,
+        labellers=['KeywordClassifier("extreme weather")'],
+        id='sg5u338r',
+        labelled_text='extreme weather'
+    )
+]
+```
+
+### Labelled passages
+
+Labelled passages store a passage of text, together with the spans of text that match a particular concept. They can contain multiple spans for multiple concepts.
+
+```python
+from src.labelled_passage import LabelledPassage
+
+labelled_passage = LabelledPassage(
+    text="This is a passage of text about extreme weather",
+    spans=[
+        Span(
+            text='This is a passage of text about extreme weather',
+            start_index=32,
+            end_index=47,
+            concept_id=None,
+            labellers=['KeywordClassifier("extreme weather")'],
+            id='sg5u338r',
+            labelled_text='extreme weather'
+        )
+    ],
+)
+```
+
+Labelled passages are a versatile data structure that we use in many ways. They store the predictions from our classifiers, but passages labelled by human experts can also be used to train new models, or be used as a source of truth for comparing and evaluating the performance of candidate models.
+
+## How does that all of that add up to a knowledge graph?
+
+We've built our knowledge graph by running a set of classifiers over our giant corpus of climate-relevant text.
+
+In the short-term, identifying where each concept is mentioned in our documents makes it easier for interested users to jump straight to the relevant sections of our documents.
+
+In the longer term, we expect the graph to be a useful artefact in its own right. By analysing the structured web of relationships between climate policy concepts and the documents that mention them, we should be able to identify emerging topics and high-leverage areas for policy intervention.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ You can see the full list of `just` commands by running:
 just --list
 ```
 
-## Basics
+## The basics
 
 ### Concepts
 
-The knowledge graph is built from a collection of concepts. Concepts can have a preferred label, description, and alternative labels.
+Concepts are the core building blocks of our knowledge graph. They represent key ideas, terms, or topics which are important to understanding the climate policy domain. Each concept has a preferred label, optional alternative labels (synonyms, acronyms, related terms), a description, and can be linked to other concepts through hierarchical or associative relationships.
 
 ```python
 from src.concept import Concept
@@ -32,13 +32,13 @@ extreme_weather_concept = Concept(
 )
 ```
 
-Most of CPR's concepts are defined in our [concept store](https://climatepolicyradar.wikibase.cloud), but you can always define your own in code.
+Most of CPR's concepts are defined in our [concept store](https://climatepolicyradar.wikibase.cloud/wiki/Item:Q374) (and are thus associated with a `wikibase_id`), but you can always define your own concepts in code.
 
-### Classifiers
+### Classifiers and spans
 
 Classifiers are used to identify concepts in text. We use a variety of classifier architectures throughout our knowledge graph, from basic keyword matching to more sophisticated BERT-sized models, to optimised calls to third-party LLMs.
 
-Classifiers are single-class, ie there is a 1:1 mapping between a `Concept` and a `Classifier`. Calling the `predict` method on a classifier with some input text will return a list of `Spans` in which the concept is mentioned.
+Each classifier is single-class, meaning there's a 1:1 mapping between a `Concept` and a `Classifier`. When you call the `predict` method on a classifier with some input text, it returns a list of `Span` objects which indicate where the concept is mentioned.
 
 ```python
 from src.classifier import KeywordClassifier
@@ -64,7 +64,7 @@ predicted_spans = extreme_weather_classifier.predict("This is a passage of text 
 
 ### Labelled passages
 
-Labelled passages store a passage of text, together with the spans of text that match a particular concept. They can contain multiple spans for multiple concepts.
+Our `LabelledPassage` objects combine a passage of text with the spans that mention a particular concept. They can contain multiple spans, referring to multiple concepts, each labelled through a different method.
 
 ```python
 from src.labelled_passage import LabelledPassage
@@ -87,10 +87,10 @@ labelled_passage = LabelledPassage(
 
 Labelled passages are a versatile data structure that we use in many ways. They store the predictions from our classifiers, but passages labelled by human experts can also be used to train new models, or be used as a source of truth for comparing and evaluating the performance of candidate models.
 
-## How does that all of that add up to a knowledge graph?
+## So what is the knowledge graph?
 
 We've built our knowledge graph by running a set of classifiers over our giant corpus of climate-relevant text.
 
-In the short-term, identifying where each concept is mentioned in our documents makes it easier for interested users to jump straight to the relevant sections of our documents.
+In the short-term, identifying where each concept is mentioned in our documents makes it easier for interested users of CPR's tools to jump straight to the relevant sections of our documents.
 
 In the longer term, we expect the graph to be a useful artefact in its own right. By analysing the structured web of relationships between climate policy concepts and the documents that mention them, we should be able to identify emerging topics and high-leverage areas for policy intervention.

--- a/docs/docs/developers/justfile.md
+++ b/docs/docs/developers/justfile.md
@@ -1,0 +1,65 @@
+# Justfile
+
+Start by installing the dependencies:
+
+```bash
+just install
+```
+
+Then you can run the tests:
+
+```bash
+just test
+```
+
+Or fetch everything we know about a concept from the concept store and argilla:
+
+```bash
+just get-concept Q123
+```
+
+You can then train a model, after logging in (with `aws sso login --profile labs`):
+
+```bash
+just train Q992
+```
+
+Or to also track in W&B and upload to S3:
+
+```bash
+just train Q992 --track --upload --aws-env labs
+```
+
+Afterwards, evaluate the trained model:
+
+```bash
+just evaluate Q992
+```
+
+Or to also track in W&B:
+
+```bash
+just evaluate Q992 --track
+```
+
+You can promote a model version from one AWS account/environment, to another. You can optionally promote that model to be the primary version that's used in that account.
+
+```bash
+poetry run promote Q992 --classifier RulesBasedClassifier --version v13 --from-aws-env labs --to-aws-env staging --primary
+```
+
+_or_
+
+```bash
+just promote Q992 --classifier RulesBasedClassifier --version v7 --within-aws-env staging --no-primary
+```
+
+You can also demote (aka disable) a promoted model version in an AWS account/environment, for a concept.
+
+```bash
+just demote Q787 labs
+```
+
+You can see the full list of commands by running:
+
+See the [docs](./docs) for more information on how to work with the knowledge graph.


### PR DESCRIPTION
The KG repo is open these days, and we expect to see more traffic over here when when the associated features start appearing in product. 

Those newcomers probably won't be interested in which commands we run to promote our models between AWS environments etc, but they might want to know how to run a classifier to produce a labelled passage, or what we're trying to do with our knowledge graph at a high level

This PR:
- spruces up the front-facing README with newcomers in mind
- moves our existing justfile command documentation to a new file in `docs/developers` (sidenote: should we be documenting more stuff in there? less? who is that dir for, and what do we think it should do for them?)