### PR TITLE
Bugfix - indexing rate limits 

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -855,25 +855,17 @@ async def run_partial_updates_of_concepts_for_batch(
     """Run partial updates for concepts in a batch of documents."""
 
     logger = get_run_logger()
+    for i, document_importer in enumerate(documents_batch):
+        logger.info(
+            f"Updating concepts for batch of documents, {batch_size} indexing tasks for batch {documents_batch_num}."
+        )
 
-    logger.info(
-        f"Updating concepts for batch of documents, {batch_size} indexing tasks for batch {documents_batch_num}."
-    )
-    indexing_tasks = [
-        run_partial_updates_of_concepts_for_document_passages(
+        result = await run_partial_updates_of_concepts_for_document_passages(
             document_importer=document_importer,
             cache_bucket=cache_bucket,
             concepts_counts_prefix=concepts_counts_prefix,
         )
-        for document_importer in documents_batch
-    ]
 
-    results = await asyncio.gather(*indexing_tasks, return_exceptions=True)
-    logger.info(
-        f"Gathered {batch_size} indexing tasks for batch {documents_batch_num}."
-    )
-    for i, result in enumerate(results):
-        # Get the S3 key for the task
         document_import_id: DocumentImportId = documents_batch[i][0]
 
         if isinstance(result, Exception):


### PR DESCRIPTION
This Pull Request: 
---
- Is a bugfix for the indexing code to ensure we no longer hit prefect api rate limits. 

We were doing the following:
```python 
index_by_s3
-> async run run_partial_updates_of_concepts_for_batch_flow_or_deployment 
-> async run run_partial_updates_of_concepts_for_batch 
-> async run run_partial_updates_of_concepts_for_document_passages 
-> async run partial_update_text_block
```

This meant that we were running a huge number of processes asynchronously, many of which were hitting the prefect api. We could have removed the flow decorator from some of the functions to reduce prefect api calls but I think at the moment it's better to just reduce the amount we're trying to do all at once. 

We can spun up n number of indexers in parallel by toggling the batch size so we can manage parallelism that way, so the change I'm implementing is that we run  `run_partial_updates_of_concepts_for_document_passages` snychronously within these containers. 