### PR TITLE
Refactor argilla v2 into `ArgillaSession`

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -29,6 +29,7 @@ from flows.inference import (
     run_classifier_inference_on_batch_of_documents,
 )
 from flows.wikibase_to_s3 import wikibase_to_s3
+from flows.data_backup import data_backup
 from scripts.cloud import PROJECT_NAME, AwsEnv, generate_deployment_name
 
 MEGABYTES_PER_GIGABYTE = 1024
@@ -157,10 +158,10 @@ create_deployment(
 
 # # Data backup
 
-# create_deployment(
-#     flow=data_backup,
-#     description="Deploy all Argilla datasets to Huggingface",
-#     env_schedules={
-#         AwsEnv.labs: "0 0 * * *",  # Every day at midnight
-#     },
-# )
+create_deployment(
+    flow=data_backup,
+    description="Deploy all Argilla datasets to Huggingface",
+    env_schedules={
+        AwsEnv.labs: "0 0 * * *",  # Every day at midnight
+    },
+)

--- a/deployments.py
+++ b/deployments.py
@@ -18,6 +18,7 @@ from flows.count_family_document_concepts import (
     count_family_document_concepts,
     load_update_document_concepts_counts,
 )
+from flows.data_backup import data_backup
 from flows.deploy_static_sites import deploy_static_sites
 from flows.index import (
     index_labelled_passages_from_s3_to_vespa,
@@ -29,7 +30,6 @@ from flows.inference import (
     run_classifier_inference_on_batch_of_documents,
 )
 from flows.wikibase_to_s3 import wikibase_to_s3
-from flows.data_backup import data_backup
 from scripts.cloud import PROJECT_NAME, AwsEnv, generate_deployment_name
 
 MEGABYTES_PER_GIGABYTE = 1024

--- a/flows/data_backup.py
+++ b/flows/data_backup.py
@@ -5,10 +5,7 @@ import os
 from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow, task
 
-from src.argilla_v2 import (
-    dataset_to_labelled_passages,
-    get_all_datasets,
-)
+from src.argilla_v2 import ArgillaSession
 from src.huggingface import HuggingfaceSession
 
 
@@ -26,12 +23,12 @@ def setup_environment():
 def data_backup():
     """Flow to deploy all our static sites."""
     setup_environment()
-
+    argilla_session = ArgillaSession()
     hf_session = HuggingfaceSession()
 
-    datasets = get_all_datasets("knowledge-graph")
+    datasets = argilla_session.get_all_datasets("knowledge-graph")
     for dataset in datasets:
-        labelled_passages = dataset_to_labelled_passages(dataset)
+        labelled_passages = argilla_session.dataset_to_labelled_passages(dataset)
         hf_session.push(dataset.name, labelled_passages)
 
 

--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -4,7 +4,7 @@ import typer
 from rich.console import Console
 
 from scripts.config import concept_dir
-from src.argilla_v2 import get_labelled_passages_from_argilla
+from src.argilla_v2 import ArgillaSession
 from src.identifiers import WikibaseID
 from src.wikibase import WikibaseSession
 
@@ -25,12 +25,16 @@ def main(
         wikibase = WikibaseSession()
     console.log("✅ Connected to Wikibase")
 
+    with console.status("Connecting to Argilla..."):
+        argilla = ArgillaSession()
+    console.log("✅ Connected to Argilla")
+
     concept = wikibase.get_concept(wikibase_id)
     console.log(f'🔍 Fetched metadata for "{concept}" from wikibase')
 
     try:
         with console.status("Fetching labelled passages from Argilla..."):
-            labelled_passages = get_labelled_passages_from_argilla(concept)
+            labelled_passages = argilla.get_labelled_passages_from_argilla(concept)
         console.log(
             f"🏷️ Found {len(labelled_passages)} labelled passages for {wikibase_id} in Argilla"
         )

--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -34,7 +34,7 @@ def main(
 
     try:
         with console.status("Fetching labelled passages from Argilla..."):
-            labelled_passages = argilla.get_labelled_passages_from_argilla(concept)
+            labelled_passages = argilla.pull_labelled_passages(concept)
         console.log(
             f"🏷️ Found {len(labelled_passages)} labelled passages for {wikibase_id} in Argilla"
         )

--- a/scripts/push_to_argilla.py
+++ b/scripts/push_to_argilla.py
@@ -9,9 +9,7 @@ from rich.console import Console
 from tqdm.auto import tqdm  # type: ignore
 
 from scripts.config import concept_dir, processed_data_dir
-from src.argilla_v2 import (
-    labelled_passages_to_feedback_dataset,
-)
+from src.argilla_v2 import ArgillaSession
 from src.concept import Concept
 from src.identifiers import WikibaseID, generate_identifier
 from src.labelled_passage import LabelledPassage
@@ -48,6 +46,9 @@ def main(
         ),
     ],
 ):
+    with console.status("Connecting to Argilla..."):
+        argilla = ArgillaSession()
+    console.log("✅ Connected to Argilla")
     sampled_passages_dir = processed_data_dir / "sampled_passages"
     sampled_passages_path = sampled_passages_dir / f"{wikibase_id}.jsonl"
 
@@ -125,7 +126,7 @@ def main(
 
     console.log(f"✅ Loaded metadata for {concept}")
 
-    dataset = labelled_passages_to_feedback_dataset(
+    dataset = argilla.labelled_passages_to_feedback_dataset(
         labelled_passages, concept, workspace
     )
 

--- a/scripts/push_to_argilla.py
+++ b/scripts/push_to_argilla.py
@@ -126,7 +126,7 @@ def main(
 
     console.log(f"✅ Loaded metadata for {concept}")
 
-    dataset = argilla.labelled_passages_to_feedback_dataset(
+    dataset = argilla.labelled_passages_to_dataset(
         labelled_passages, concept, workspace
     )
 

--- a/src/argilla_v2.py
+++ b/src/argilla_v2.py
@@ -22,300 +22,300 @@ from src.wikibase import Concept
 
 load_dotenv(find_dotenv())
 
-# TODO we'll need something more robust than creating this global variable here
-client = rg.Argilla(
-    api_key=os.getenv("ARGILLA_API_KEY"),
-    api_url=os.getenv("ARGILLA_API_URL"),
-)
 
-
-def get_all_datasets(workspace_name: str) -> list[Dataset]:
-    """
-    Get all datasets in a workspace.
-
-    :param Workspace workspace: The workspace to get the datasets from
-    :return list[Dataset]: A list of datasets
-    """
-    datasets = []
-    workspace = client.workspaces(name=workspace_name)
-    assert isinstance(workspace, Workspace)
-    for dataset in workspace.datasets:
-        datasets.append(dataset)
-    return datasets
-
-
-def concept_to_dataset_name(concept: Concept) -> str:
-    if not concept.wikibase_id:
-        raise ValueError("Concept has no Wikibase ID")
-    return concept.wikibase_id
-
-
-def labelled_passages_to_feedback_dataset(
-    labelled_passages: list[LabelledPassage], concept: Concept, workspace: Workspace
-) -> Dataset:
-    """
-    Convert a list of LabelledPassages into an Argilla kDataset.
-
-    :param list[LabelledPassage] labelled_passages: The labelled passages to convert
-    :param Concept concept: The concept being annotated
-    :return Dataset: An Argilla Dataset, ready to be pushed
-    """
-    dataset = Dataset(
-        name=concept_to_dataset_name(concept),
-        settings=Settings(
-            guidelines="Highlight the entity if it is present in the text",
-            fields=[
-                TextField(name="text", title="Text", use_markdown=True),
-            ],
-            questions=[
-                SpanQuestion(
-                    name="entities",
-                    labels={str(concept.wikibase_id): concept.preferred_label},
-                    field="text",
-                    required=True,
-                    allow_overlapping=False,
-                )
-            ],
-            # Argilla has the following regex for metadata field names: {"pattern":"^(?=.*[a-z0-9])[a-z0-9_-]+$"}
-            # changing the dots to hyphens.
-            # Also, it doesn't allow capital characters, so lowercasing everything
-            metadata=[
-                TermsMetadataProperty("text_block-text_block_id"),
-                TermsMetadataProperty("text_block-language"),
-                TermsMetadataProperty("text_block-type"),
-                FloatMetadataProperty("text_block-type_confidence"),
-                FloatMetadataProperty("text_block-page_number"),
-                TermsMetadataProperty("text_block-coords"),
-                TermsMetadataProperty("document_id"),
-                TermsMetadataProperty("document_name"),
-                TermsMetadataProperty("document_source_url"),
-                TermsMetadataProperty("document_content_type"),
-                TermsMetadataProperty("document_md5_sum"),
-                TermsMetadataProperty("languages"),
-                TermsMetadataProperty("translated"),
-                TermsMetadataProperty("has_valid_text"),
-                TermsMetadataProperty("pipeline_metadata"),
-                TermsMetadataProperty("document_metadata-name"),
-                TermsMetadataProperty("document_metadata-document_title"),
-                TermsMetadataProperty("document_metadata-description"),
-                TermsMetadataProperty("document_metadata-import_id"),
-                TermsMetadataProperty("document_metadata-slug"),
-                TermsMetadataProperty("document_metadata-family_import_id"),
-                TermsMetadataProperty("document_metadata-family_slug"),
-                TermsMetadataProperty("document_metadata-publication_ts"),
-                TermsMetadataProperty("document_metadata-date"),
-                TermsMetadataProperty("document_metadata-source_url"),
-                TermsMetadataProperty("document_metadata-download_url"),
-                TermsMetadataProperty("document_metadata-corpus_import_id"),
-                TermsMetadataProperty("document_metadata-corpus_type_name"),
-                TermsMetadataProperty("document_metadata-collection_title"),
-                TermsMetadataProperty("document_metadata-collection_summary"),
-                TermsMetadataProperty("document_metadata-type"),
-                TermsMetadataProperty("document_metadata-source"),
-                TermsMetadataProperty("document_metadata-category"),
-                TermsMetadataProperty("document_metadata-geography"),
-                TermsMetadataProperty("document_metadata-geographies"),
-                TermsMetadataProperty("document_metadata-languages"),
-                TermsMetadataProperty("document_metadata-metadata"),
-                TermsMetadataProperty("document_description"),
-                TermsMetadataProperty("document_cdn_object"),
-                TermsMetadataProperty("document_slug"),
-                TermsMetadataProperty("pdf_data-md5sum"),
-                TermsMetadataProperty("pdf_data_page_metadata-dimensions"),
-                TermsMetadataProperty("pdf_data_page_metadata-page_number"),
-                TermsMetadataProperty("_html_data-detected_title"),
-                TermsMetadataProperty("_html_data-detected_date"),
-                TermsMetadataProperty("_html_data-has_valid_text"),
-                TermsMetadataProperty("pipeline_metadata-parser_metadata"),
-                TermsMetadataProperty("text_block-index"),
-                TermsMetadataProperty("world_bank_region"),
-                # TermsMetadataProperty("keywordclassifier"),
-            ],
-        ),
-        workspace=workspace,
-        client=client,
-    )
-
-    dataset.id = uuid.uuid4()
-    dataset.create()
-
-    records = [
-        Record(
-            fields={"text": passage.text},
-            metadata=_reformat_metadata_keys(passage.metadata),
-        )
-        for passage in labelled_passages
-    ]
-
-    dataset.records.log(records)
-
-    return dataset
-
-
-def _reformat_metadata_keys(metadata: dict) -> dict:
-    """Changes dots to hyphens in the key name"""
-    # Dropping this, as it can't be serialised into the metadata field by Argilla...
-    metadata.pop("KeywordClassifier", None)
-    return {key.replace(".", "-").lower(): value for key, value in metadata.items()}
-
-
-def dataset_to_labelled_passages(dataset: Dataset) -> list[LabelledPassage]:
-    """
-    Convert an Argilla Dataset into a list of LabelledPassages.
-
-    :param kDataset dataset: The Argilla Dataset to convert
-    :return list[LabelledPassage]: A list of LabelledPassage objects
-    """
-    return [
-        LabelledPassage.from_argilla_record(record, client)
-        for record in dataset.records
-    ]
-
-
-def is_between_timestamps(
-    timestamp: datetime,
-    min_timestamp: Optional[datetime],
-    max_timestamp: Optional[datetime],
-) -> bool:
-    """
-    Check whether a timestamp falls within a given time range.
-
-    :param datetime timestamp: The timestamp to check
-    :param Optional[datetime] min_timestamp: The minimum timestamp (inclusive). If None, no minimum limit.
-    :param Optional[datetime] max_timestamp: The maximum timestamp (inclusive). If None, no maximum limit.
-    :return bool: True if the timestamp is within the range, False otherwise
-    """
-    if max_timestamp and timestamp > max_timestamp:
-        return False
-    if min_timestamp and timestamp < min_timestamp:
-        return False
-    return True
-
-
-def filter_labelled_passages_by_timestamp(
-    labelled_passages: list[LabelledPassage],
-    min_timestamp: Optional[datetime] = None,
-    max_timestamp: Optional[datetime] = None,
-) -> list[LabelledPassage]:
-    filtered_passages = []
-    for passage in labelled_passages:
-        passage_copy = passage.model_copy(update={"spans": []})
-        for span in passage.spans:
-            span_copy = span.model_copy(update={"labellers": [], "timestamps": []})
-            for labeller, timestamp in zip(span.labellers, span.timestamps):
-                if is_between_timestamps(
-                    timestamp=timestamp,
-                    min_timestamp=min_timestamp,
-                    max_timestamp=max_timestamp,
-                ):
-                    span_copy.labellers.append(labeller)
-                    span_copy.timestamps.append(timestamp)
-
-            if len(span_copy.labellers) > 0:
-                passage_copy.spans.append(span_copy)
-
-        if len(passage_copy.spans) > 0:
-            filtered_passages.append(passage_copy)
-
-    return filtered_passages
-
-
-def get_labelled_passages_from_argilla(
-    concept: Concept,
-    workspace: str = "knowledge-graph",
-    min_timestamp: Optional[datetime] = None,
-    max_timestamp: Optional[datetime] = None,
-    client: Optional[rg.Argilla] = client,
-) -> list[LabelledPassage]:
-    """
-    Get the labelled passages from Argilla for a given concept.
-
-    :param Concept concept: The concept to get the labelled passages for
-    :param Optional[datetime] min_timestamp: Only get annotations made after this timestamp (inclusive), defaults to None
-    :param Optional[datetime] max_timestamp: Only get annotations made before this timestamp (inclusive), defaults to None
-    :raises ValueError: If no dataset matching the concept ID was found in Argilla
-    :raises ValueError: If no datasets were found in Argilla, you may need to be granted access to the workspace(s)
-    :return list[LabelledPassage]: A list of LabelledPassage objects
-    """
-    # First, see whether the dataset exists with the name we expect
-
-    dataset = client.datasets(  # type: ignore
-        concept_to_dataset_name(concept), workspace=workspace
-    )
-
-    labelled_passages = dataset_to_labelled_passages(dataset)  # type: ignore
-    if min_timestamp or max_timestamp:
-        labelled_passages = filter_labelled_passages_by_timestamp(
-            labelled_passages, min_timestamp, max_timestamp
-        )
-    return labelled_passages
-
-
-def distribute_labelling_projects(
-    datasets: list, labellers: list[str], min_labellers: int = 2
-) -> Generator[tuple[Dataset, str], None, None]:
-    """
-    Distribute labelling projects to labellers.
-
-    For efficient labelling, tasks should be distributed such that each dataset is
-    labelled by at least `min_labellers` labellers, and each labeller is assigned to a
-    minimal number of datasets.
-
-    :param list[] datasets: datasets to distribute among labellers
-    :param list[str] labellers: list of labellers
-    :param int min_labellers: minimum number of labellers per dataset, defaults to 2
-    :return Generator[tuple[FeedbackDataset, str], None, None]: a generator of tuples containing
-        the dataset and the labeller assigned to it
-    """
-    if len(labellers) < min_labellers:
-        raise ValueError(
-            "number of items in labellers must be greater than or equal to min_labellers"
+class ArgillaService:
+    def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None):
+        self.client = rg.Argilla(
+            api_key=api_key or os.getenv("ARGILLA_API_KEY"),
+            api_url=api_url or os.getenv("ARGILLA_API_URL"),
         )
 
-    labeller_cycle = cycle(labellers)
-    for dataset in datasets:
-        for _ in range(min_labellers):
-            yield dataset, next(labeller_cycle)
+    def get_all_datasets(self, workspace_name: str) -> list[Dataset]:
+        """
+        Get all datasets in a workspace.
 
+        :param Workspace workspace: The workspace to get the datasets from
+        :return list[Dataset]: A list of datasets
+        """
+        datasets = []
+        workspace = self.client.workspaces(name=workspace_name)
+        assert isinstance(workspace, Workspace)
+        for dataset in workspace.datasets:
+            datasets.append(dataset)
+        return datasets
 
-def combine_datasets(*datasets: Dataset) -> Dataset:
-    """
-    Combine an arbitrary number of argilla datasets into one.
+    @staticmethod
+    def concept_to_dataset_name(concept: Concept) -> str:
+        if not concept.wikibase_id:
+            raise ValueError("Concept has no Wikibase ID")
+        return concept.wikibase_id
 
-    :param FeedbackDataset *datasets: Unspecified number of datasets to combine, at
-    least one.
-    :return FeedbackDataset: The combined dataset
-    """
-    if not datasets:
-        raise ValueError("At least one dataset must be provided")
+    def labelled_passages_to_feedback_dataset(
+        self,
+        labelled_passages: list[LabelledPassage],
+        concept: Concept,
+        workspace: Workspace,
+    ) -> Dataset:
+        """
+        Convert a list of LabelledPassages into an Argilla kDataset.
 
-    _assert_datasets_of_the_same_type(*datasets)
+        :param list[LabelledPassage] labelled_passages: The labelled passages to convert
+        :param Concept concept: The concept being annotated
+        :return Dataset: An Argilla Dataset, ready to be pushed
+        """
+        dataset = Dataset(
+            name=self.concept_to_dataset_name(concept),
+            settings=Settings(
+                guidelines="Highlight the entity if it is present in the text",
+                fields=[
+                    TextField(name="text", title="Text", use_markdown=True),
+                ],
+                questions=[
+                    SpanQuestion(
+                        name="entities",
+                        labels={str(concept.wikibase_id): concept.preferred_label},
+                        field="text",
+                        required=True,
+                        allow_overlapping=False,
+                    )
+                ],
+                # Argilla has the following regex for metadata field names: {"pattern":"^(?=.*[a-z0-9])[a-z0-9_-]+$"}
+                # changing the dots to hyphens.
+                # Also, it doesn't allow capital characters, so lowercasing everything
+                metadata=[
+                    TermsMetadataProperty("text_block-text_block_id"),
+                    TermsMetadataProperty("text_block-language"),
+                    TermsMetadataProperty("text_block-type"),
+                    FloatMetadataProperty("text_block-type_confidence"),
+                    FloatMetadataProperty("text_block-page_number"),
+                    TermsMetadataProperty("text_block-coords"),
+                    TermsMetadataProperty("document_id"),
+                    TermsMetadataProperty("document_name"),
+                    TermsMetadataProperty("document_source_url"),
+                    TermsMetadataProperty("document_content_type"),
+                    TermsMetadataProperty("document_md5_sum"),
+                    TermsMetadataProperty("languages"),
+                    TermsMetadataProperty("translated"),
+                    TermsMetadataProperty("has_valid_text"),
+                    TermsMetadataProperty("pipeline_metadata"),
+                    TermsMetadataProperty("document_metadata-name"),
+                    TermsMetadataProperty("document_metadata-document_title"),
+                    TermsMetadataProperty("document_metadata-description"),
+                    TermsMetadataProperty("document_metadata-import_id"),
+                    TermsMetadataProperty("document_metadata-slug"),
+                    TermsMetadataProperty("document_metadata-family_import_id"),
+                    TermsMetadataProperty("document_metadata-family_slug"),
+                    TermsMetadataProperty("document_metadata-publication_ts"),
+                    TermsMetadataProperty("document_metadata-date"),
+                    TermsMetadataProperty("document_metadata-source_url"),
+                    TermsMetadataProperty("document_metadata-download_url"),
+                    TermsMetadataProperty("document_metadata-corpus_import_id"),
+                    TermsMetadataProperty("document_metadata-corpus_type_name"),
+                    TermsMetadataProperty("document_metadata-collection_title"),
+                    TermsMetadataProperty("document_metadata-collection_summary"),
+                    TermsMetadataProperty("document_metadata-type"),
+                    TermsMetadataProperty("document_metadata-source"),
+                    TermsMetadataProperty("document_metadata-category"),
+                    TermsMetadataProperty("document_metadata-geography"),
+                    TermsMetadataProperty("document_metadata-geographies"),
+                    TermsMetadataProperty("document_metadata-languages"),
+                    TermsMetadataProperty("document_metadata-metadata"),
+                    TermsMetadataProperty("document_description"),
+                    TermsMetadataProperty("document_cdn_object"),
+                    TermsMetadataProperty("document_slug"),
+                    TermsMetadataProperty("pdf_data-md5sum"),
+                    TermsMetadataProperty("pdf_data_page_metadata-dimensions"),
+                    TermsMetadataProperty("pdf_data_page_metadata-page_number"),
+                    TermsMetadataProperty("_html_data-detected_title"),
+                    TermsMetadataProperty("_html_data-detected_date"),
+                    TermsMetadataProperty("_html_data-has_valid_text"),
+                    TermsMetadataProperty("pipeline_metadata-parser_metadata"),
+                    TermsMetadataProperty("text_block-index"),
+                    TermsMetadataProperty("world_bank_region"),
+                    # TermsMetadataProperty("keywordclassifier"),
+                ],
+            ),
+            workspace=workspace,
+            client=self.client,
+        )
 
-    settings = datasets[0].settings
+        dataset.id = uuid.uuid4()
+        dataset.create()
 
-    combined_dataset = Dataset(
-        name=f"combined-{'-'.join([dataset.name for dataset in datasets])}",
-        settings=settings,
-    ).create()
+        records = [
+            Record(
+                fields={"text": passage.text},
+                metadata=self._reformat_metadata_keys(passage.metadata),
+            )
+            for passage in labelled_passages
+        ]
 
-    for dataset in datasets:
-        combined_dataset.records.log(list(dataset.records))
+        dataset.records.log(records)
 
-    return combined_dataset
+        return dataset
 
+    @staticmethod
+    def _reformat_metadata_keys(metadata: dict) -> dict:
+        """Changes dots to hyphens in the key name"""
+        # Dropping this, as it can't be serialised into the metadata field by Argilla...
+        metadata.pop("KeywordClassifier", None)
+        return {key.replace(".", "-").lower(): value for key, value in metadata.items()}
 
-def _assert_datasets_of_the_same_type(*datasets: Dataset):
-    """
-    Assert that all datasets are of the same type.
+    def dataset_to_labelled_passages(self, dataset: Dataset) -> list[LabelledPassage]:
+        """
+        Convert an Argilla Dataset into a list of LabelledPassages.
 
-    :param FeedbackDataset *datasets: The datasets to check
-    :raises ValueError: If the datasets are not of the same type
-    """
-    fields = datasets[0].fields
-    questions = datasets[0].questions
+        :param kDataset dataset: The Argilla Dataset to convert
+        :return list[LabelledPassage]: A list of LabelledPassage objects
+        """
+        return [
+            LabelledPassage.from_argilla_record(record, self.client)
+            for record in dataset.records
+        ]
 
-    for dataset in datasets[1:]:
-        if dataset.fields != fields:
-            raise ValueError("All datasets must have the same fields")
-        if dataset.questions != questions:
-            raise ValueError("All datasets must have the same questions")
+    @staticmethod
+    def is_between_timestamps(
+        timestamp: datetime,
+        min_timestamp: Optional[datetime],
+        max_timestamp: Optional[datetime],
+    ) -> bool:
+        """
+        Check whether a timestamp falls within a given time range.
+
+        :param datetime timestamp: The timestamp to check
+        :param Optional[datetime] min_timestamp: The minimum timestamp (inclusive). If None, no minimum limit.
+        :param Optional[datetime] max_timestamp: The maximum timestamp (inclusive). If None, no maximum limit.
+        :return bool: True if the timestamp is within the range, False otherwise
+        """
+        if max_timestamp and timestamp > max_timestamp:
+            return False
+        if min_timestamp and timestamp < min_timestamp:
+            return False
+        return True
+
+    def filter_labelled_passages_by_timestamp(
+        self,
+        labelled_passages: list[LabelledPassage],
+        min_timestamp: Optional[datetime] = None,
+        max_timestamp: Optional[datetime] = None,
+    ) -> list[LabelledPassage]:
+        filtered_passages = []
+        for passage in labelled_passages:
+            passage_copy = passage.model_copy(update={"spans": []})
+            for span in passage.spans:
+                span_copy = span.model_copy(update={"labellers": [], "timestamps": []})
+                for labeller, timestamp in zip(span.labellers, span.timestamps):
+                    if self.is_between_timestamps(
+                        timestamp=timestamp,
+                        min_timestamp=min_timestamp,
+                        max_timestamp=max_timestamp,
+                    ):
+                        span_copy.labellers.append(labeller)
+                        span_copy.timestamps.append(timestamp)
+
+                if len(span_copy.labellers) > 0:
+                    passage_copy.spans.append(span_copy)
+
+            if len(passage_copy.spans) > 0:
+                filtered_passages.append(passage_copy)
+
+        return filtered_passages
+
+    def get_labelled_passages_from_argilla(
+        self,
+        concept: Concept,
+        workspace: str = "knowledge-graph",
+        min_timestamp: Optional[datetime] = None,
+        max_timestamp: Optional[datetime] = None,
+    ) -> list[LabelledPassage]:
+        """
+        Get the labelled passages from Argilla for a given concept.
+
+        :param Concept concept: The concept to get the labelled passages for
+        :param Optional[datetime] min_timestamp: Only get annotations made after this timestamp (inclusive), defaults to None
+        :param Optional[datetime] max_timestamp: Only get annotations made before this timestamp (inclusive), defaults to None
+        :raises ValueError: If no dataset matching the concept ID was found in Argilla
+        :raises ValueError: If no datasets were found in Argilla, you may need to be granted access to the workspace(s)
+        :return list[LabelledPassage]: A list of LabelledPassage objects
+        """
+        # First, see whether the dataset exists with the name we expect
+
+        dataset = self.client.datasets(  # type: ignore
+            self.concept_to_dataset_name(concept), workspace=workspace
+        )
+
+        labelled_passages = dataset_to_labelled_passages(dataset)  # type: ignore
+        if min_timestamp or max_timestamp:
+            labelled_passages = self.filter_labelled_passages_by_timestamp(
+                labelled_passages, min_timestamp, max_timestamp
+            )
+        return labelled_passages
+
+    @staticmethod
+    def distribute_labelling_projects(
+        datasets: list, labellers: list[str], min_labellers: int = 2
+    ) -> Generator[tuple[Dataset, str], None, None]:
+        """
+        Distribute labelling projects to labellers.
+
+        For efficient labelling, tasks should be distributed such that each dataset is
+        labelled by at least `min_labellers` labellers, and each labeller is assigned to a
+        minimal number of datasets.
+
+        :param list[] datasets: datasets to distribute among labellers
+        :param list[str] labellers: list of labellers
+        :param int min_labellers: minimum number of labellers per dataset, defaults to 2
+        :return Generator[tuple[FeedbackDataset, str], None, None]: a generator of tuples containing
+            the dataset and the labeller assigned to it
+        """
+        if len(labellers) < min_labellers:
+            raise ValueError(
+                "number of items in labellers must be greater than or equal to min_labellers"
+            )
+
+        labeller_cycle = cycle(labellers)
+        for dataset in datasets:
+            for _ in range(min_labellers):
+                yield dataset, next(labeller_cycle)
+
+    def combine_datasets(self, *datasets: Dataset) -> Dataset:
+        """
+        Combine an arbitrary number of argilla datasets into one.
+
+        :param FeedbackDataset *datasets: Unspecified number of datasets to combine, at
+        least one.
+        :return FeedbackDataset: The combined dataset
+        """
+        if not datasets:
+            raise ValueError("At least one dataset must be provided")
+
+        self._assert_datasets_of_the_same_type(*datasets)
+
+        settings = datasets[0].settings
+
+        combined_dataset = Dataset(
+            name=f"combined-{'-'.join([dataset.name for dataset in datasets])}",
+            settings=settings,
+        ).create()
+
+        for dataset in datasets:
+            combined_dataset.records.log(list(dataset.records))
+
+        return combined_dataset
+
+    @staticmethod
+    def _assert_datasets_of_the_same_type(*datasets: Dataset):
+        """
+        Assert that all datasets are of the same type.
+
+        :param FeedbackDataset *datasets: The datasets to check
+        :raises ValueError: If the datasets are not of the same type
+        """
+        fields = datasets[0].fields
+        questions = datasets[0].questions
+
+        for dataset in datasets[1:]:
+            if dataset.fields != fields:
+                raise ValueError("All datasets must have the same fields")
+            if dataset.questions != questions:
+                raise ValueError("All datasets must have the same questions")

--- a/src/argilla_v2.py
+++ b/src/argilla_v2.py
@@ -23,7 +23,7 @@ from src.wikibase import Concept
 load_dotenv(find_dotenv())
 
 
-class ArgillaService:
+class ArgillaSession:
     def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None):
         self.client = rg.Argilla(
             api_key=api_key or os.getenv("ARGILLA_API_KEY"),

--- a/src/argilla_v2.py
+++ b/src/argilla_v2.py
@@ -24,6 +24,8 @@ load_dotenv(find_dotenv())
 
 
 class ArgillaSession:
+    """A session for interacting with Argilla"""
+
     def __init__(self, api_key: Optional[str] = None, api_url: Optional[str] = None):
         self.client = rg.Argilla(
             api_key=api_key or os.getenv("ARGILLA_API_KEY"),
@@ -46,6 +48,7 @@ class ArgillaSession:
 
     @staticmethod
     def concept_to_dataset_name(concept: Concept) -> str:
+        """Extracts the dataset name from a concept"""
         if not concept.wikibase_id:
             raise ValueError("Concept has no Wikibase ID")
         return concept.wikibase_id
@@ -199,6 +202,7 @@ class ArgillaSession:
         min_timestamp: Optional[datetime] = None,
         max_timestamp: Optional[datetime] = None,
     ) -> list[LabelledPassage]:
+        """Uses max- and min-timestampts to filter out the labelled passages"""
         filtered_passages = []
         for passage in labelled_passages:
             passage_copy = passage.model_copy(update={"spans": []})
@@ -244,7 +248,7 @@ class ArgillaSession:
             self.concept_to_dataset_name(concept), workspace=workspace
         )
 
-        labelled_passages = dataset_to_labelled_passages(dataset)  # type: ignore
+        labelled_passages = self.dataset_to_labelled_passages(dataset)  # type: ignore
         if min_timestamp or max_timestamp:
             labelled_passages = self.filter_labelled_passages_by_timestamp(
                 labelled_passages, min_timestamp, max_timestamp

--- a/tests/test_argilla_v2.py
+++ b/tests/test_argilla_v2.py
@@ -2,7 +2,6 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from dotenv import load_dotenv, find_dotenv
 from argilla import (
     Dataset,
     Record,
@@ -11,9 +10,9 @@ from argilla import (
     TextField,
     TextQuestion,
 )
+from dotenv import find_dotenv, load_dotenv
 
 from src.argilla_v2 import ArgillaSession
-
 
 load_dotenv(find_dotenv())
 

--- a/tests/test_argilla_v2.py
+++ b/tests/test_argilla_v2.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+from dotenv import load_dotenv, find_dotenv
 from argilla import (
     Dataset,
     Record,
@@ -11,7 +12,10 @@ from argilla import (
     TextQuestion,
 )
 
-from src.argilla_v2 import _assert_datasets_of_the_same_type, combine_datasets
+from src.argilla_v2 import ArgillaSession
+
+
+load_dotenv(find_dotenv())
 
 
 def test_combine_datasets():
@@ -72,7 +76,8 @@ def test_combine_datasets():
         "tests.test_argilla_v2.DatasetRecordsIterator._list",
         lambda self: records[self.__dataset.name],
     ):
-        combine_dataset = combine_datasets(dataset1, dataset2)
+        argilla = ArgillaSession()
+        combine_dataset = argilla.combine_datasets(dataset1, dataset2)
 
         assert combine_dataset.name == "combined-dataset1-dataset2"
         assert combine_dataset.settings.fields == [TextField(name="field1")]
@@ -87,6 +92,7 @@ def test_combine_datasets():
 
 
 def test__assert_datasets_of_the_same_type_errors():
+    argilla = ArgillaSession()
     dataset1 = Dataset(
         name="dataset1",
         settings=Settings(
@@ -108,10 +114,11 @@ def test__assert_datasets_of_the_same_type_errors():
     )
 
     with pytest.raises(ValueError):
-        _assert_datasets_of_the_same_type(dataset1, dataset2)
+        argilla._assert_datasets_of_the_same_type(dataset1, dataset2)
 
 
 def test__assert_datasets_of_the_same_type():
+    argilla = ArgillaSession()
     dataset1 = Dataset(
         name="dataset1",
         settings=Settings(
@@ -131,4 +138,4 @@ def test__assert_datasets_of_the_same_type():
         ),
     )
 
-    assert _assert_datasets_of_the_same_type(dataset1, dataset2) is None
+    assert argilla._assert_datasets_of_the_same_type(dataset1, dataset2) is None


### PR DESCRIPTION
## What this PR does
We want to follow the same pattern with Argilla that we did for Huggingface, and Wikibase, our other two external data stores in this repo, namely that each of them have a `<service_name>Session` class, which is responsible for all transactions between the data store and the KG repo. This PR refactors all of the argilla v2 code into the `ArgillaSession` class which follows this pattern.

It also readds the data-backup flow deployment, now that the bug of trying to initialise the argilla client before pulling the credentials from ssm is fixed, and client connection is more safely managed.