### PR TITLE
Adding a limit in to the passage query.

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -329,6 +329,7 @@ def load_labelled_passages_by_uri(
 def get_document_passages_from_vespa(
     document_import_id: DocumentImportId,
     vespa_search_adapter: VespaSearchAdapter,
+    limit_hits: int = 50000,
 ) -> list[tuple[VespaHitId, VespaPassage]]:
     """
     Retrieve all the passages for a document in Vespa.
@@ -344,7 +345,7 @@ def get_document_passages_from_vespa(
         yql=(
             # trunk-ignore(bandit/B608)
             "select * from document_passage where family_document_ref contains "
-            f'"id:doc_search:family_document::{document_import_id}"'
+            f'"id:doc_search:family_document::{document_import_id}" limit {limit_hits}'
         )
     )
 


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for the indexer where we were listing out passages for documents from vespa with a default limit of 5000 hits. 
- Some passages have more than 5000 hits as per the example in the linked linear issue where we were receiving 10922 hits. 
- 50,000 is the maximum number of hits that we allow for a response so setting to that as we don't want to be accidentally hitting up against this limit again. 
- I've checked over the KG pipeline and this is the only place we run a `select * ....` vespa query and thus we shouldn't need to make any other query updates to set limits. 


50,000 is the maximum we set ourselves for the deployment: 
- [Infra](https://github.com/climatepolicyradar/navigator-infra/blob/main/vespa/navigator_app/search/query-profiles/default.xml#L3).
- Confirmed in this [ticket](https://linear.app/climate-policy-radar/issue/PLA-480/confirm-whether-we-have-documents-in-vespa-with-over-50000-passages) that some documents do exceed 50,000 so I'm chasing up a fix with vespa.


How was this tested? 
- Did a run in [staging](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/e2c78418-4b4a-456c-a2c7-1325f11e2300?entity_id=e2c78418-4b4a-456c-a2c7-1325f11e2300) on the document and verified that we see the error there. 
- [Deployed](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/13696195270) the bug fix PR to staging. 
- Reran the indexing [flow](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/5ec98532-471e-460f-b4da-80fc8ee33b20?entity_id=5ec98532-471e-460f-b4da-80fc8ee33b20) and no errors were seen.
- Validated via a vespa query that we have data. 