### PR TITLE
Only run inference on english docs and write out with correct file stem 

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -9,7 +9,6 @@ from typing import Final, Optional, Set, Tuple, TypeAlias
 
 import boto3
 import prefect.artifacts as artifacts
-import wandb
 from botocore.client import ClientError
 from cpr_sdk.parser_models import BaseParserOutput, BlockType
 from cpr_sdk.ssm import get_aws_ssm_param
@@ -18,9 +17,9 @@ from prefect.concurrency.asyncio import concurrency
 from prefect.deployments import run_deployment
 from prefect.task_runners import ConcurrentTaskRunner
 from pydantic import SecretStr
-from wandb.sdk.wandb_run import Run
 
-from flows.utils import SlackNotify
+import wandb
+from flows.utils import SlackNotify, remove_translated_suffix
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
@@ -32,6 +31,7 @@ from scripts.update_classifier_spec import parse_spec_file
 from src.classifier import Classifier
 from src.labelled_passage import LabelledPassage
 from src.span import DateTimeEncoder, Span
+from wandb.sdk.wandb_run import Run
 
 DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "embeddings_input"
 # NOTE: Comparable list being maintained at https://github.com/climatepolicyradar/navigator-search-indexer/blob/91e341b8a20affc38cd5ce90c7d5651f21a1fd7a/src/config.py#L13.
@@ -104,18 +104,23 @@ def get_bucket_paginator(config: Config, prefix: str):
     )
 
 
-def list_bucket_doc_ids(config: Config) -> list[str]:
-    """Scan configured bucket and return all IDs."""
+def list_bucket_file_stems(config: Config) -> list[str]:
+    """
+    Scan configured bucket and return all file stems.
+
+    Where a stem refers to a file name without the extension. Often, this is the same as
+    the document id, but not always as we have translated documents.
+    """
     page_iterator = get_bucket_paginator(config, config.document_source_prefix)
-    doc_ids = []
+    file_stems = []
 
     for p in page_iterator:
         if "Contents" in p:
             for o in p["Contents"]:
-                doc_id = Path(o["Key"]).stem
-                doc_ids.append(doc_id)
+                file_stem = Path(o["Key"]).stem
+                file_stems.append(file_stem)
 
-    return doc_ids
+    return file_stems
 
 
 def get_latest_ingest_documents(config: Config) -> list[str]:
@@ -153,33 +158,35 @@ def get_latest_ingest_documents(config: Config) -> list[str]:
     return new + updated
 
 
-def determine_document_ids(
+def determine_file_stems(
     config: Config,
     use_new_and_updated: bool,
     requested_document_ids: Optional[list[str]],
-    current_bucket_ids: list[str],
+    current_bucket_file_stems: list[str],
 ) -> list[str]:
     """
-    Confirm chosen document ids or default to all if not specified.
+    Confirm chosen file stems or default to all if not specified.
 
     Compares the requested_document_ids to what actually exists in the bucket.
-    If a document id has been requested but does not exist this will
-    raise a `ValueError`. If no document id were requested, this will
-    instead return the `current_bucket_ids`.
+    If a file stem has been requested but does not exist this will
+    raise a `ValueError`. If no file stems were requested, this will
+    instead return the `current_bucket_file_stems`.
     """
     if use_new_and_updated and requested_document_ids:
         raise ValueError(
-            "`use_new_and_updated`, and `document_ids` are mutually exclusive"
+            "`use_new_and_updated`, and `requested_document_ids` are mutually exclusive"
         )
     elif use_new_and_updated:
         requested_document_ids = get_latest_ingest_documents(config)
     elif requested_document_ids is None:
-        return current_bucket_ids
+        return current_bucket_file_stems
 
-    missing_from_bucket = list(set(requested_document_ids) - set(current_bucket_ids))
+    missing_from_bucket = list(
+        set(requested_document_ids) - set(current_bucket_file_stems)
+    )
     if len(missing_from_bucket) > 0:
         raise ValueError(
-            f"Requested document_ids not found in bucket: {missing_from_bucket}"
+            f"Requested file stems not found in bucket: {missing_from_bucket}"
         )
 
     return requested_document_ids
@@ -235,11 +242,11 @@ def download_s3_file(config: Config, key: str):
     return content
 
 
-def load_document(config: Config, document_id: str) -> BaseParserOutput:
+def load_document(config: Config, file_stem: str) -> BaseParserOutput:
     """Download and opens a parser output based on a document ID."""
     file_key = os.path.join(
         config.document_source_prefix,
-        f"{document_id}.json",
+        f"{file_stem}.json",
     )
     content = download_s3_file(config=config, key=file_key)
     document = BaseParserOutput.model_validate_json(content)
@@ -274,7 +281,7 @@ def document_passages(
 def store_labels(
     config: Config,
     labels: list[LabelledPassage],
-    document_id: str,
+    file_stem: str,
     classifier_name: str,
     classifier_alias: str,
 ) -> None:
@@ -283,9 +290,9 @@ def store_labels(
         config.document_target_prefix,
         classifier_name,
         classifier_alias,
-        f"{document_id}.json",
+        f"{file_stem}.json",
     )
-    print(f"Storing labels for document {document_id} at {key}")
+    print(f"Storing labels for document {file_stem} at {key}")
 
     data = [label.model_dump() for label in labels]
 
@@ -357,22 +364,28 @@ async def report_documents_runs(
 async def run_classifier_inference_on_document(
     run,
     config: Config,
-    document_id: str,
+    file_stem: str,
     classifier_name: str,
     classifier_alias: str,
     classifier: Classifier,
 ) -> DocumentRunIdentifier:
     """Run the classifier inference flow on a document."""
-    print(f"Loading document with ID {document_id}")
+    print(f"Loading document with file stem {file_stem}")
     try:
-        document = load_document(config, document_id)
+        document = load_document(config, file_stem)
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
-            print(f"Document with ID {document_id} not found in cache bucket")
-            return (document_id, classifier_name, classifier_alias)
+            print(f"Document with file stem {file_stem} not found in cache bucket")
+            return (file_stem, classifier_name, classifier_alias)
         else:
             raise
-    print(f"Loaded document with ID {document_id}")
+    print(f"Loaded document with file stem {file_stem}")
+
+    if document.languages != ["en"]:
+        print(f"Cannot run inference on document {file_stem} as it is not in English.")
+        raise ValueError(
+            f"Cannot run inference on document {file_stem} as it is not in English."
+        )
 
     doc_labels = []
     for text, block_id in document_passages(document):
@@ -386,12 +399,12 @@ async def run_classifier_inference_on_document(
         store_labels(
             config=config,
             labels=doc_labels,
-            document_id=document_id,
+            file_stem=remove_translated_suffix(file_stem),
             classifier_name=classifier_name,
             classifier_alias=classifier_alias,
         )
 
-    return (document_id, classifier_name, classifier_alias)
+    return (file_stem, classifier_name, classifier_alias)
 
 
 def iterate_batch(data: list[str], batch_size: int = 400) -> Generator:
@@ -444,12 +457,12 @@ async def run_classifier_inference_on_batch_of_documents(
         run_classifier_inference_on_document(
             run=run,
             config=config,
-            document_id=document_id,
+            file_stem=file_stem,
             classifier_name=classifier_name,
             classifier_alias=classifier_alias,
             classifier=classifier,
         )
-        for document_id in batch
+        for file_stem in batch
     ]
 
     await asyncio.gather(*tasks)
@@ -488,19 +501,19 @@ async def classifier_inference(
 
     print(f"Running with config: {config}")
 
-    current_bucket_ids = list_bucket_doc_ids(config=config)
-    validated_document_ids = determine_document_ids(
+    current_bucket_file_stems = list_bucket_file_stems(config=config)
+    validated_file_stems = determine_file_stems(
         config=config,
         use_new_and_updated=use_new_and_updated,
         requested_document_ids=document_ids,
-        current_bucket_ids=current_bucket_ids,
+        current_bucket_file_stems=current_bucket_file_stems,
     )
 
     if classifier_specs is None:
         classifier_specs = parse_spec_file(config.aws_env)
 
     print(
-        f"Running with {len(validated_document_ids)} documents and "
+        f"Running with {len(validated_file_stems)} documents and "
         f"{len(classifier_specs)} classifiers"
     )
 
@@ -510,7 +523,7 @@ async def classifier_inference(
     )
 
     for classifier_spec in classifier_specs:
-        batches = iterate_batch(validated_document_ids, batch_size)
+        batches = iterate_batch(validated_file_stems, batch_size)
 
         tasks = [
             run_deployment(

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from prefect.settings import PREFECT_UI_URL
 from prefect_slack.credentials import SlackWebhook
@@ -54,3 +55,12 @@ class SlackNotify:
 
         slack = SlackWebhook.load(cls.slack_block_name)
         slack.notify(body=msg)
+
+
+def remove_translated_suffix(file_name: str) -> str:
+    """
+    Remove the suffix from a file name that indicates it has been translated.
+
+    E.g. "CCLW.executive.1.1_en_translated" -> "CCLW.executive.1.1"
+    """
+    return re.sub(r"(_translated(?:_[a-zA-Z]+)?)$", "", file_name)

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -11,12 +11,12 @@ from flows.inference import (
     ClassifierSpec,
     _stringify,
     classifier_inference,
-    determine_document_ids,
+    determine_file_stems,
     document_passages,
     download_classifier_from_wandb_to_local,
     get_latest_ingest_documents,
     iterate_batch,
-    list_bucket_doc_ids,
+    list_bucket_file_stems,
     load_classifier,
     load_document,
     store_labels,
@@ -36,9 +36,9 @@ def helper_list_labels_in_bucket(test_config, bucket_name):
     return labels
 
 
-def test_list_bucket_doc_ids(test_config, mock_bucket_documents):
+def test_list_bucket_file_stems(test_config, mock_bucket_documents):
     expected_ids = [Path(d).stem for d in mock_bucket_documents]
-    got_ids = list_bucket_doc_ids(test_config)
+    got_ids = list_bucket_file_stems(test_config)
     assert sorted(expected_ids) == sorted(got_ids)
 
 
@@ -49,23 +49,23 @@ def test_list_bucket_doc_ids(test_config, mock_bucket_documents):
         (None, ["1"], ["1"]),
     ],
 )
-def test_determine_document_ids(test_config, doc_ids, bucket_ids, expected):
-    got = determine_document_ids(
+def test_determine_file_stems(test_config, doc_ids, bucket_ids, expected):
+    got = determine_file_stems(
         config=test_config,
         use_new_and_updated=False,
         requested_document_ids=doc_ids,
-        current_bucket_ids=bucket_ids,
+        current_bucket_file_stems=bucket_ids,
     )
     assert got == expected
 
 
-def test_determine_document_ids__error(test_config):
+def test_determine_file_stems__error(test_config):
     with pytest.raises(ValueError):
-        determine_document_ids(
+        determine_file_stems(
             config=test_config,
             use_new_and_updated=False,
             requested_document_ids=["1", "2"],
-            current_bucket_ids=["3", "4"],
+            current_bucket_file_stems=["3", "4"],
         )
 
 

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flows.utils import SlackNotify, file_name_from_path
+from flows.utils import SlackNotify, file_name_from_path, remove_translated_suffix
 
 
 @pytest.mark.parametrize(
@@ -33,3 +33,18 @@ def test_message(mock_prefect_slack_webhook, mock_flow, mock_flow_run):
         "2025-01-28T12:00:00+00:00. For environment: sandbox. Flow run URL: "
         "None/flow-runs/flow-run/test-flow-run-id. State message: message"
     )
+
+
+@pytest.mark.parametrize(
+    "file_name, expected",
+    [
+        ("CCLW.executive.1.1_en_translated", "CCLW.executive.1.1"),
+        ("CCLW.executive.1.1", "CCLW.executive.1.1"),
+        ("CCLW.executive.10083.rtl_190_translated_en", "CCLW.executive.10083.rtl_190"),
+        ("CCLW.executive.10083.rtl_190_translated_fr", "CCLW.executive.10083.rtl_190"),
+    ],
+)
+def test_remove_translated_suffix(file_name: str, expected: str) -> None:
+    """Test that we can remove the translated suffix from a file name."""
+
+    remove_translated_suffix(file_name) == expected


### PR DESCRIPTION
This Pull Request: 
---
Is a fix for the following:
- We are running inference on english and non english documents. 
- This means that inference is taking longer than required and is resulting with us indexing incorrect concepts that were for example run over french documents where the file stem matches the document id but the language is not english. 
- We are also saving translated documents to a file name with the suffix translated_en which means they are not being correctly indexed. 

Please see a diagram of the problem at this link: 

 [POL-2385](https://linear.app/climate-policy-radar/issue/POL-2385/classifiers-not-working-on-translated-documents#comment-a3d1103a)