### PR TITLE
Additional logging to debug indexing flow

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import os
 import re
+import sys
 import tempfile
 from collections import Counter
 from collections.abc import Generator
@@ -892,6 +893,16 @@ async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
         "Running partial updates of concepts for batch as sub-flow or deployment: "
         f"batch length {len(documents_batch)}, as_subflow: {as_subflow}"
     )
+    size_in_bytes = sys.getsizeof(documents_batch)
+    size_in_kb = size_in_bytes / 1024
+    logger.info(
+        f"The parameter size of the documents_batch is approximately {size_in_kb:.2f} KB"
+    )
+    if size_in_kb > 512:
+        logger.warning(
+            "The parameter size of the documents_batch is greater than 512 KB. "
+            "Consider reducing the batch size."
+        )
 
     if as_subflow:
         return await run_partial_updates_of_concepts_for_batch(

--- a/flows/index.py
+++ b/flows/index.py
@@ -876,6 +876,7 @@ async def run_partial_updates_of_concepts_for_batch(
             continue
 
 
+@flow
 async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
     documents_batch: list[DocumentImporter],
     batch_size: int,
@@ -886,6 +887,12 @@ async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
     as_subflow: bool,
 ) -> None:
     """Run partial updates for a batch of documents as a sub-flow or deployment."""
+    logger = get_run_logger()
+    logger.info(
+        "Running partial updates of concepts for batch as sub-flow or deployment: "
+        f"batch length {len(documents_batch)}, as_subflow: {as_subflow}"
+    )
+
     if as_subflow:
         return await run_partial_updates_of_concepts_for_batch(
             documents_batch=documents_batch,


### PR DESCRIPTION
This Pull Request: 
---
- Adds logging to the `run_partial_updates_of_concepts_for_batch_flow_or_deployment` function.
- This is in response to some undesired behaviour in the latest run where asynchronous running of deployments didn't go as planned. My theory is that we are exceeding the max limit of a parameter to pass into a flow in prefect: 
https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/2ad3e80b-ee0c-4841-8193-a450b50f9294?entity_id=e67b2924-9467-4b33-a3be-e5a3380fbcac