### PR TITLE
Adding removal of translated from DocumentImportId's we declare.

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 from vespa.io import VespaQueryResponse, VespaResponse
 
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
-from flows.utils import SlackNotify
+from flows.utils import SlackNotify, remove_translated_suffix
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
@@ -278,7 +278,7 @@ def s3_obj_generator_from_s3_prefixes(
             bucket = Path(s3_prefix).parts[1]
             object_keys = _get_s3_keys_with_prefix(s3_prefix=s3_prefix)
             for key in object_keys:
-                id: DocumentImportId = Path(key).stem
+                id: DocumentImportId = remove_translated_suffix(Path(key).stem)
                 key: DocumentObjectUri = os.path.join("s3://", bucket, key)
 
                 yield id, key
@@ -307,7 +307,7 @@ def s3_obj_generator_from_s3_paths(
     logger = get_logger()
     for s3_path in s3_paths:
         try:
-            id: DocumentImportId = Path(s3_path).stem
+            id: DocumentImportId = remove_translated_suffix(Path(s3_path).stem)
             uri: DocumentObjectUri = s3_path
             yield id, uri
         except Exception as e:

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from prefect.settings import PREFECT_UI_URL
 from prefect_slack.credentials import SlackWebhook
@@ -54,3 +55,12 @@ class SlackNotify:
 
         slack = SlackWebhook.load(cls.slack_block_name)
         slack.notify(body=msg)
+
+
+def remove_translated_suffix(file_name: str) -> str:
+    """
+    Remove the suffix from a file name that indicates it has been translated.
+
+    E.g. "CCLW.executive.1.1_en_translated" -> "CCLW.executive.1.1"
+    """
+    return re.sub(r"(_translated(?:_[a-zA-Z]+)?)$", "", file_name)

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flows.utils import SlackNotify, file_name_from_path
+from flows.utils import SlackNotify, file_name_from_path, remove_translated_suffix
 
 
 @pytest.mark.parametrize(
@@ -33,3 +33,18 @@ def test_message(mock_prefect_slack_webhook, mock_flow, mock_flow_run):
         "2025-01-28T12:00:00+00:00. For environment: sandbox. Flow run URL: "
         "None/flow-runs/flow-run/test-flow-run-id. State message: message"
     )
+
+
+@pytest.mark.parametrize(
+    "file_name, expected",
+    [
+        ("CCLW.executive.1.1_en_translated", "CCLW.executive.1.1"),
+        ("CCLW.executive.1.1", "CCLW.executive.1.1"),
+        ("CCLW.executive.10083.rtl_190_translated_en", "CCLW.executive.10083.rtl_190"),
+        ("CCLW.executive.10083.rtl_190_translated_fr", "CCLW.executive.10083.rtl_190"),
+    ],
+)
+def test_remove_translated_suffix(file_name: str, expected: str) -> None:
+    """Test that we can remove the translated suffix from a file name."""
+
+    remove_translated_suffix(file_name) == expected


### PR DESCRIPTION
This Pull Request: 
---
- Updates the `DocumentImportId` that we declare in the `DocumentImporter` objects that we yield from the s3 paths or s3 prefixes generators to no longer include translated suffixes. 
- This is as import ids in vespa will not contain these suffixes and thus indexing is not working. 

Steps: 

- [ ] Run in staging using a translated document. 
- [ ] Confirm that we are not indexing translated documents. 
- [ ] Deploy this branch to staging.
- [ ] Confirm that we can now index translated documents. 