### PR TITLE
include recursive_subconcept_of in objects persisted to s3

### DIFF
--- a/flows/wikibase_to_s3.py
+++ b/flows/wikibase_to_s3.py
@@ -131,7 +131,7 @@ def wikibase_to_s3(config: Optional[Config] = None):
             logger.info(f"Uploading concept #{i}: {wikibase_id}")
         try:
             concept = wikibase.get_concept(
-                wikibase_id, include_recursive_parent_concepts=True
+                wikibase_id, include_recursive_subconcept_of=True
             )
             upload_to_s3(config, concept)
         except Exception as e:

--- a/flows/wikibase_to_s3.py
+++ b/flows/wikibase_to_s3.py
@@ -130,7 +130,9 @@ def wikibase_to_s3(config: Optional[Config] = None):
         if i % config.logging_interval == 0:
             logger.info(f"Uploading concept #{i}: {wikibase_id}")
         try:
-            concept = wikibase.get_concept(wikibase_id)
+            concept = wikibase.get_concept(
+                wikibase_id, include_recursive_parent_concepts=True
+            )
             upload_to_s3(config, concept)
         except Exception as e:
             logger.error(f"Failed to upload concept #{i}: {wikibase_id}, error: {e}")

--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -110,8 +110,8 @@ class WikibaseSession:
         wikibase_id: WikibaseID,
         timestamp: Optional[datetime] = None,
         include_labels_from_subconcepts: bool = False,
-        include_recursive_parent_concepts: bool = False,
-        include_recursive_subconcepts: bool = False,
+        include_recursive_subconcept_of: bool = False,
+        include_recursive_has_subconcept: bool = False,
     ) -> Concept:
         """
         Get a concept from Wikibase by its Wikibase ID
@@ -121,8 +121,10 @@ class WikibaseSession:
             If not provided, the latest version of the concept will be fetched.
         :param bool include_labels_from_subconcepts: Whether to include the labels
             from subconcepts in the concept
-        :param bool include_recursive_parent_concepts: Whether to include the concept's
+        :param bool include_recursive_subconcept_of: Whether to include the concept's
             complete ancestry of all parent concepts, recursively up the hierarchy
+        :param bool include_recursive_has_subconcept: Whether to include the concept's
+            complete subconcepts, recursively down the hierarchy
         :return Concept: The concept with the given Wikibase ID
         """
         # Resolve any redirects first
@@ -159,7 +161,7 @@ class WikibaseSession:
         redirects = (
             page_id_response.get("entities", {})
             .get(wikibase_id, {})
-            .get("redirects", [])
+            .get("redirects", {})
         )
         if redirects:
             logger.warning(
@@ -260,13 +262,13 @@ class WikibaseSession:
                         elif property_id == self.definition_property_id:
                             concept.definition = value
 
-        if include_recursive_parent_concepts:
+        if include_recursive_subconcept_of:
             concept.recursive_subconcept_of = (
                 self.get_recursive_subconcept_of_relationships(wikibase_id)
             )
 
-        if include_recursive_subconcepts:
-            concept.recursive_subconcept_of = (
+        if include_recursive_has_subconcept:
+            concept.recursive_has_subconcept = (
                 self.get_recursive_has_subconcept_relationships(wikibase_id)
             )
 


### PR DESCRIPTION
following https://github.com/climatepolicyradar/knowledge-graph/pull/281, adding this kwarg to our `get_concept` call should give us the complete ancestry for each concept object in s3. I'll follow up with a separate PR to propagate the values down the pipeline towards vespa, but this should _already_ be a helpful addition for the application team 🎉 

the last PR also included a stupid mistake re which fields we add the fetched relationships to! I've fixed that here.