### PR TITLE
fix: Enable reporting for loading concepts counts

### DIFF
--- a/flows/count_family_document_concepts.py
+++ b/flows/count_family_document_concepts.py
@@ -132,9 +132,8 @@ async def load_parse_concepts_counts(
 
 
 @flow(
-    # TODO: Enable once confident
-    # on_failure=[SlackNotify.message],
-    # on_crashed=[SlackNotify.message],
+    on_failure=[SlackNotify.message],
+    on_crashed=[SlackNotify.message],
 )
 async def load_update_document_concepts_counts(
     document_import_id: DocumentImportId,


### PR DESCRIPTION
We're confident now, since it's been used for several weeks.
