### PR TITLE
Removing flow decorator.

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -877,7 +877,6 @@ async def run_partial_updates_of_concepts_for_batch(
             continue
 
 
-@flow
 async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
     documents_batch: list[DocumentImporter],
     batch_size: int,


### PR DESCRIPTION
This Pull Request: 
---
- Removes the flow decorator from a function. 
- Below we are validating the size of the parameters before invoking a flow or deployment, thus this can't be a flow itself. 