### PR TITLE
Catching raised exceptions when no passages for a document.

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -855,26 +855,25 @@ async def run_partial_updates_of_concepts_for_batch(
     """Run partial updates for concepts in a batch of documents."""
 
     logger = get_run_logger()
+    logger.info(
+        f"Updating concepts for batch of documents, documents in batch: {len(documents_batch)}."
+    )
     for i, document_importer in enumerate(documents_batch):
-        logger.info(
-            f"Updating concepts for batch of documents, {batch_size} indexing tasks for batch {documents_batch_num}."
-        )
+        try:
+            _ = await run_partial_updates_of_concepts_for_document_passages(
+                document_importer=document_importer,
+                cache_bucket=cache_bucket,
+                concepts_counts_prefix=concepts_counts_prefix,
+            )
 
-        result = await run_partial_updates_of_concepts_for_document_passages(
-            document_importer=document_importer,
-            cache_bucket=cache_bucket,
-            concepts_counts_prefix=concepts_counts_prefix,
-        )
+            logger.info(f"processed batch documents #{documents_batch_num}")
 
-        document_import_id: DocumentImportId = documents_batch[i][0]
-
-        if isinstance(result, Exception):
+        except Exception as e:
+            document_import_id: DocumentImportId = documents_batch[i][0]
             logger.error(
-                f"failed to process document `{document_import_id}`: {str(result)}",
+                f"failed to process document `{document_import_id}`: {e.__str__()}",
             )
             continue
-
-        logger.info(f"processed batch documents #{documents_batch_num}")
 
 
 async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(


### PR DESCRIPTION
This Pull Request: 
---
- Catches raised exceptions, particularly when no passages are found for a document. 
- When we were running `run_partial_updates_of_concepts_for_batch` asynchronously the value errors that were thrown when there were no passages found for a document did not propagate and stop the program due to the use of the `asyncio.gather`. Now that we are awaiting the result the exception is being thrown and thus must be caught.
- I considered being tight on the exception handling and setting a ValueError, but then we might stop the entire program for another type of error and the prior solution didn't have granular exception handling so this is no step backwards. 