### PR TITLE
feat: Clean-up and de-index concepts

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -14,6 +14,7 @@ from prefect.client.schemas.schedules import CronSchedule
 from prefect.deployments.runner import DeploymentImage
 from prefect.flows import Flow
 
+from flows.boundary import run_partial_updates_of_concepts_for_batch
 from flows.count_family_document_concepts import (
     count_family_document_concepts,
     load_update_document_concepts_counts,
@@ -22,8 +23,7 @@ from flows.data_backup import data_backup
 from flows.deploy_static_sites import deploy_static_sites
 from flows.index import (
     index_labelled_passages_from_s3_to_vespa,
-    run_partial_updates_of_concepts_for_batch,
-    run_partial_updates_of_concepts_for_document_passages,
+    run_partial_updates_of_concepts_for_document_passages__update,
 )
 from flows.inference import (
     classifier_inference,
@@ -106,7 +106,7 @@ create_deployment(
 # Index
 
 create_deployment(
-    flow=run_partial_updates_of_concepts_for_document_passages,
+    flow=run_partial_updates_of_concepts_for_document_passages__update,
     description="Co-ordinate updating inference results for concepts in Vespa",
 )
 

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1,0 +1,878 @@
+"""Boundary between Prefect, Vespa, and AWS."""
+
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Generator
+from io import BytesIO
+from pathlib import Path
+from typing import Callable, ContextManager, TypeAlias
+
+import boto3
+import vespa.querybuilder as qb
+from cpr_sdk.models.search import Concept as VespaConcept
+from cpr_sdk.models.search import Document as VespaDocument
+from cpr_sdk.models.search import Passage as VespaPassage
+from cpr_sdk.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
+from cpr_sdk.search_adaptors import VespaSearchAdapter
+from cpr_sdk.ssm import get_aws_ssm_param
+from prefect import flow, get_run_logger
+from prefect.deployments.deployments import run_deployment
+from prefect.logging import get_logger
+from pydantic import BaseModel
+from vespa.io import VespaQueryResponse, VespaResponse
+
+from flows.utils import iterate_batch
+from scripts.cloud import (
+    AwsEnv,
+    ClassifierSpec,
+    function_to_flow_name,
+    generate_deployment_name,
+)
+from src.concept import Concept
+from src.exceptions import PartialUpdateError, QueryError
+from src.identifiers import WikibaseID
+from src.labelled_passage import LabelledPassage
+from src.span import Span
+
+HTTP_OK = 200
+CONCEPT_COUNT_SEPARATOR: str = ":"
+DEFAULT_DOCUMENTS_BATCH_SIZE = 500
+DEFAULT_INDEXING_TASK_BATCH_SIZE = 20
+
+# Needed to get document passages from Vespa
+# Example: CCLW.executive.1813.2418
+DocumentImportId: TypeAlias = str
+# Needed to load the inference results
+# Example: s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json
+DocumentObjectUri: TypeAlias = str
+DocumentStem: TypeAlias = str
+# Passed to a self-sufficient flow run
+DocumentImporter: TypeAlias = tuple[DocumentStem, DocumentObjectUri]
+
+
+class S3Accessor(BaseModel):
+    """Representing S3 paths and prefixes for accessing documents."""
+
+    paths: list[str] | None = None
+    prefixes: list[str] | None = None
+
+
+# AKA LabelledPassage
+TextBlockId: TypeAlias = str
+SpanId: TypeAlias = str
+# The ID used in Vespa, that we don't keep in our models in the CPR
+# SDK, that is in a Hit.
+VespaHitId: TypeAlias = str
+# The same as above, but without the schema
+VespaDataId: TypeAlias = str
+
+
+def get_vespa_search_adapter_from_aws_secrets(
+    cert_dir: str,
+    vespa_instance_url_param_name: str = "VESPA_INSTANCE_URL",
+    vespa_public_cert_param_name: str = "VESPA_PUBLIC_CERT_READ",
+    vespa_private_key_param_name: str = "VESPA_PRIVATE_KEY_READ",
+) -> VespaSearchAdapter:
+    """
+    Get a VespaSearchAdapter instance by retrieving secrets from AWS Secrets Manager.
+
+    We then save the secrets to local files in the cert_dir directory and instantiate
+    the VespaSearchAdapter.
+    """
+    cert_dir_path = Path(cert_dir)
+    if not cert_dir_path.exists():
+        raise FileNotFoundError(f"Certificate directory does not exist: {cert_dir}")
+
+    vespa_instance_url = get_aws_ssm_param(vespa_instance_url_param_name)
+    vespa_public_cert_encoded = get_aws_ssm_param(vespa_public_cert_param_name)
+    vespa_private_key_encoded = get_aws_ssm_param(vespa_private_key_param_name)
+
+    vespa_public_cert = base64.b64decode(vespa_public_cert_encoded).decode("utf-8")
+    vespa_private_key = base64.b64decode(vespa_private_key_encoded).decode("utf-8")
+
+    cert_path = cert_dir_path / "cert.pem"
+    key_path = cert_dir_path / "key.pem"
+
+    with open(cert_path, "w", encoding="utf-8") as f:
+        _ = f.write(vespa_public_cert)
+
+    with open(key_path, "w", encoding="utf-8") as f:
+        _ = f.write(vespa_private_key)
+
+    return VespaSearchAdapter(
+        instance_url=vespa_instance_url,
+        cert_directory=str(cert_dir_path),
+    )
+
+
+def s3_object_write_text(s3_uri: str, text: str) -> None:
+    """Write text content to an S3 object."""
+    # Parse the S3 URI
+    s3_path: Path = Path(s3_uri)
+    if len(s3_path.parts) < 3:
+        raise ValueError(f"Invalid S3 path: {s3_path}")
+
+    bucket: str = s3_path.parts[1]
+    key = str(Path(*s3_path.parts[2:]))
+
+    # Create BytesIO buffer with the text content
+    body = BytesIO(text.encode("utf-8"))
+
+    # Upload to S3
+    s3 = boto3.client("s3")
+    _ = s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+
+
+def s3_obj_generator_from_s3_prefixes(
+    s3_prefixes: list[str],
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """Return a generator that yields keys from a list of S3 prefixes."""
+    logger = get_logger()
+
+    for s3_prefix in s3_prefixes:
+        try:
+            # E.g. Path("s3://bucket/prefix/file.json").parts[1] == "bucket"
+            bucket = Path(s3_prefix).parts[1]
+            object_keys = _get_s3_keys_with_prefix(s3_prefix=s3_prefix)
+            for key in object_keys:
+                stem: DocumentStem = Path(key).stem
+                key: DocumentObjectUri = os.path.join("s3://", bucket, key)
+
+                yield stem, key
+        except Exception as e:
+            logger.error(
+                f"failed to yield from S3 prefix. Error: {str(e)}",
+            )
+            continue
+
+
+def s3_obj_generator_from_s3_paths(
+    s3_paths: list[str],
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """
+    Return a generator that yields keys from a list of S3 paths.
+
+    We extract the key from the S3 path by removing the first two
+    elements in the path.
+
+    E.g. "s3://bucket/prefix/file.json" -> "prefix/file.json"
+    """
+    logger = get_logger()
+    for s3_path in s3_paths:
+        try:
+            stem: DocumentStem = Path(s3_path).stem
+            uri: DocumentObjectUri = s3_path
+            yield stem, uri
+        except Exception as e:
+            logger.error(
+                f"failed to yield from S3 path. Error: {str(e)}",
+            )
+            continue
+
+
+def s3_obj_generator(
+    s3_prefixes: list[str] | None,
+    s3_paths: list[str] | None,
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """
+    Return a generator that returns S3 objects for each path or prefix.
+
+    These will be for each output from the inference stage, of
+    labelled passages.
+    """
+    logger = get_run_logger()
+
+    match (s3_prefixes, s3_paths):
+        case (list(), list()):
+            raise ValueError(
+                "Either s3_prefixes or s3_paths must be provided, not both."
+            )
+        case (list(), None):
+            logger.info("S3 object generator: prefixes")
+            return s3_obj_generator_from_s3_prefixes(s3_prefixes=s3_prefixes)
+        case (None, list()):
+            logger.info("S3 object generator: paths")
+            return s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
+        case (None, None):
+            raise ValueError("Either s3_prefix or s3_paths must be provided.")
+
+
+def s3_paths_or_s3_prefixes(
+    classifier_specs: list[ClassifierSpec] | None,
+    document_ids: list[str] | None,
+    cache_bucket: str,
+    prefix: str,
+) -> S3Accessor:
+    """
+    Return the paths or prefix for the documents and classifiers.
+
+    - s3_prefix: The S3 prefix (directory) to yield objects from. Example:
+      "s3://cpr-sandbox-data-pipeline-cache/labelled_passages"
+    - s3_paths: A list of S3 object keys to yield objects from. Example:
+      [
+        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json",
+        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.legislative.10695.6015.json",
+      ]
+    """
+    logger = get_run_logger()
+
+    match (classifier_specs, document_ids):
+        case (None, None):
+            # Run on all documents, regardless of classifier
+            logger.info("run on all documents, regardless of classifier")
+            s3_prefix: str = "s3://" + os.path.join(
+                cache_bucket,
+                prefix,
+            )
+            return S3Accessor(paths=None, prefixes=[s3_prefix])
+
+        case (list(), None):
+            # Run on all documents, for the specified classifier
+            logger.info("run on all documents, for the specified classifier")
+            s3_prefixes = [
+                "s3://"
+                + os.path.join(
+                    cache_bucket,
+                    prefix,
+                    classifier_spec.name,
+                    classifier_spec.alias,
+                )
+                for classifier_spec in classifier_specs
+            ]
+            return S3Accessor(paths=None, prefixes=s3_prefixes)
+
+        case (list(), list()):
+            # Run on specified documents, for the specified classifier
+            logger.info("run on specified documents, for the specified classifier")
+
+            # FIXME: Add translated documents here!
+            #   This is handled in a later stacked PR.
+            document_paths = [
+                "s3://"
+                + os.path.join(
+                    cache_bucket,
+                    prefix,
+                    classifier_spec.name,
+                    classifier_spec.alias,
+                    f"{doc_id}.json",
+                )
+                for classifier_spec in classifier_specs
+                for doc_id in document_ids
+            ]
+            return S3Accessor(paths=document_paths, prefixes=None)
+
+        case (None, list()):
+            raise ValueError(
+                "if document IDs are specified, a classifier "
+                "specifcation must also be specified, since they're "
+                "namespaced by classifiers (e.g. "
+                "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
+                "v4/CCLW.legislative.10695.6015.json`)"
+            )
+
+
+def load_labelled_passages_by_uri(
+    document_object_uri: DocumentObjectUri,
+) -> list[LabelledPassage]:
+    """Load and transforms the S3 object's body into LabelledPassages objects."""
+    object_json = json.loads(_s3_object_read_text(s3_path=document_object_uri))
+
+    return [LabelledPassage(**labelled_passage) for labelled_passage in object_json]
+
+
+def get_model_from_span(span: Span) -> str:
+    """
+    Get the model used to label the span.
+
+    Labellers are stored in a list, these can contain many labellers as seen in the
+    example below, referring to human and machine annotators.
+
+    [
+        "alice",
+        "bob",
+        "68edec6f-fe74-413d-9cf1-39b1c3dad2c0",
+        'KeywordClassifier("extreme weather")',
+    ]
+
+    In the context of inference the labellers array should only hold the model used to
+    label the span as seen in the example below.
+
+    [
+        'KeywordClassifier("extreme weather")',
+    ]
+    """
+    if len(span.labellers) != 1:
+        raise ValueError(
+            f"Span has more than one labeller. Expected 1, got {len(span.labellers)}."
+        )
+    return span.labellers[0]
+
+
+def get_parent_concepts_from_concept(
+    concept: Concept,
+) -> tuple[list[dict], str]:
+    """
+    Extract parent concepts from a Concept object.
+
+    Currently we pull the name from the Classifier used to label the passage, this
+    doesn't hold the concept id. This is a temporary solution that is not desirable as
+    the relationship between concepts can change frequently and thus shouldn't be
+    coupled with inference.
+    """
+    parent_concepts = [
+        {"id": subconcept, "name": ""} for subconcept in concept.subconcept_of
+    ]
+    parent_concept_ids_flat = (
+        ",".join([parent_concept["id"] for parent_concept in parent_concepts]) + ","
+    )
+
+    return parent_concepts, parent_concept_ids_flat
+
+
+def convert_labelled_passage_to_concepts(
+    labelled_passage: LabelledPassage,
+) -> list[VespaConcept]:
+    """
+    Convert a labelled passage to a list of VespaConcept objects and their text block ID.
+
+    The labelled passage contains a list of spans relating to concepts
+    that we must convert to VespaConcept objects.
+    """
+    logger = get_run_logger()
+
+    concepts: list[VespaConcept] = []
+
+    # The concept used to label the passage holds some information on the parent
+    # concepts and thus this is being used as a temporary solution for providing
+    # the relationship between concepts. This has the downside that it ties a
+    # labelled passage to a particular concept when in fact the Spans that a
+    # labelled passage has can be labelled by multiple concepts.
+    concept = Concept.model_validate(labelled_passage.metadata["concept"])
+    parent_concepts, parent_concept_ids_flat = get_parent_concepts_from_concept(
+        concept=concept
+    )
+
+    # This expands the list from `n` for `LabelledPassages` to `n` for `Spans`
+    for span_idx, span in enumerate(labelled_passage.spans):
+        if span.concept_id is None:
+            # Include the Span index since Span's don't have IDs
+            logger.error(
+                f"span concept ID is missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+            )
+            continue
+
+        if not span.timestamps:
+            logger.error(
+                f"span timestamps are missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+            )
+            continue
+
+        concepts.append(
+            VespaConcept(
+                id=span.concept_id,
+                name=concept.preferred_label,
+                parent_concepts=parent_concepts,
+                parent_concept_ids_flat=parent_concept_ids_flat,
+                model=get_model_from_span(span),
+                end=span.end_index,
+                start=span.start_index,
+                # These timestamps _should_ all be the same,
+                # but just in case, take the latest.
+                timestamp=max(span.timestamps),
+            )
+        )
+
+    return concepts
+
+
+def get_vespa_search_adapter(
+    vespa_search_adapter: VespaSearchAdapter | None,
+) -> tuple[
+    ContextManager[str] | ContextManager[None],
+    VespaSearchAdapter,
+]:
+    """
+    Get a Vespa search adapter, if none provided.
+
+    It uses certs fetched, and then, saved to disk, if none was provided.
+    """
+    logger = get_run_logger()
+
+    # We want the directory used for the `VespaSearchAdapter` to be
+    # automatically cleaned up.
+    #
+    # To do this, we rely on the `tempfile.TemporaryDirectory`'s behaviour,
+    # or, a `contextlib.nullcontext` no-op, if a temporary directory
+    # wasn't needed.
+    if vespa_search_adapter is None:
+        logger.info("no Vespa search adapter, getting it from AWS secrets")
+        cm = tempfile.TemporaryDirectory()
+
+        vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
+            cert_dir=cm.name,  # type: ignore
+            vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
+            vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
+        )
+    else:
+        logger.info("Vespa search adapter provided")
+        cm = contextlib.nullcontext()
+
+    return cm, vespa_search_adapter
+
+
+def get_document_from_vespa(
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+) -> tuple[VespaHitId, VespaDocument]:
+    """Retrieve a passage for a document in Vespa."""
+    logger = get_logger()
+
+    logger.info(f"Getting document from Vespa: `{document_import_id}`")
+
+    condition = qb.QueryField("document_import_id").contains(document_import_id)
+
+    yql = (
+        qb.select("*")  # pyright:ignore[reportAttributeAccessIssue]
+        .from_("family_document")
+        .where(condition)
+    )
+
+    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
+        yql=yql
+    )
+
+    if not vespa_query_response.is_successful():
+        raise QueryError(vespa_query_response.get_status_code())
+    if len(vespa_query_response.hits) != 1:
+        raise ValueError(
+            f"Expected 1 document `{document_import_id}`, got {len(vespa_query_response.hits)}"
+        )
+
+    logger.info(
+        (
+            f"Vespa search response for document: {document_import_id} "
+            f"with {len(vespa_query_response.hits)} hits"
+        )
+    )
+
+    hit = vespa_query_response.hits[0]
+    document_id = hit["id"]
+    document = VespaDocument.model_validate(hit["fields"])
+
+    return document_id, document
+
+
+def get_document_passage_from_vespa(
+    text_block_id: str,
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+) -> tuple[VespaHitId, VespaPassage]:
+    """Retrieve a passage for a document in Vespa."""
+    logger = get_logger()
+
+    logger.info(
+        f"Getting document passage from Vespa: {document_import_id}, text block: {text_block_id}"
+    )
+
+    condition = qb.QueryField("family_document_ref").contains(
+        f"id:doc_search:family_document::{document_import_id}"
+    ) & qb.QueryField("text_block_id").contains(text_block_id)
+
+    yql = qb.select("*").from_("document_passage").where(condition)
+
+    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
+        yql=yql
+    )
+
+    if not vespa_query_response.is_successful():
+        raise QueryError(vespa_query_response.get_status_code())
+    if len(vespa_query_response.hits) != 1:
+        raise ValueError(
+            f"Expected 1 document passage for text block `{text_block_id}`, got {len(vespa_query_response.hits)}"
+        )
+
+    logger.info(
+        (
+            f"Vespa search response for document: {document_import_id} "
+            f"with {len(vespa_query_response.hits)} hits"
+        )
+    )
+
+    hit = vespa_query_response.hits[0]
+    passage_id = hit["id"]
+    passage = VespaPassage.model_validate(hit["fields"])
+
+    return passage_id, passage
+
+
+def get_document_passages_from_vespa(
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+) -> list[tuple[VespaHitId, VespaPassage]]:
+    """
+    Retrieve all the passages for a document in Vespa.
+
+    params:
+    - document_import_id: The document import id for a unique family document.
+    """
+    logger = get_logger()
+
+    logger.info(f"Getting document passages from Vespa: {document_import_id}")
+
+    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
+        yql=(
+            # trunk-ignore(bandit/B608)
+            "select * from document_passage where family_document_ref contains "
+            f'"id:doc_search:family_document::{document_import_id}"'
+        )
+    )
+
+    if (status_code := vespa_query_response.get_status_code()) != HTTP_OK:
+        raise QueryError(status_code)
+
+    logger.info(
+        (
+            f"Vespa search response for document: {document_import_id} "
+            f"with {len(vespa_query_response.hits)} hits"
+        )
+    )
+
+    return [
+        (passage["id"], VespaPassage.model_validate(passage["fields"]))
+        for passage in vespa_query_response.hits
+    ]
+
+
+def get_data_id_from_vespa_hit_id(hit_id: VespaHitId) -> VespaDataId:
+    """
+    Extract non-schema namespaced ID (last element after "::")
+
+    Example:
+    "CCLW.executive.10014.4470.623" from document passage ID like
+    "id:doc_search:document_passage::CCLW.executive.10014.4470.623".
+    """
+    splits = hit_id.split("::")
+    if len(splits) != 2:
+        raise ValueError(f"received {len(splits)} splits, when expecting 2: {splits}")
+    return splits[1]
+
+
+def get_document_passage_from_all_document_passages(
+    text_block_id: TextBlockId,
+    document_passages: list[tuple[VespaHitId, VespaPassage]],
+) -> tuple[VespaDataId, VespaPassage]:
+    """
+    Get the document passage, if it exists.
+
+    Earlier, we get all of the family document's document passages. We do this once, so there's
+    1 big network request to Vespa. We still need to confirm that the document passage exists.
+    """
+    hit_id_and_passage = next(
+        (
+            passage
+            for passage in document_passages
+            if passage[1].text_block_id == text_block_id
+        ),
+        None,
+    )
+
+    if not hit_id_and_passage:
+        raise ValueError(
+            f"could not found document passage `{text_block_id}` for family document"
+        )
+
+    data_id = get_data_id_from_vespa_hit_id(hit_id_and_passage[0])
+
+    return data_id, hit_id_and_passage[1]
+
+
+class ConceptModel(BaseModel):
+    """
+    A concept and the model used to identify it.
+
+    This class represents a pairing of a Wikibase concept ID with the name of the model
+    used to identify that concept in text. It is hashable to allow use in sets and as
+    dictionary keys.
+
+    Attributes:
+        wikibase_id: The Wikibase ID of the concept
+        model_name: The name of the model used to identify the concept
+
+    Example:
+        >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
+        ...                     model_name='KeywordClassifier("professional services sector")')
+        >>> str(model)
+        'Q123:KeywordClassifier("professional services sector")'
+    """
+
+    wikibase_id: WikibaseID
+    model_name: str
+
+    def __str__(self) -> str:
+        """
+        Convert the ConceptModel to a string in the format 'WIKIBASE_ID:MODEL_NAME'.
+
+        Returns:
+            str: String representation in the format 'WIKIBASE_ID:MODEL_NAME'
+        """
+        return f"{self.wikibase_id}{CONCEPT_COUNT_SEPARATOR}{self.concept_name}"
+
+    def __hash__(self) -> int:
+        """
+        Generate a hash value for the ConceptModel.
+
+        The hash is based on both the wikibase_id and model_name to ensure
+        uniqueness when used in sets or as dictionary keys.
+
+        Returns:
+            int: Hash value of the ConceptModel
+        """
+        return hash((self.wikibase_id, self.model_name))
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Compare this ConceptModel with another for equality.
+
+        Two ConceptModels are equal if they have the same wikibase_id and model_name.
+
+        Args:
+            other: The object to compare with
+
+        Returns:
+            bool: True if the objects are equal, False otherwise
+        """
+        if not isinstance(other, ConceptModel):
+            return NotImplemented
+        return (
+            self.wikibase_id == other.wikibase_id
+            and self.model_name == other.model_name
+        )
+
+    @property
+    def concept_name(self) -> str:
+        """
+        Extract the concept name from the model name.
+
+        Examples:
+            >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
+            ...                     model_name='KeywordClassifier("professional services sector")')
+            >>> model.concept_name
+            'professional services sector'
+            >>> model2 = ConceptModel(wikibase_id=WikibaseID("Q456"),
+            ...                      model_name='LLMClassifier("agriculture")')
+            >>> model2.concept_name
+            'agriculture'
+            >>> model3 = ConceptModel(wikibase_id=WikibaseID("Q789"),
+            ...                      model_name='InvalidModelName')
+            >>> model3.concept_name  # doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+                ...
+            ValueError: Could not extract concept name from model name 'InvalidModelName'
+        """
+        match = re.search(r'"([^"]+)"', self.model_name)
+        if match:
+            return match.group(1)
+
+        raise ValueError(
+            f"Could not extract concept name from model name '{self.model_name}'"
+        )
+
+
+async def partial_update_text_block(
+    text_block_id: TextBlockId,
+    concepts: list[VespaConcept],  # A possibly empty list
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+    update_function: Callable,
+):
+    """Partial update a singular text block and its concepts."""
+    document_passage_id, document_passage = get_document_passage_from_vespa(
+        text_block_id, document_import_id, vespa_search_adapter
+    )
+
+    data_id = get_data_id_from_vespa_hit_id(document_passage_id)
+
+    serialised_concepts = update_function(document_passage, concepts)
+
+    response: VespaResponse = vespa_search_adapter.client.update_data(  # pyright: ignore[reportOptionalMemberAccess]
+        schema="document_passage",
+        namespace="doc_search",
+        data_id=data_id,
+        fields={"concepts": serialised_concepts},
+    )
+
+    if (status_code := response.get_status_code()) != HTTP_OK:
+        raise PartialUpdateError(data_id, status_code)
+
+    return None
+
+
+@flow
+async def run_partial_updates_of_concepts_for_batch(
+    documents_batch: list[DocumentImporter],
+    documents_batch_num: int,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    partial_update_flow: Callable,
+) -> None:
+    """Run partial updates for concepts in a batch of documents."""
+
+    logger = get_run_logger()
+    logger.info(
+        f"Updating concepts for batch of documents, documents in batch: {len(documents_batch)}."
+    )
+    for i, document_importer in enumerate(documents_batch):
+        try:
+            _ = await partial_update_flow(
+                document_importer=document_importer,
+                cache_bucket=cache_bucket,
+                concepts_counts_prefix=concepts_counts_prefix,
+            )
+
+            logger.info(f"processed batch documents #{documents_batch_num}")
+
+        except Exception as e:
+            document_stem: DocumentStem = documents_batch[i][0]
+            logger.error(
+                f"failed to process document `{document_stem}`: {e.__str__()}",
+            )
+            continue
+
+
+async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
+    documents_batch: list[DocumentImporter],
+    documents_batch_num: int,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    aws_env: AwsEnv,
+    as_deployment: bool,
+    partial_update_flow: Callable,
+) -> None:
+    """Run partial updates for a batch of documents as a sub-flow or deployment."""
+    logger = get_run_logger()
+    logger.info(
+        "Running partial updates of concepts for batch as sub-flow or deployment: "
+        f"batch length {len(documents_batch)}, as_deployment: {as_deployment}"
+    )
+
+    if as_deployment:
+        flow_name = function_to_flow_name(partial_update_flow)
+        deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
+
+        return await run_deployment(
+            name=f"{flow_name}/{deployment_name}",
+            parameters={
+                "documents_batch": documents_batch,
+                "documents_batch_num": documents_batch_num,
+                "cache_bucket": cache_bucket,
+                "concepts_counts_prefix": concepts_counts_prefix,
+                "partial_update_flow": partial_update_flow,
+            },
+            timeout=3600,
+        )
+
+    return await run_partial_updates_of_concepts_for_batch(
+        documents_batch=documents_batch,
+        documents_batch_num=documents_batch_num,
+        cache_bucket=cache_bucket,
+        concepts_counts_prefix=concepts_counts_prefix,
+        partial_update_flow=partial_update_flow,
+    )
+
+
+@flow
+async def index_by_s3(
+    partial_update_flow: Callable,
+    aws_env: AwsEnv,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    vespa_search_adapter: VespaSearchAdapter | None,
+    s3_prefixes: list[str] | None = None,
+    s3_paths: list[str] | None = None,
+    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
+    indexing_task_batch_size: int = DEFAULT_INDEXING_TASK_BATCH_SIZE,
+    as_deployment: bool = True,
+) -> None:
+    """
+    Asynchronously index concepts from S3 files into Vespa.
+
+    This function retrieves concept documents from files stored in an S3 path and
+    indexes them in a Vespa instance. The name of each file in the specified S3 path is
+    expected to represent the document's import ID.
+
+    When `s3_prefix` is provided, the function will index all files within that S3
+    prefix (directory). When `s3_paths` is provided, the function will index only the
+    files specified in the list of S3 object keys. If both are provided `s3_paths` will
+    be used.
+
+    Assumptions:
+    - The S3 file names represent document import IDs.
+
+    params:
+    - s3_prefix: The S3 prefix (directory) to yield objects from.
+        E.g. "s3://bucket/prefix/"
+    - s3_paths: A list of S3 object keys to yield objects from.
+        E.g. {"s3://bucket/prefix/file1.json", "s3://bucket/prefix/file2.json"}
+    - vespa_search_adapter: An instance of VespaSearchAdapter.
+        E.g. VespaSearchAdapter(
+            instance_url="https://vespa-instance-url.com",
+            cert_directory="certs/"
+        )
+    """
+    logger = get_run_logger()
+
+    cm, vespa_search_adapter = get_vespa_search_adapter(vespa_search_adapter)
+
+    with cm:
+        logger.info("Getting S3 object generator")
+        documents_generator = s3_obj_generator(s3_prefixes, s3_paths)
+        documents_batches = iterate_batch(documents_generator, batch_size=batch_size)
+        indexing_task_batches = iterate_batch(
+            data=documents_batches, batch_size=indexing_task_batch_size
+        )
+
+        for i, indexing_task_batch in enumerate(indexing_task_batches, start=1):
+            logger.info(f"Processing indexing task batch #{i}")
+
+            indexing_tasks = [
+                run_partial_updates_of_concepts_for_batch_flow_or_deployment(
+                    documents_batch=documents_batch,
+                    documents_batch_num=documents_batch_num,
+                    cache_bucket=cache_bucket,
+                    concepts_counts_prefix=concepts_counts_prefix,
+                    aws_env=aws_env,
+                    as_deployment=as_deployment,
+                    partial_update_flow=partial_update_flow,
+                )
+                for documents_batch_num, documents_batch in enumerate(
+                    indexing_task_batch, start=1
+                )
+            ]
+
+            logger.info(f"Gathering indexing tasks for batch #{i}")
+            results = await asyncio.gather(*indexing_tasks, return_exceptions=True)
+            logger.info(f"Gathered indexing tasks for batch #{i}")
+
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.error(
+                        f"failed to process document batch in indexing task batch #{i}: {str(result)}",
+                    )
+                    continue

--- a/flows/count_family_document_concepts.py
+++ b/flows/count_family_document_concepts.py
@@ -11,15 +11,17 @@ from prefect import flow, get_run_logger
 from prefect.deployments.deployments import run_deployment
 from vespa.io import VespaResponse
 
-from flows.index import (
+from flows.boundary import (
     CONCEPT_COUNT_SEPARATOR,
-    CONCEPTS_COUNTS_PREFIX_DEFAULT,
     DocumentImportId,
     DocumentObjectUri,
     S3Accessor,
+    s3_obj_generator,
+)
+from flows.index import (
+    CONCEPTS_COUNTS_PREFIX_DEFAULT,
     get_vespa_search_adapter,
     iterate_batch,
-    s3_obj_generator,
     s3_paths_or_s3_prefixes,
 )
 from flows.utils import SlackNotify
@@ -83,7 +85,7 @@ async def partial_update_family_document_concepts_counts(
     """
     Update document concept counts in Vespa via partial updates.
 
-    Similar to index.get_updated_passage_concepts, during the update
+    Similar to index.update_concepts_on_existing_vespa_concepts, during the update
     we remove all the old concepts related to a model. This is as it
     was decided that holding out dated concepts counts on the document
     in Vespa for a model is not useful.

--- a/flows/deindex.py
+++ b/flows/deindex.py
@@ -1,0 +1,1239 @@
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import re
+import tempfile
+from collections import Counter
+from collections.abc import Generator
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any, ContextManager, TypeAlias, TypeVar
+
+import boto3
+import vespa.querybuilder as qb
+from cpr_sdk.models.search import Concept as VespaConcept
+from cpr_sdk.models.search import Passage as VespaPassage
+from cpr_sdk.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
+from cpr_sdk.search_adaptors import VespaSearchAdapter
+from cpr_sdk.ssm import get_aws_ssm_param
+from prefect import flow
+from prefect.deployments.deployments import run_deployment
+from prefect.logging import get_logger, get_run_logger
+from pydantic import BaseModel
+from vespa.io import VespaQueryResponse, VespaResponse
+
+from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
+from flows.utils import SlackNotify
+from scripts.cloud import (
+    AwsEnv,
+    ClassifierSpec,
+    function_to_flow_name,
+    generate_deployment_name,
+    get_prefect_job_variable,
+)
+from src.concept import Concept
+from src.exceptions import PartialUpdateError, QueryError
+from src.identifiers import WikibaseID
+from src.labelled_passage import LabelledPassage
+from src.span import Span
+
+DEFAULT_DOCUMENTS_BATCH_SIZE = 500
+DEFAULT_INDEXING_TASK_BATCH_SIZE = 20
+HTTP_OK = 200
+CONCEPTS_COUNTS_PREFIX_DEFAULT: str = "concepts_counts"
+CONCEPT_COUNT_SEPARATOR: str = ":"
+
+# Needed to get document passages from Vespa
+# Example: CCLW.executive.1813.2418
+DocumentImportId: TypeAlias = str
+# Needed to load the inference results
+# Example: s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json
+DocumentObjectUri: TypeAlias = str
+# Passed to a self-sufficient flow run
+DocumentImporter: TypeAlias = tuple[DocumentImportId, DocumentObjectUri]
+
+
+class S3Accessor(BaseModel):
+    """Representing S3 paths and prefixes for accessing documents."""
+
+    paths: list[str] | None = None
+    prefixes: list[str] | None = None
+
+
+# AKA LabelledPassage
+TextBlockId: TypeAlias = str
+SpanId: TypeAlias = str
+# The ID used in Vespa, that we don't keep in our models in the CPR
+# SDK, that is in a Hit.
+VespaHitId: TypeAlias = str
+# The same as above, but without the schema
+VespaDataId: TypeAlias = str
+
+T = TypeVar("T")
+
+
+@dataclass()
+class Config:
+    """Configuration used across flow runs."""
+
+    cache_bucket: str | None = None
+    document_source_prefix: str = DOCUMENT_TARGET_PREFIX_DEFAULT
+    concepts_counts_prefix: str = CONCEPTS_COUNTS_PREFIX_DEFAULT
+    bucket_region: str = "eu-west-1"
+    # An instance of VespaSearchAdapter.
+    #
+    # E.g.
+    #
+    # VespaSearchAdapter(
+    #   instance_url="https://vespa-instance-url.com",
+    #   cert_directory="certs/"
+    # )
+    vespa_search_adapter: VespaSearchAdapter | None = None
+    aws_env: AwsEnv = AwsEnv(os.environ["AWS_ENV"])
+    as_deployment: bool = True
+
+    @classmethod
+    async def create(cls) -> "Config":
+        """Create a new Config instance with initialized values."""
+        logger = get_run_logger()
+
+        config = cls()
+
+        if not config.cache_bucket:
+            logger.info(
+                "no cache bucket provided, getting it from Prefect job variable"
+            )
+            config.cache_bucket = await get_prefect_job_variable(
+                "pipeline_cache_bucket_name"
+            )
+
+        return config
+
+
+class ConceptModel(BaseModel):
+    """
+    A concept and the model used to identify it.
+
+    This class represents a pairing of a Wikibase concept ID with the name of the model
+    used to identify that concept in text. It is hashable to allow use in sets and as
+    dictionary keys.
+
+    Attributes:
+        wikibase_id: The Wikibase ID of the concept
+        model_name: The name of the model used to identify the concept
+
+    Example:
+        >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
+        ...                     model_name='KeywordClassifier("professional services sector")')
+        >>> str(model)
+        'Q123:KeywordClassifier("professional services sector")'
+    """
+
+    wikibase_id: WikibaseID
+    model_name: str
+
+    def __str__(self) -> str:
+        """
+        Convert the ConceptModel to a string in the format 'WIKIBASE_ID:MODEL_NAME'.
+
+        Returns:
+            str: String representation in the format 'WIKIBASE_ID:MODEL_NAME'
+        """
+        return f"{self.wikibase_id}{CONCEPT_COUNT_SEPARATOR}{self.concept_name}"
+
+    def __hash__(self) -> int:
+        """
+        Generate a hash value for the ConceptModel.
+
+        The hash is based on both the wikibase_id and model_name to ensure
+        uniqueness when used in sets or as dictionary keys.
+
+        Returns:
+            int: Hash value of the ConceptModel
+        """
+        return hash((self.wikibase_id, self.model_name))
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Compare this ConceptModel with another for equality.
+
+        Two ConceptModels are equal if they have the same wikibase_id and model_name.
+
+        Args:
+            other: The object to compare with
+
+        Returns:
+            bool: True if the objects are equal, False otherwise
+        """
+        if not isinstance(other, ConceptModel):
+            return NotImplemented
+        return (
+            self.wikibase_id == other.wikibase_id
+            and self.model_name == other.model_name
+        )
+
+    @property
+    def concept_name(self) -> str:
+        """
+        Extract the concept name from the model name.
+
+        Examples:
+            >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
+            ...                     model_name='KeywordClassifier("professional services sector")')
+            >>> model.concept_name
+            'professional services sector'
+            >>> model2 = ConceptModel(wikibase_id=WikibaseID("Q456"),
+            ...                      model_name='LLMClassifier("agriculture")')
+            >>> model2.concept_name
+            'agriculture'
+            >>> model3 = ConceptModel(wikibase_id=WikibaseID("Q789"),
+            ...                      model_name='InvalidModelName')
+            >>> model3.concept_name  # doctest: +IGNORE_EXCEPTION_DETAIL
+            Traceback (most recent call last):
+                ...
+            ValueError: Could not extract concept name from model name 'InvalidModelName'
+        """
+        match = re.search(r'"([^"]+)"', self.model_name)
+        if match:
+            return match.group(1)
+
+        raise ValueError(
+            f"Could not extract concept name from model name '{self.model_name}'"
+        )
+
+
+def get_vespa_search_adapter_from_aws_secrets(
+    cert_dir: str,
+    vespa_instance_url_param_name: str = "VESPA_INSTANCE_URL",
+    vespa_public_cert_param_name: str = "VESPA_PUBLIC_CERT_READ",
+    vespa_private_key_param_name: str = "VESPA_PRIVATE_KEY_READ",
+) -> VespaSearchAdapter:
+    """
+    Get a VespaSearchAdapter instance by retrieving secrets from AWS Secrets Manager.
+
+    We then save the secrets to local files in the cert_dir directory and instantiate
+    the VespaSearchAdapter.
+    """
+    cert_dir_path = Path(cert_dir)
+    if not cert_dir_path.exists():
+        raise FileNotFoundError(f"Certificate directory does not exist: {cert_dir}")
+
+    vespa_instance_url = get_aws_ssm_param(vespa_instance_url_param_name)
+    vespa_public_cert_encoded = get_aws_ssm_param(vespa_public_cert_param_name)
+    vespa_private_key_encoded = get_aws_ssm_param(vespa_private_key_param_name)
+
+    vespa_public_cert = base64.b64decode(vespa_public_cert_encoded).decode("utf-8")
+    vespa_private_key = base64.b64decode(vespa_private_key_encoded).decode("utf-8")
+
+    cert_path = cert_dir_path / "cert.pem"
+    key_path = cert_dir_path / "key.pem"
+
+    with open(cert_path, "w", encoding="utf-8") as f:
+        _ = f.write(vespa_public_cert)
+
+    with open(key_path, "w", encoding="utf-8") as f:
+        _ = f.write(vespa_private_key)
+
+    return VespaSearchAdapter(
+        instance_url=vespa_instance_url,
+        cert_directory=str(cert_dir_path),
+    )
+
+
+def save_labelled_passages_by_uri(
+    document_object_uri: DocumentObjectUri,
+    labelled_passages: list[LabelledPassage],
+) -> None:
+    """Save LabelledPassages objects to S3."""
+    object_json = json.dumps(
+        [labelled_passage.model_dump_json() for labelled_passage in labelled_passages]
+    )
+
+    _ = _s3_object_write_text(
+        s3_uri=document_object_uri,
+        text=object_json,
+    )
+
+
+def get_model_from_span(span: Span) -> str:
+    """
+    Get the model used to label the span.
+
+    Labellers are stored in a list, these can contain many labellers as seen in the
+    example below, referring to human and machine annotators.
+
+    [
+        "alice",
+        "bob",
+        "68edec6f-fe74-413d-9cf1-39b1c3dad2c0",
+        'KeywordClassifier("extreme weather")',
+    ]
+
+    In the context of inference the labellers array should only hold the model used to
+    label the span as seen in the example below.
+
+    [
+        'KeywordClassifier("extreme weather")',
+    ]
+    """
+    if len(span.labellers) != 1:
+        raise ValueError(
+            f"Span has more than one labeller. Expected 1, got {len(span.labellers)}."
+        )
+    return span.labellers[0]
+
+
+def get_data_id_from_vespa_hit_id(hit_id: VespaHitId) -> VespaDataId:
+    """
+    Extract non-schema namespaced ID (last element after "::")
+
+    Example:
+    "CCLW.executive.10014.4470.623" from document passage ID like
+    "id:doc_search:document_passage::CCLW.executive.10014.4470.623".
+    """
+    splits = hit_id.split("::")
+    if len(splits) != 2:
+        raise ValueError(f"received {len(splits)} splits, when expecting 2: {splits}")
+    return splits[1]
+
+
+def get_document_passages_from_vespa(
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+) -> list[tuple[VespaHitId, VespaPassage]]:
+    """
+    Retrieve all the passages for a document in Vespa.
+
+    params:
+    - document_import_id: The document import id for a unique family document.
+    """
+    logger = get_logger()
+
+    logger.info(f"Getting document passages from Vespa: {document_import_id}")
+
+    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
+        yql=(
+            # trunk-ignore(bandit/B608)
+            "select * from document_passage where family_document_ref contains "
+            f'"id:doc_search:family_document::{document_import_id}"'
+        )
+    )
+
+    if (status_code := vespa_query_response.get_status_code()) != HTTP_OK:
+        raise QueryError(status_code)
+
+    logger.info(
+        (
+            f"Vespa search response for document: {document_import_id} "
+            f"with {len(vespa_query_response.hits)} hits"
+        )
+    )
+
+    return [
+        (passage["id"], VespaPassage.model_validate(passage["fields"]))
+        for passage in vespa_query_response.hits
+    ]
+
+
+def get_document_passage_from_vespa(
+    text_block_id: str,
+    document_import_id: DocumentImportId,
+    vespa_search_adapter: VespaSearchAdapter,
+) -> tuple[VespaHitId, VespaPassage]:
+    """Retrieve a passage for a document in Vespa."""
+    logger = get_logger()
+
+    logger.info(
+        f"Getting document passage from Vespa: {document_import_id}, text block: {text_block_id}"
+    )
+
+    condition = qb.QueryField("family_document_ref").contains(
+        f"id:doc_search:family_document::{document_import_id}"
+    ) & qb.QueryField("text_block_id").contains(text_block_id)
+
+    yql = (
+        qb.select("*")  # pyright:ignore[reportAttributeAccessIssue]
+        .from_("document_passage")
+        .where(condition)
+    )
+
+    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
+        yql=yql
+    )
+
+    if not vespa_query_response.is_successful():
+        raise QueryError(vespa_query_response.get_status_code())
+    if len(vespa_query_response.hits) != 1:
+        raise ValueError(
+            f"Expected 1 document passage for text block `{text_block_id}`, got {len(vespa_query_response.hits)}"
+        )
+
+    logger.info(
+        (
+            f"Vespa search response for document: {document_import_id} "
+            f"with {len(vespa_query_response.hits)} hits"
+        )
+    )
+
+    hit = vespa_query_response.hits[0]
+    passage_id = hit["id"]
+    passage = VespaPassage.model_validate(hit["fields"])
+
+    return passage_id, passage
+
+
+def load_labelled_passages_by_uri(
+    document_object_uri: DocumentObjectUri,
+) -> list[LabelledPassage]:
+    """Load and transforms the S3 object's body into LabelledPassages objects."""
+    object_json = json.loads(_s3_object_read_text(s3_path=document_object_uri))
+
+    return [LabelledPassage(**labelled_passage) for labelled_passage in object_json]
+
+
+def get_updated_passage_concepts(
+    passage: VespaPassage,
+    concepts_in_vespa: list[VespaConcept],
+) -> list[dict[str, Any]]:
+    """
+    Update a passage's concepts with the updated/removed concepts.
+
+    During the update we remove all the old concepts related to a model. This is as it
+    was decided that holding out dated concepts/spans on the passage in Vespa for a
+    model is not useful.
+
+    It is also, not possible to duplicate a Concept object in the concepts array as we
+    are removing all instances where the model is the same.
+    """
+    # Put them in the right structure for identification and removal
+    concepts_to_remove = {concept.model for concept in concepts_in_vespa}
+
+    # It's an optional sequence at the moment, so massage it
+    concepts_in_vespa = list(passage.concepts) if passage.concepts is not None else []
+
+    # We'll be removing all of the listed concepts, so filter them out
+    concepts_in_vespa_to_keep = [
+        concept
+        for concept in concepts_in_vespa
+        if concept.model not in concepts_to_remove
+    ]
+
+    return [concept_.model_dump(mode="json") for concept_ in concepts_in_vespa_to_keep]
+
+
+@flow
+async def run_partial_updates_of_concepts_for_document_passages(
+    document_importer: DocumentImporter,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    vespa_search_adapter: VespaSearchAdapter | None = None,
+) -> None:
+    """
+    Run partial update for VespaConcepts on text blocks for a document.
+
+    This is done in the document_passage index.
+
+    Assumptions:
+
+    - The ID field of the VespaConcept object holds the
+    context of the text block that it relates to. E.g. the concept ID
+    1.10 would relate to the text block ID 10.
+    """
+    logger = get_run_logger()
+
+    cm, vespa_search_adapter = get_vespa_search_adapter(vespa_search_adapter)
+
+    logger.info("getting S3 labelled passages generator")
+    document_labelled_passages = load_labelled_passages_by_uri(document_importer[1])
+
+    with cm:
+        logger.info(
+            (
+                "getting document passages from Vespa for document "
+                f"import ID {document_importer[0]}"
+            )
+        )
+
+        logger.info("converting labelled passages to Vespa concepts")
+        grouped_concepts: dict[TextBlockId, list[VespaConcept]] = {
+            labelled_passage.id: convert_labelled_passage_to_concepts(labelled_passage)
+            for labelled_passage in document_labelled_passages
+        }
+
+        logger.info(
+            f"starting partial updates for {len(grouped_concepts)} grouped concepts"
+        )
+
+        batches = iterate_batch(
+            list(grouped_concepts.items()),
+            batch_size=DEFAULT_DOCUMENTS_BATCH_SIZE,
+        )
+
+        for batch_num, batch in enumerate(batches, start=1):
+            logger.info(f"processing partial updates batch {batch_num}")
+
+            partial_update_tasks = [
+                partial_update_text_block(
+                    text_block_id=text_block_id,
+                    document_import_id=document_importer[0],
+                    concepts=concepts,
+                    vespa_search_adapter=vespa_search_adapter,
+                )
+                for text_block_id, concepts in batch
+            ]
+
+            logger.info(f"gathering partial updates tasks for batch {batch_num}")
+            results = await asyncio.gather(
+                *partial_update_tasks, return_exceptions=True
+            )
+            logger.info(
+                f"gathered partial {len(results)} updates tasks for batch {batch_num}"
+            )
+
+            concepts_counts = calculate_concepts_counts_from_results(results, batch)
+
+            await update_s3_with_latest_concepts_counts(
+                document_importer=document_importer,
+                concepts_counts=concepts_counts,
+                cache_bucket=cache_bucket,
+                concepts_counts_prefix=concepts_counts_prefix,
+                document_labelled_passages=document_labelled_passages,
+            )
+
+
+def calculate_concepts_counts_from_results(
+    results: list[BaseException | None],
+    batch: list[tuple[TextBlockId, list[VespaConcept]]],
+) -> Counter[ConceptModel]:
+    # This can handle multiple concepts, but, in practice at the
+    # moment, this function is operating on a DocumentImporter,
+    # which represents a labelled passages object, which is per
+    # concept.
+    concepts_counts: Counter[ConceptModel] = Counter()
+
+    for i, result in enumerate(results):
+        _text_block_id, concepts = batch[i]
+
+        # Example:
+        #
+        # ..
+        # "labellers": [
+        #   "KeywordClassifier(\"professional services sector\")"
+        # ],
+        # ...
+        concepts_models = [
+            ConceptModel(wikibase_id=WikibaseID(concept.id), model_name=concept.model)
+            for concept in concepts
+        ]
+
+        # Set 0s in the counter for all seen concepts. This ensures
+        # all concepts are represented in the counter even if they're
+        # not updated.
+        for concept_model in concepts_models:
+            if concept_model not in concepts_counts:
+                concepts_counts[concept_model] = 0
+
+        if isinstance(result, Exception):
+            # Since we failed to remove them from the spans, make sure
+            # they're accounted for as remaining
+            concepts_counts.update(concepts_models)
+
+    return concepts_counts
+
+
+async def update_s3_with_latest_concepts_counts(
+    document_importer: DocumentImporter,
+    concepts_counts: Counter[ConceptModel],
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    document_labelled_passages: list[LabelledPassage],
+) -> None:
+    logger = get_run_logger()
+
+    # Ideally, we'd remove the concepts count file entirely, but, we may fail above in updating
+    # 1 or more document passages in Vespa, which means that they'd still have the concept present.
+    #
+    # To avoid a mismatch of the family documents' concepts counts, and what's _still_ reflected on
+    # document passages due to failed partial updates, still write an updated concepts counts to
+    # S3.
+    #
+    # However, if we successfully removed all of the concepts from the document passages, then we can
+    # delete it. Then, also update the family document's concepts counts to remove it from there.
+
+    # Remove entries with a value of 0 from the counter
+    concepts_counts_filtered = Counter(
+        {k: v for k, v in concepts_counts.items() if v != 0}
+    )
+
+    # If after filtering out, there's no concepts, that means we
+    # succeeded in all the partial updates to the document
+    # passages.
+    if len(concepts_counts_filtered) == 0:
+        logger.info("successfully updated all concepts")
+        update_s3_with_all_successes(
+            document_object_uri=document_importer[1],
+            cache_bucket=cache_bucket,
+            concepts_counts_prefix=concepts_counts_prefix,
+        )
+    # We didn't succeed with all, so write the concepts counts still
+    else:
+        logger.info("only updated some concepts")
+        update_s3_with_some_successes(
+            document_object_uri=document_importer[1],
+            concepts_counts_filtered=concepts_counts_filtered,
+            document_labelled_passages=document_labelled_passages,
+            cache_bucket=cache_bucket,
+            concepts_counts_prefix=concepts_counts_prefix,
+        )
+
+    return None
+
+
+def update_s3_with_all_successes(
+    document_object_uri: DocumentObjectUri,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+) -> None:
+    logger = get_run_logger()
+
+    logger.info("updating S3 with all successes")
+
+    s3 = boto3.client("s3")
+
+    s3_uri = Path(document_object_uri)
+
+    # First, delete the concepts counts object
+    # Get all parts after the prefix (e.g. "Q787/v4/CCLW.executive.1813.2418.json")
+    key_parts = "/".join(s3_uri.parts[3:])  # Skip s3://bucket/labelled_passages/
+
+    concepts_counts_key = f"{concepts_counts_prefix}/{key_parts}"
+
+    _ = s3.delete_object(Bucket=cache_bucket, Key=concepts_counts_key)
+
+    logger.info("updated S3 with deleted concepts counts")
+
+    # Second, delete the labelled passages
+    # Get all parts except for the bucket (e.g. "labelled_passages/Q787/v4/CCLW.executive.1813.2418.json")
+    labelled_passages_key = "/".join(s3_uri.parts[2:])  # Skip s3://bucket/
+
+    _ = s3.delete_object(Bucket=cache_bucket, Key=labelled_passages_key)
+
+    logger.info("updated S3 with deleted labelled passages")
+
+    logger.info("updated S3 with all successes")
+
+    return None
+
+
+def update_s3_with_some_successes(
+    document_object_uri: DocumentObjectUri,
+    concepts_counts_filtered: Counter[ConceptModel],
+    document_labelled_passages: list[LabelledPassage],
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+) -> None:
+    logger = get_run_logger()
+
+    logger.info("updating S3 with partial successes")
+
+    # First, update the concepts counts object
+    serialised_concepts_counts = json.dumps(
+        {str(k): v for k, v in concepts_counts_filtered.items()}
+    )
+
+    s3_uri = Path(document_object_uri)
+
+    # Get all parts after the prefix (e.g. "Q787/v4/CCLW.executive.1813.2418.json")
+    key_parts = "/".join(s3_uri.parts[3:])  # Skip s3://bucket/labelled_passages/
+
+    concepts_counts_uri = f"s3://{cache_bucket}/{concepts_counts_prefix}/{key_parts}"
+
+    _ = _s3_object_write_text(
+        s3_uri=concepts_counts_uri,
+        text=serialised_concepts_counts,
+    )
+
+    logger.info("updated S3 with updated concepts counts")
+
+    # Second, update the labelled passages
+    concept_ids_to_keep: list[WikibaseID] = [
+        concept_model.wikibase_id for concept_model in concepts_counts_filtered
+    ]
+
+    filtered_labelled_passages: list[LabelledPassage] = []
+
+    for labelled_passage in document_labelled_passages:
+        # It doesn't matter if this list is empty, as it
+        # emulates an empty result from the inference
+        # pipeline.
+        updated_spans: list[Span] = [
+            span
+            for span in labelled_passage.spans
+            if span.concept_id in concept_ids_to_keep
+        ]
+
+        labelled_passage.spans = updated_spans
+
+        filtered_labelled_passages.append(labelled_passage)
+
+    _ = save_labelled_passages_by_uri(
+        document_object_uri=document_object_uri,
+        labelled_passages=filtered_labelled_passages,
+    )
+
+    logger.info("updated S3 with updated labelled passages")
+
+    logger.info("updated S3 with partial successes")
+
+    return None
+
+
+def get_parent_concepts_from_concept(
+    concept: Concept,
+) -> tuple[list[dict], str]:
+    """
+    Extract parent concepts from a Concept object.
+
+    Currently we pull the name from the Classifier used to label the passage, this
+    doesn't hold the concept id. This is a temporary solution that is not desirable as
+    the relationship between concepts can change frequently and thus shouldn't be
+    coupled with inference.
+    """
+    parent_concepts = [
+        {"id": subconcept, "name": ""} for subconcept in concept.subconcept_of
+    ]
+    parent_concept_ids_flat = (
+        ",".join([parent_concept["id"] for parent_concept in parent_concepts]) + ","
+    )
+
+    return parent_concepts, parent_concept_ids_flat
+
+
+def convert_labelled_passage_to_concepts(
+    labelled_passage: LabelledPassage,
+) -> list[VespaConcept]:
+    """
+    Convert a labelled passage to a list of VespaConcept objects and their text block ID.
+
+    The labelled passage contains a list of spans relating to concepts
+    that we must convert to VespaConcept objects.
+    """
+    logger = get_run_logger()
+
+    concepts: list[VespaConcept] = []
+
+    # The concept used to label the passage holds some information on the parent
+    # concepts and thus this is being used as a temporary solution for providing
+    # the relationship between concepts. This has the downside that it ties a
+    # labelled passage to a particular concept when in fact the Spans that a
+    # labelled passage has can be labelled by multiple concepts.
+    concept = Concept.model_validate(labelled_passage.metadata["concept"])
+    parent_concepts, parent_concept_ids_flat = get_parent_concepts_from_concept(
+        concept=concept
+    )
+
+    # This expands the list from `n` for `LabelledPassages` to `n` for `Spans`
+    for span_idx, span in enumerate(labelled_passage.spans):
+        if span.concept_id is None:
+            # Include the Span index since Span's don't have IDs
+            logger.error(
+                f"span concept ID is missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+            )
+            continue
+
+        if not span.timestamps:
+            logger.error(
+                f"span timestamps are missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
+            )
+            continue
+
+        concepts.append(
+            VespaConcept(
+                id=span.concept_id,
+                name=concept.preferred_label,
+                parent_concepts=parent_concepts,
+                parent_concept_ids_flat=parent_concept_ids_flat,
+                model=get_model_from_span(span),
+                end=span.end_index,
+                start=span.start_index,
+                # These timestamps _should_ all be the same,
+                # but just in case, take the latest.
+                timestamp=max(span.timestamps),
+            )
+        )
+
+    return concepts
+
+
+async def partial_update_text_block(
+    text_block_id: TextBlockId,
+    document_import_id: DocumentImportId,
+    concepts: list[VespaConcept],  # A possibly empty list
+    vespa_search_adapter: VespaSearchAdapter,
+) -> None:
+    """Partial update a singular text block and its concepts, if any."""
+    document_passage_id, document_passage = get_document_passage_from_vespa(
+        text_block_id, document_import_id, vespa_search_adapter
+    )
+
+    data_id = get_data_id_from_vespa_hit_id(document_passage_id)
+
+    serialised_concepts = get_updated_passage_concepts(
+        passage=document_passage,
+        concepts_in_vespa=concepts,
+    )
+
+    response: VespaResponse = vespa_search_adapter.client.update_data(  # pyright: ignore[reportOptionalMemberAccess]
+        schema="document_passage",
+        namespace="doc_search",
+        data_id=data_id,
+        fields={"concepts": serialised_concepts},
+    )
+
+    if (status_code := response.get_status_code()) != HTTP_OK:
+        raise PartialUpdateError(data_id, status_code)
+
+    return None
+
+
+@flow
+async def run_partial_updates_of_concepts_for_batch(
+    documents_batch: list[DocumentImporter],
+    documents_batch_num: int,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+) -> None:
+    """Run partial updates for concepts in a batch of documents."""
+
+    logger = get_run_logger()
+    logger.info(
+        f"Updating concepts for batch of documents, documents in batch: {len(documents_batch)}."
+    )
+    for i, document_importer in enumerate(documents_batch):
+        try:
+            _ = await run_partial_updates_of_concepts_for_document_passages(
+                document_importer=document_importer,
+                cache_bucket=cache_bucket,
+                concepts_counts_prefix=concepts_counts_prefix,
+            )
+
+            logger.info(f"processed batch documents #{documents_batch_num}")
+
+        except Exception as e:
+            document_import_id: DocumentImportId = documents_batch[i][0]
+            logger.error(
+                f"failed to process document `{document_import_id}`: {e.__str__()}",
+            )
+            continue
+
+
+def get_vespa_search_adapter(
+    vespa_search_adapter: VespaSearchAdapter | None,
+) -> tuple[
+    ContextManager[str] | ContextManager[None],
+    VespaSearchAdapter,
+]:
+    """
+    Get a Vespa search adapter, if none provided.
+
+    It uses certs fetched, and then, saved to disk, if none was provided.
+    """
+    logger = get_run_logger()
+
+    # We want the directory used for the `VespaSearchAdapter` to be
+    # automatically cleaned up.
+    #
+    # To do this, we rely on the `tempfile.TemporaryDirectory`'s behaviour,
+    # or, a `contextlib.nullcontext` no-op, if a temporary directory
+    # wasn't needed.
+    if vespa_search_adapter is None:
+        logger.info("no Vespa search adapter, getting it from AWS secrets")
+        cm = tempfile.TemporaryDirectory()
+
+        vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
+            cert_dir=cm.name,  # type: ignore
+            vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
+            vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
+        )
+    else:
+        logger.info("Vespa search adapter provided")
+        cm = contextlib.nullcontext()
+
+    return cm, vespa_search_adapter
+
+
+async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
+    documents_batch: list[DocumentImporter],
+    documents_batch_num: int,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    aws_env: AwsEnv,
+    as_deployment: bool,
+) -> None:
+    """Run partial updates for a batch of documents as a sub-flow or deployment."""
+    logger = get_run_logger()
+    logger.info(
+        "Running partial updates of concepts for batch as sub-flow or deployment: "
+        f"batch length {len(documents_batch)}, as_deployment: {as_deployment}"
+    )
+
+    if as_deployment:
+        flow_name = function_to_flow_name(run_partial_updates_of_concepts_for_batch)
+        deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
+
+        return await run_deployment(
+            name=f"{flow_name}/{deployment_name}",
+            parameters={
+                "documents_batch": documents_batch,
+                "documents_batch_num": documents_batch_num,
+                "cache_bucket": cache_bucket,
+                "concepts_counts_prefix": concepts_counts_prefix,
+            },
+            timeout=3600,
+        )
+
+    return await run_partial_updates_of_concepts_for_batch(
+        documents_batch=documents_batch,
+        documents_batch_num=documents_batch_num,
+        cache_bucket=cache_bucket,
+        concepts_counts_prefix=concepts_counts_prefix,
+    )
+
+
+def iterate_batch(
+    data: list[T] | Generator[T, None, None],
+    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
+) -> Generator[list[T], None, None]:
+    """Generate batches from a list or generator with a specified size."""
+    if isinstance(data, list):
+        # For lists, we can use list slicing
+        for i in range(0, len(data), batch_size):
+            yield data[i : i + batch_size]
+    else:
+        # For generators, accumulate items until we reach batch size
+        batch: list[T] = []
+        for item in data:
+            batch.append(item)
+            if len(batch) >= batch_size:
+                yield batch
+                batch = []
+        if batch:  # Don't forget to yield the last partial batch
+            yield batch
+
+
+def s3_paths_or_s3_prefixes(
+    classifier_specs: list[ClassifierSpec] | None,
+    document_ids: list[str] | None,
+    cache_bucket: str,
+    prefix: str,
+) -> S3Accessor:
+    """
+    Return the paths or prefix for the documents and classifiers.
+
+    - s3_prefix: The S3 prefix (directory) to yield objects from. Example:
+      "s3://cpr-sandbox-data-pipeline-cache/labelled_passages"
+    - s3_paths: A list of S3 object keys to yield objects from. Example:
+      [
+        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json",
+        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.legislative.10695.6015.json",
+      ]
+    """
+    logger = get_run_logger()
+
+    match (classifier_specs, document_ids):
+        case (None, None):
+            # Run on all documents, regardless of classifier
+            logger.info("run on all documents, regardless of classifier")
+            s3_prefix: str = "s3://" + os.path.join(
+                cache_bucket,
+                prefix,
+            )
+            return S3Accessor(paths=None, prefixes=[s3_prefix])
+
+        case (list(), None):
+            # Run on all documents, for the specified classifier
+            logger.info("run on all documents, for the specified classifier")
+            s3_prefixes = [
+                "s3://"
+                + os.path.join(
+                    cache_bucket,
+                    prefix,
+                    classifier_spec.name,
+                    classifier_spec.alias,
+                )
+                for classifier_spec in classifier_specs
+            ]
+            return S3Accessor(paths=None, prefixes=s3_prefixes)
+
+        case (list(), list()):
+            # Run on specified documents, for the specified classifier
+            logger.info("run on specified documents, for the specified classifier")
+            document_paths = [
+                "s3://"
+                + os.path.join(
+                    cache_bucket,
+                    prefix,
+                    classifier_spec.name,
+                    classifier_spec.alias,
+                    f"{doc_id}.json",
+                )
+                for classifier_spec in classifier_specs
+                for doc_id in document_ids
+            ]
+            return S3Accessor(paths=document_paths, prefixes=None)
+
+        case (None, list()):
+            raise ValueError(
+                "if document IDs are specified, a classifier "
+                "specifcation must also be specified, since they're "
+                "namespaced by classifiers (e.g. "
+                "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
+                "v4/CCLW.legislative.10695.6015.json`)"
+            )
+
+
+def _s3_object_write_text(s3_uri: str, text: str) -> None:
+    """Write text content to an S3 object."""
+    # Parse the S3 URI
+    s3_path: Path = Path(s3_uri)
+    if len(s3_path.parts) < 3:
+        raise ValueError(f"Invalid S3 path: {s3_path}")
+
+    bucket: str = s3_path.parts[1]
+    key = str(Path(*s3_path.parts[2:]))
+
+    # Create BytesIO buffer with the text content
+    body = BytesIO(text.encode("utf-8"))
+
+    # Upload to S3
+    s3 = boto3.client("s3")
+    _ = s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+
+
+def s3_obj_generator_from_s3_prefixes(
+    s3_prefixes: list[str],
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """Return a generator that yields keys from a list of S3 prefixes."""
+    logger = get_logger()
+
+    for s3_prefix in s3_prefixes:
+        try:
+            # E.g. Path("s3://bucket/prefix/file.json").parts[1] == "bucket"
+            bucket = Path(s3_prefix).parts[1]
+            object_keys = _get_s3_keys_with_prefix(s3_prefix=s3_prefix)
+            for key in object_keys:
+                id: DocumentImportId = Path(key).stem
+                key: DocumentObjectUri = os.path.join("s3://", bucket, key)
+
+                yield id, key
+        except Exception as e:
+            logger.error(
+                f"failed to yield from S3 prefix. Error: {str(e)}",
+            )
+            continue
+
+
+def s3_obj_generator_from_s3_paths(
+    s3_paths: list[str],
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """
+    Return a generator that yields keys from a list of S3 paths.
+
+    We extract the key from the S3 path by removing the first two
+    elements in the path.
+
+    E.g. "s3://bucket/prefix/file.json" -> "prefix/file.json"
+    """
+    logger = get_logger()
+    for s3_path in s3_paths:
+        try:
+            id: DocumentImportId = Path(s3_path).stem
+            uri: DocumentObjectUri = s3_path
+            yield id, uri
+        except Exception as e:
+            logger.error(
+                f"failed to yield from S3 path. Error: {str(e)}",
+            )
+            continue
+
+
+def s3_obj_generator(
+    s3_prefixes: list[str] | None,
+    s3_paths: list[str] | None,
+) -> Generator[
+    DocumentImporter,
+    None,
+    None,
+]:
+    """
+    Return a generator that returns S3 objects for each path or prefix.
+
+    These will be for each output from the inference stage, of
+    labelled passages.
+    """
+    logger = get_run_logger()
+
+    match (s3_prefixes, s3_paths):
+        case (list(), list()):
+            raise ValueError(
+                "Either s3_prefixes or s3_paths must be provided, not both."
+            )
+        case (list(), None):
+            logger.info("S3 object generator: prefixes")
+            return s3_obj_generator_from_s3_prefixes(s3_prefixes=s3_prefixes)
+        case (None, list()):
+            logger.info("S3 object generator: paths")
+            return s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
+        case (None, None):
+            raise ValueError("Either s3_prefix or s3_paths must be provided.")
+
+
+@flow
+async def deindex_by_s3(
+    aws_env: AwsEnv,
+    cache_bucket: str,
+    concepts_counts_prefix: str,
+    vespa_search_adapter: VespaSearchAdapter | None,
+    s3_prefixes: list[str] | None = None,
+    s3_paths: list[str] | None = None,
+    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
+    indexing_task_batch_size: int = DEFAULT_INDEXING_TASK_BATCH_SIZE,
+    as_deployment: bool = True,
+) -> None:
+    """
+    Asynchronously index concepts from S3 files into Vespa.
+
+    This function retrieves concept documents from files stored in an S3 path and
+    indexes them in a Vespa instance. The name of each file in the specified S3 path is
+    expected to represent the document's import ID.
+
+    When `s3_prefix` is provided, the function will index all files within that S3
+    prefix (directory). When `s3_paths` is provided, the function will index only the
+    files specified in the list of S3 object keys. If both are provided `s3_paths` will
+    be used.
+
+    Assumptions:
+    - The S3 file names represent document import IDs.
+
+    params:
+    - s3_prefix: The S3 prefix (directory) to yield objects from.
+        E.g. "s3://bucket/prefix/"
+    - s3_paths: A list of S3 object keys to yield objects from.
+        E.g. {"s3://bucket/prefix/file1.json", "s3://bucket/prefix/file2.json"}
+    - vespa_search_adapter: An instance of VespaSearchAdapter.
+        E.g. VespaSearchAdapter(
+            instance_url="https://vespa-instance-url.com",
+            cert_directory="certs/"
+        )
+    """
+    logger = get_run_logger()
+
+    cm, vespa_search_adapter = get_vespa_search_adapter(vespa_search_adapter)
+
+    with cm:
+        logger.info("Getting S3 object generator")
+        documents_generator = s3_obj_generator(s3_prefixes, s3_paths)
+        documents_batches = iterate_batch(documents_generator, batch_size=batch_size)
+        indexing_task_batches = iterate_batch(
+            data=documents_batches, batch_size=indexing_task_batch_size
+        )
+
+        for i, indexing_task_batch in enumerate(indexing_task_batches, start=1):
+            logger.info(f"Processing indexing task batch #{i}")
+
+            indexing_tasks = [
+                run_partial_updates_of_concepts_for_batch_flow_or_deployment(
+                    documents_batch=documents_batch,
+                    documents_batch_num=documents_batch_num,
+                    cache_bucket=cache_bucket,
+                    concepts_counts_prefix=concepts_counts_prefix,
+                    aws_env=aws_env,
+                    as_deployment=as_deployment,
+                )
+                for documents_batch_num, documents_batch in enumerate(
+                    indexing_task_batch, start=1
+                )
+            ]
+
+            logger.info(f"Gathering indexing tasks for batch #{i}")
+            results = await asyncio.gather(*indexing_tasks, return_exceptions=True)
+            logger.info(f"Gathered indexing tasks for batch #{i}")
+
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.error(
+                        f"failed to process document batch in indexing task batch #{i}: {str(result)}",
+                    )
+                    continue
+
+
+@flow(
+    on_failure=[SlackNotify.message],
+    on_crashed=[SlackNotify.message],
+)
+async def deindex_labelled_passages_from_s3_to_vespa(
+    classifier_specs: list[ClassifierSpec],
+    document_ids: list[str] | None = None,
+    config: Config | None = None,
+    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
+    indexing_task_batch_size: int = DEFAULT_INDEXING_TASK_BATCH_SIZE,
+) -> None:
+    """
+    Asynchronously de-index concepts from S3 into Vespa.
+
+    This function retrieves inference results of concepts in documents
+    from S3, "undoes" them in a Vespa instance, and deletes the
+    appropriate objects from S3.
+
+    The undoing is relative to the doing in the index pipeline. It's
+    resilient to de-indexing per document failing, so that it can be
+    retried.
+
+    The name of each file in the specified S3 path is expected to
+    represent the document's import ID.
+    """
+    logger = get_run_logger()
+
+    if not config:
+        logger.info("no config provided, creating one")
+
+        config = await Config.create()
+    else:
+        logger.info("config provided")
+    assert config.cache_bucket
+
+    logger.info(f"running with config: {config}")
+
+    logger.info(f"running with classifier specs: {classifier_specs}")
+
+    s3_accessor = s3_paths_or_s3_prefixes(
+        classifier_specs,
+        document_ids,
+        config.cache_bucket,
+        config.document_source_prefix,
+    )
+
+    logger.info(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
+
+    await deindex_by_s3(
+        aws_env=config.aws_env,
+        vespa_search_adapter=config.vespa_search_adapter,
+        s3_prefixes=s3_accessor.prefixes,
+        s3_paths=s3_accessor.paths,
+        batch_size=batch_size,
+        indexing_task_batch_size=indexing_task_batch_size,
+        as_deployment=config.as_deployment,
+        cache_bucket=config.cache_bucket,
+        concepts_counts_prefix=config.concepts_counts_prefix,
+    )

--- a/flows/deindex.py
+++ b/flows/deindex.py
@@ -1,79 +1,45 @@
 import asyncio
-import base64
-import contextlib
 import json
 import os
-import re
-import tempfile
 from collections import Counter
-from collections.abc import Generator
 from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
-from typing import Any, ContextManager, TypeAlias, TypeVar
+from typing import Any
 
 import boto3
-import vespa.querybuilder as qb
 from cpr_sdk.models.search import Concept as VespaConcept
-from cpr_sdk.models.search import Document as VespaDocument
 from cpr_sdk.models.search import Passage as VespaPassage
-from cpr_sdk.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 from cpr_sdk.search_adaptors import VespaSearchAdapter
-from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
-from prefect.deployments.deployments import run_deployment
-from prefect.logging import get_logger, get_run_logger
-from pydantic import BaseModel
-from vespa.io import VespaQueryResponse, VespaResponse
+from prefect.logging import get_run_logger
 
+from flows.boundary import (
+    ConceptModel,
+    DocumentImporter,
+    DocumentObjectUri,
+    TextBlockId,
+    convert_labelled_passage_to_concepts,
+    get_vespa_search_adapter,
+    index_by_s3,
+    load_labelled_passages_by_uri,
+    partial_update_text_block,
+    s3_object_write_text,
+    s3_paths_or_s3_prefixes,
+)
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
-from flows.utils import SlackNotify
+from flows.utils import SlackNotify, iterate_batch
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
-    function_to_flow_name,
-    generate_deployment_name,
     get_prefect_job_variable,
 )
-from src.concept import Concept
-from src.exceptions import PartialUpdateError, QueryError
 from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
 DEFAULT_DOCUMENTS_BATCH_SIZE = 500
 DEFAULT_INDEXING_TASK_BATCH_SIZE = 20
-HTTP_OK = 200
 CONCEPTS_COUNTS_PREFIX_DEFAULT: str = "concepts_counts"
-CONCEPT_COUNT_SEPARATOR: str = ":"
-
-# Needed to get document passages from Vespa
-# Example: CCLW.executive.1813.2418
-DocumentImportId: TypeAlias = str
-# Needed to load the inference results
-# Example: s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json
-DocumentObjectUri: TypeAlias = str
-# Passed to a self-sufficient flow run
-DocumentImporter: TypeAlias = tuple[DocumentImportId, DocumentObjectUri]
-
-
-class S3Accessor(BaseModel):
-    """Representing S3 paths and prefixes for accessing documents."""
-
-    paths: list[str] | None = None
-    prefixes: list[str] | None = None
-
-
-# AKA LabelledPassage
-TextBlockId: TypeAlias = str
-SpanId: TypeAlias = str
-# The ID used in Vespa, that we don't keep in our models in the CPR
-# SDK, that is in a Hit.
-VespaHitId: TypeAlias = str
-# The same as above, but without the schema
-VespaDataId: TypeAlias = str
-
-T = TypeVar("T")
 
 
 @dataclass()
@@ -114,136 +80,6 @@ class Config:
         return config
 
 
-class ConceptModel(BaseModel):
-    """
-    A concept and the model used to identify it.
-
-    This class represents a pairing of a Wikibase concept ID with the name of the model
-    used to identify that concept in text. It is hashable to allow use in sets and as
-    dictionary keys.
-
-    Attributes:
-        wikibase_id: The Wikibase ID of the concept
-        model_name: The name of the model used to identify the concept
-
-    Example:
-        >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
-        ...                     model_name='KeywordClassifier("professional services sector")')
-        >>> str(model)
-        'Q123:KeywordClassifier("professional services sector")'
-    """
-
-    wikibase_id: WikibaseID
-    model_name: str
-
-    def __str__(self) -> str:
-        """
-        Convert the ConceptModel to a string in the format 'WIKIBASE_ID:MODEL_NAME'.
-
-        Returns:
-            str: String representation in the format 'WIKIBASE_ID:MODEL_NAME'
-        """
-        return f"{self.wikibase_id}{CONCEPT_COUNT_SEPARATOR}{self.concept_name}"
-
-    def __hash__(self) -> int:
-        """
-        Generate a hash value for the ConceptModel.
-
-        The hash is based on both the wikibase_id and model_name to ensure
-        uniqueness when used in sets or as dictionary keys.
-
-        Returns:
-            int: Hash value of the ConceptModel
-        """
-        return hash((self.wikibase_id, self.model_name))
-
-    def __eq__(self, other: object) -> bool:
-        """
-        Compare this ConceptModel with another for equality.
-
-        Two ConceptModels are equal if they have the same wikibase_id and model_name.
-
-        Args:
-            other: The object to compare with
-
-        Returns:
-            bool: True if the objects are equal, False otherwise
-        """
-        if not isinstance(other, ConceptModel):
-            return NotImplemented
-        return (
-            self.wikibase_id == other.wikibase_id
-            and self.model_name == other.model_name
-        )
-
-    @property
-    def concept_name(self) -> str:
-        """
-        Extract the concept name from the model name.
-
-        Examples:
-            >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
-            ...                     model_name='KeywordClassifier("professional services sector")')
-            >>> model.concept_name
-            'professional services sector'
-            >>> model2 = ConceptModel(wikibase_id=WikibaseID("Q456"),
-            ...                      model_name='LLMClassifier("agriculture")')
-            >>> model2.concept_name
-            'agriculture'
-            >>> model3 = ConceptModel(wikibase_id=WikibaseID("Q789"),
-            ...                      model_name='InvalidModelName')
-            >>> model3.concept_name  # doctest: +IGNORE_EXCEPTION_DETAIL
-            Traceback (most recent call last):
-                ...
-            ValueError: Could not extract concept name from model name 'InvalidModelName'
-        """
-        match = re.search(r'"([^"]+)"', self.model_name)
-        if match:
-            return match.group(1)
-
-        raise ValueError(
-            f"Could not extract concept name from model name '{self.model_name}'"
-        )
-
-
-def get_vespa_search_adapter_from_aws_secrets(
-    cert_dir: str,
-    vespa_instance_url_param_name: str = "VESPA_INSTANCE_URL",
-    vespa_public_cert_param_name: str = "VESPA_PUBLIC_CERT_READ",
-    vespa_private_key_param_name: str = "VESPA_PRIVATE_KEY_READ",
-) -> VespaSearchAdapter:
-    """
-    Get a VespaSearchAdapter instance by retrieving secrets from AWS Secrets Manager.
-
-    We then save the secrets to local files in the cert_dir directory and instantiate
-    the VespaSearchAdapter.
-    """
-    cert_dir_path = Path(cert_dir)
-    if not cert_dir_path.exists():
-        raise FileNotFoundError(f"Certificate directory does not exist: {cert_dir}")
-
-    vespa_instance_url = get_aws_ssm_param(vespa_instance_url_param_name)
-    vespa_public_cert_encoded = get_aws_ssm_param(vespa_public_cert_param_name)
-    vespa_private_key_encoded = get_aws_ssm_param(vespa_private_key_param_name)
-
-    vespa_public_cert = base64.b64decode(vespa_public_cert_encoded).decode("utf-8")
-    vespa_private_key = base64.b64decode(vespa_private_key_encoded).decode("utf-8")
-
-    cert_path = cert_dir_path / "cert.pem"
-    key_path = cert_dir_path / "key.pem"
-
-    with open(cert_path, "w", encoding="utf-8") as f:
-        _ = f.write(vespa_public_cert)
-
-    with open(key_path, "w", encoding="utf-8") as f:
-        _ = f.write(vespa_private_key)
-
-    return VespaSearchAdapter(
-        instance_url=vespa_instance_url,
-        cert_directory=str(cert_dir_path),
-    )
-
-
 def save_labelled_passages_by_uri(
     document_object_uri: DocumentObjectUri,
     labelled_passages: list[LabelledPassage],
@@ -253,191 +89,13 @@ def save_labelled_passages_by_uri(
         [labelled_passage.model_dump_json() for labelled_passage in labelled_passages]
     )
 
-    _ = _s3_object_write_text(
+    _ = s3_object_write_text(
         s3_uri=document_object_uri,
         text=object_json,
     )
 
 
-def get_model_from_span(span: Span) -> str:
-    """
-    Get the model used to label the span.
-
-    Labellers are stored in a list, these can contain many labellers as seen in the
-    example below, referring to human and machine annotators.
-
-    [
-        "alice",
-        "bob",
-        "68edec6f-fe74-413d-9cf1-39b1c3dad2c0",
-        'KeywordClassifier("extreme weather")',
-    ]
-
-    In the context of inference the labellers array should only hold the model used to
-    label the span as seen in the example below.
-
-    [
-        'KeywordClassifier("extreme weather")',
-    ]
-    """
-    if len(span.labellers) != 1:
-        raise ValueError(
-            f"Span has more than one labeller. Expected 1, got {len(span.labellers)}."
-        )
-    return span.labellers[0]
-
-
-def get_data_id_from_vespa_hit_id(hit_id: VespaHitId) -> VespaDataId:
-    """
-    Extract non-schema namespaced ID (last element after "::")
-
-    Example:
-    "CCLW.executive.10014.4470.623" from document passage ID like
-    "id:doc_search:document_passage::CCLW.executive.10014.4470.623".
-    """
-    splits = hit_id.split("::")
-    if len(splits) != 2:
-        raise ValueError(f"received {len(splits)} splits, when expecting 2: {splits}")
-    return splits[1]
-
-
-def get_document_passages_from_vespa(
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-) -> list[tuple[VespaHitId, VespaPassage]]:
-    """
-    Retrieve all the passages for a document in Vespa.
-
-    params:
-    - document_import_id: The document import id for a unique family document.
-    """
-    logger = get_logger()
-
-    logger.info(f"Getting document passages from Vespa: {document_import_id}")
-
-    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
-        yql=(
-            # trunk-ignore(bandit/B608)
-            "select * from document_passage where family_document_ref contains "
-            f'"id:doc_search:family_document::{document_import_id}"'
-        )
-    )
-
-    if (status_code := vespa_query_response.get_status_code()) != HTTP_OK:
-        raise QueryError(status_code)
-
-    logger.info(
-        (
-            f"Vespa search response for document: {document_import_id} "
-            f"with {len(vespa_query_response.hits)} hits"
-        )
-    )
-
-    return [
-        (passage["id"], VespaPassage.model_validate(passage["fields"]))
-        for passage in vespa_query_response.hits
-    ]
-
-
-def get_document_passage_from_vespa(
-    text_block_id: str,
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-) -> tuple[VespaHitId, VespaPassage]:
-    """Retrieve a passage for a document in Vespa."""
-    logger = get_logger()
-
-    logger.info(
-        f"Getting document passage from Vespa: {document_import_id}, text block: {text_block_id}"
-    )
-
-    condition = qb.QueryField("family_document_ref").contains(
-        f"id:doc_search:family_document::{document_import_id}"
-    ) & qb.QueryField("text_block_id").contains(text_block_id)
-
-    yql = (
-        qb.select("*")  # pyright:ignore[reportAttributeAccessIssue]
-        .from_("document_passage")
-        .where(condition)
-    )
-
-    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
-        yql=yql
-    )
-
-    if not vespa_query_response.is_successful():
-        raise QueryError(vespa_query_response.get_status_code())
-    if len(vespa_query_response.hits) != 1:
-        raise ValueError(
-            f"Expected 1 document passage for text block `{text_block_id}` and document `{document_import_id}`, got {len(vespa_query_response.hits)}"
-        )
-
-    logger.info(
-        (
-            f"Vespa search response for document: {document_import_id} "
-            f"with {len(vespa_query_response.hits)} hits"
-        )
-    )
-
-    hit = vespa_query_response.hits[0]
-    passage_id = hit["id"]
-    passage = VespaPassage.model_validate(hit["fields"])
-
-    return passage_id, passage
-
-
-def get_document_from_vespa(
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-) -> tuple[VespaHitId, VespaDocument]:
-    """Retrieve a passage for a document in Vespa."""
-    logger = get_logger()
-
-    logger.info(f"Getting document from Vespa: `{document_import_id}`")
-
-    condition = qb.QueryField("document_import_id").contains(document_import_id)
-
-    yql = (
-        qb.select("*")  # pyright:ignore[reportAttributeAccessIssue]
-        .from_("family_document")
-        .where(condition)
-    )
-
-    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
-        yql=yql
-    )
-
-    if not vespa_query_response.is_successful():
-        raise QueryError(vespa_query_response.get_status_code())
-    if len(vespa_query_response.hits) != 1:
-        raise ValueError(
-            f"Expected 1 document `{document_import_id}`, got {len(vespa_query_response.hits)}"
-        )
-
-    logger.info(
-        (
-            f"Vespa search response for document: {document_import_id} "
-            f"with {len(vespa_query_response.hits)} hits"
-        )
-    )
-
-    hit = vespa_query_response.hits[0]
-    document_id = hit["id"]
-    document = VespaDocument.model_validate(hit["fields"])
-
-    return document_id, document
-
-
-def load_labelled_passages_by_uri(
-    document_object_uri: DocumentObjectUri,
-) -> list[LabelledPassage]:
-    """Load and transforms the S3 object's body into LabelledPassages objects."""
-    object_json = json.loads(_s3_object_read_text(s3_path=document_object_uri))
-
-    return [LabelledPassage(**labelled_passage) for labelled_passage in object_json]
-
-
-def get_updated_passage_concepts(
+def remove_concepts_from_existing_vespa_concepts(
     passage: VespaPassage,
     concepts_to_remove: list[VespaConcept],
 ) -> list[dict[str, Any]]:
@@ -470,7 +128,7 @@ def get_updated_passage_concepts(
 
 
 @flow
-async def run_partial_updates_of_concepts_for_document_passages(
+async def run_partial_updates_of_concepts_for_document_passages__removal(
     document_importer: DocumentImporter,
     cache_bucket: str,
     concepts_counts_prefix: str,
@@ -526,6 +184,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
                     document_import_id=document_importer[0],
                     concepts=concepts,
                     vespa_search_adapter=vespa_search_adapter,
+                    update_function=remove_concepts_from_existing_vespa_concepts,
                 )
                 for text_block_id, concepts in batch
             ]
@@ -701,7 +360,7 @@ def update_s3_with_some_successes(
 
     concepts_counts_uri = f"s3://{cache_bucket}/{concepts_counts_prefix}/{key_parts}"
 
-    _ = _s3_object_write_text(
+    _ = s3_object_write_text(
         s3_uri=concepts_counts_uri,
         text=serialised_concepts_counts,
     )
@@ -739,510 +398,6 @@ def update_s3_with_some_successes(
     logger.info("updated S3 with partial successes")
 
     return None
-
-
-def get_parent_concepts_from_concept(
-    concept: Concept,
-) -> tuple[list[dict], str]:
-    """
-    Extract parent concepts from a Concept object.
-
-    Currently we pull the name from the Classifier used to label the passage, this
-    doesn't hold the concept id. This is a temporary solution that is not desirable as
-    the relationship between concepts can change frequently and thus shouldn't be
-    coupled with inference.
-    """
-    parent_concepts = [
-        {"id": subconcept, "name": ""} for subconcept in concept.subconcept_of
-    ]
-    parent_concept_ids_flat = (
-        ",".join([parent_concept["id"] for parent_concept in parent_concepts]) + ","
-    )
-
-    return parent_concepts, parent_concept_ids_flat
-
-
-def convert_labelled_passage_to_concepts(
-    labelled_passage: LabelledPassage,
-) -> list[VespaConcept]:
-    """
-    Convert a labelled passage to a list of VespaConcept objects and their text block ID.
-
-    The labelled passage contains a list of spans relating to concepts
-    that we must convert to VespaConcept objects.
-    """
-    logger = get_run_logger()
-
-    concepts: list[VespaConcept] = []
-
-    # The concept used to label the passage holds some information on the parent
-    # concepts and thus this is being used as a temporary solution for providing
-    # the relationship between concepts. This has the downside that it ties a
-    # labelled passage to a particular concept when in fact the Spans that a
-    # labelled passage has can be labelled by multiple concepts.
-    concept = Concept.model_validate(labelled_passage.metadata["concept"])
-    parent_concepts, parent_concept_ids_flat = get_parent_concepts_from_concept(
-        concept=concept
-    )
-
-    # This expands the list from `n` for `LabelledPassages` to `n` for `Spans`
-    for span_idx, span in enumerate(labelled_passage.spans):
-        if span.concept_id is None:
-            # Include the Span index since Span's don't have IDs
-            logger.error(
-                f"span concept ID is missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
-            )
-            continue
-
-        if not span.timestamps:
-            logger.error(
-                f"span timestamps are missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
-            )
-            continue
-
-        concepts.append(
-            VespaConcept(
-                id=span.concept_id,
-                name=concept.preferred_label,
-                parent_concepts=parent_concepts,
-                parent_concept_ids_flat=parent_concept_ids_flat,
-                model=get_model_from_span(span),
-                end=span.end_index,
-                start=span.start_index,
-                # These timestamps _should_ all be the same,
-                # but just in case, take the latest.
-                timestamp=max(span.timestamps),
-            )
-        )
-
-    return concepts
-
-
-async def partial_update_text_block(
-    text_block_id: TextBlockId,
-    document_import_id: DocumentImportId,
-    concepts: list[VespaConcept],  # A possibly empty list
-    vespa_search_adapter: VespaSearchAdapter,
-) -> None:
-    """Partial update a singular text block and its concepts, if any."""
-    document_passage_id, document_passage = get_document_passage_from_vespa(
-        text_block_id, document_import_id, vespa_search_adapter
-    )
-
-    data_id = get_data_id_from_vespa_hit_id(document_passage_id)
-
-    serialised_concepts = get_updated_passage_concepts(
-        passage=document_passage,
-        concepts_to_remove=concepts,
-    )
-
-    response: VespaResponse = vespa_search_adapter.client.update_data(  # pyright: ignore[reportOptionalMemberAccess]
-        schema="document_passage",
-        namespace="doc_search",
-        data_id=data_id,
-        fields={"concepts": serialised_concepts},
-    )
-
-    if (status_code := response.get_status_code()) != HTTP_OK:
-        raise PartialUpdateError(data_id, status_code)
-
-    return None
-
-
-@flow
-async def run_partial_updates_of_concepts_for_batch(
-    documents_batch: list[DocumentImporter],
-    documents_batch_num: int,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-) -> None:
-    """Run partial updates for concepts in a batch of documents."""
-
-    logger = get_run_logger()
-    logger.info(
-        f"Updating concepts for batch of documents, documents in batch: {len(documents_batch)}."
-    )
-    for i, document_importer in enumerate(documents_batch):
-        try:
-            _ = await run_partial_updates_of_concepts_for_document_passages(
-                document_importer=document_importer,
-                cache_bucket=cache_bucket,
-                concepts_counts_prefix=concepts_counts_prefix,
-            )
-
-            logger.info(f"processed batch documents #{documents_batch_num}")
-
-        except Exception as e:
-            document_import_id: DocumentImportId = documents_batch[i][0]
-            logger.error(
-                f"failed to process document `{document_import_id}`: {e.__str__()}",
-            )
-            continue
-
-
-def get_vespa_search_adapter(
-    vespa_search_adapter: VespaSearchAdapter | None,
-) -> tuple[
-    ContextManager[str] | ContextManager[None],
-    VespaSearchAdapter,
-]:
-    """
-    Get a Vespa search adapter, if none provided.
-
-    It uses certs fetched, and then, saved to disk, if none was provided.
-    """
-    logger = get_run_logger()
-
-    # We want the directory used for the `VespaSearchAdapter` to be
-    # automatically cleaned up.
-    #
-    # To do this, we rely on the `tempfile.TemporaryDirectory`'s behaviour,
-    # or, a `contextlib.nullcontext` no-op, if a temporary directory
-    # wasn't needed.
-    if vespa_search_adapter is None:
-        logger.info("no Vespa search adapter, getting it from AWS secrets")
-        cm = tempfile.TemporaryDirectory()
-
-        vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
-            cert_dir=cm.name,  # type: ignore
-            vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
-            vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
-        )
-    else:
-        logger.info("Vespa search adapter provided")
-        cm = contextlib.nullcontext()
-
-    return cm, vespa_search_adapter
-
-
-async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
-    documents_batch: list[DocumentImporter],
-    documents_batch_num: int,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-    aws_env: AwsEnv,
-    as_deployment: bool,
-) -> None:
-    """Run partial updates for a batch of documents as a sub-flow or deployment."""
-    logger = get_run_logger()
-    logger.info(
-        "Running partial updates of concepts for batch as sub-flow or deployment: "
-        f"batch length {len(documents_batch)}, as_deployment: {as_deployment}"
-    )
-
-    if as_deployment:
-        flow_name = function_to_flow_name(run_partial_updates_of_concepts_for_batch)
-        deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
-
-        return await run_deployment(
-            name=f"{flow_name}/{deployment_name}",
-            parameters={
-                "documents_batch": documents_batch,
-                "documents_batch_num": documents_batch_num,
-                "cache_bucket": cache_bucket,
-                "concepts_counts_prefix": concepts_counts_prefix,
-            },
-            timeout=3600,
-        )
-
-    return await run_partial_updates_of_concepts_for_batch(
-        documents_batch=documents_batch,
-        documents_batch_num=documents_batch_num,
-        cache_bucket=cache_bucket,
-        concepts_counts_prefix=concepts_counts_prefix,
-    )
-
-
-def iterate_batch(
-    data: list[T] | Generator[T, None, None],
-    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
-) -> Generator[list[T], None, None]:
-    """Generate batches from a list or generator with a specified size."""
-    if isinstance(data, list):
-        # For lists, we can use list slicing
-        for i in range(0, len(data), batch_size):
-            yield data[i : i + batch_size]
-    else:
-        # For generators, accumulate items until we reach batch size
-        batch: list[T] = []
-        for item in data:
-            batch.append(item)
-            if len(batch) >= batch_size:
-                yield batch
-                batch = []
-        if batch:  # Don't forget to yield the last partial batch
-            yield batch
-
-
-def s3_paths_or_s3_prefixes(
-    classifier_specs: list[ClassifierSpec] | None,
-    document_ids: list[str] | None,
-    cache_bucket: str,
-    prefix: str,
-) -> S3Accessor:
-    """
-    Return the paths or prefix for the documents and classifiers.
-
-    - s3_prefix: The S3 prefix (directory) to yield objects from. Example:
-      "s3://cpr-sandbox-data-pipeline-cache/labelled_passages"
-    - s3_paths: A list of S3 object keys to yield objects from. Example:
-      [
-        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json",
-        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.legislative.10695.6015.json",
-      ]
-    """
-    logger = get_run_logger()
-
-    match (classifier_specs, document_ids):
-        case (None, None):
-            # Run on all documents, regardless of classifier
-            logger.info("run on all documents, regardless of classifier")
-            s3_prefix: str = "s3://" + os.path.join(
-                cache_bucket,
-                prefix,
-            )
-            return S3Accessor(paths=None, prefixes=[s3_prefix])
-
-        case (list(), None):
-            # Run on all documents, for the specified classifier
-            logger.info("run on all documents, for the specified classifier")
-            s3_prefixes = [
-                "s3://"
-                + os.path.join(
-                    cache_bucket,
-                    prefix,
-                    classifier_spec.name,
-                    classifier_spec.alias,
-                )
-                for classifier_spec in classifier_specs
-            ]
-            return S3Accessor(paths=None, prefixes=s3_prefixes)
-
-        case (list(), list()):
-            # Run on specified documents, for the specified classifier
-            logger.info("run on specified documents, for the specified classifier")
-            document_paths = [
-                "s3://"
-                + os.path.join(
-                    cache_bucket,
-                    prefix,
-                    classifier_spec.name,
-                    classifier_spec.alias,
-                    f"{doc_id}.json",
-                )
-                for classifier_spec in classifier_specs
-                for doc_id in document_ids
-            ]
-            return S3Accessor(paths=document_paths, prefixes=None)
-
-        case (None, list()):
-            raise ValueError(
-                "if document IDs are specified, a classifier "
-                "specifcation must also be specified, since they're "
-                "namespaced by classifiers (e.g. "
-                "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
-                "v4/CCLW.legislative.10695.6015.json`)"
-            )
-
-
-def _s3_object_write_text(s3_uri: str, text: str) -> None:
-    """Write text content to an S3 object."""
-    # Parse the S3 URI
-    s3_path: Path = Path(s3_uri)
-    if len(s3_path.parts) < 3:
-        raise ValueError(f"Invalid S3 path: {s3_path}")
-
-    bucket: str = s3_path.parts[1]
-    key = str(Path(*s3_path.parts[2:]))
-
-    # Create BytesIO buffer with the text content
-    body = BytesIO(text.encode("utf-8"))
-
-    # Upload to S3
-    s3 = boto3.client("s3")
-    _ = s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
-
-
-def _s3_object_write_bytes(s3_uri: str, bytes: BytesIO) -> None:
-    """Write text content to an S3 object."""
-    # Parse the S3 URI
-    s3_path: Path = Path(s3_uri)
-    if len(s3_path.parts) < 3:
-        raise ValueError(f"Invalid S3 path: {s3_path}")
-
-    bucket: str = s3_path.parts[1]
-    key = str(Path(*s3_path.parts[2:]))
-
-    # Upload to S3
-    s3 = boto3.client("s3")
-    _ = s3.put_object(
-        Bucket=bucket, Key=key, Body=bytes, ContentType="application/json"
-    )
-
-
-def s3_obj_generator_from_s3_prefixes(
-    s3_prefixes: list[str],
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """Return a generator that yields keys from a list of S3 prefixes."""
-    logger = get_logger()
-
-    for s3_prefix in s3_prefixes:
-        try:
-            # E.g. Path("s3://bucket/prefix/file.json").parts[1] == "bucket"
-            bucket = Path(s3_prefix).parts[1]
-            object_keys = _get_s3_keys_with_prefix(s3_prefix=s3_prefix)
-            for key in object_keys:
-                id: DocumentImportId = Path(key).stem
-                key: DocumentObjectUri = os.path.join("s3://", bucket, key)
-
-                yield id, key
-        except Exception as e:
-            logger.error(
-                f"failed to yield from S3 prefix. Error: {str(e)}",
-            )
-            continue
-
-
-def s3_obj_generator_from_s3_paths(
-    s3_paths: list[str],
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """
-    Return a generator that yields keys from a list of S3 paths.
-
-    We extract the key from the S3 path by removing the first two
-    elements in the path.
-
-    E.g. "s3://bucket/prefix/file.json" -> "prefix/file.json"
-    """
-    logger = get_logger()
-    for s3_path in s3_paths:
-        try:
-            id: DocumentImportId = Path(s3_path).stem
-            uri: DocumentObjectUri = s3_path
-            yield id, uri
-        except Exception as e:
-            logger.error(
-                f"failed to yield from S3 path. Error: {str(e)}",
-            )
-            continue
-
-
-def s3_obj_generator(
-    s3_prefixes: list[str] | None,
-    s3_paths: list[str] | None,
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """
-    Return a generator that returns S3 objects for each path or prefix.
-
-    These will be for each output from the inference stage, of
-    labelled passages.
-    """
-    logger = get_run_logger()
-
-    match (s3_prefixes, s3_paths):
-        case (list(), list()):
-            raise ValueError(
-                "Either s3_prefixes or s3_paths must be provided, not both."
-            )
-        case (list(), None):
-            logger.info("S3 object generator: prefixes")
-            return s3_obj_generator_from_s3_prefixes(s3_prefixes=s3_prefixes)
-        case (None, list()):
-            logger.info("S3 object generator: paths")
-            return s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
-        case (None, None):
-            raise ValueError("Either s3_prefix or s3_paths must be provided.")
-
-
-@flow
-async def deindex_by_s3(
-    aws_env: AwsEnv,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-    vespa_search_adapter: VespaSearchAdapter | None,
-    s3_prefixes: list[str] | None = None,
-    s3_paths: list[str] | None = None,
-    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
-    indexing_task_batch_size: int = DEFAULT_INDEXING_TASK_BATCH_SIZE,
-    as_deployment: bool = True,
-) -> None:
-    """
-    Asynchronously index concepts from S3 files into Vespa.
-
-    This function retrieves concept documents from files stored in an S3 path and
-    indexes them in a Vespa instance. The name of each file in the specified S3 path is
-    expected to represent the document's import ID.
-
-    When `s3_prefix` is provided, the function will index all files within that S3
-    prefix (directory). When `s3_paths` is provided, the function will index only the
-    files specified in the list of S3 object keys. If both are provided `s3_paths` will
-    be used.
-
-    Assumptions:
-    - The S3 file names represent document import IDs.
-
-    params:
-    - s3_prefix: The S3 prefix (directory) to yield objects from.
-        E.g. "s3://bucket/prefix/"
-    - s3_paths: A list of S3 object keys to yield objects from.
-        E.g. {"s3://bucket/prefix/file1.json", "s3://bucket/prefix/file2.json"}
-    - vespa_search_adapter: An instance of VespaSearchAdapter.
-        E.g. VespaSearchAdapter(
-            instance_url="https://vespa-instance-url.com",
-            cert_directory="certs/"
-        )
-    """
-    logger = get_run_logger()
-
-    cm, vespa_search_adapter = get_vespa_search_adapter(vespa_search_adapter)
-
-    with cm:
-        logger.info("Getting S3 object generator")
-        documents_generator = s3_obj_generator(s3_prefixes, s3_paths)
-        documents_batches = iterate_batch(documents_generator, batch_size=batch_size)
-        indexing_task_batches = iterate_batch(
-            data=documents_batches, batch_size=indexing_task_batch_size
-        )
-
-        for i, indexing_task_batch in enumerate(indexing_task_batches, start=1):
-            logger.info(f"Processing indexing task batch #{i}")
-
-            indexing_tasks = [
-                run_partial_updates_of_concepts_for_batch_flow_or_deployment(
-                    documents_batch=documents_batch,
-                    documents_batch_num=documents_batch_num,
-                    cache_bucket=cache_bucket,
-                    concepts_counts_prefix=concepts_counts_prefix,
-                    aws_env=aws_env,
-                    as_deployment=as_deployment,
-                )
-                for documents_batch_num, documents_batch in enumerate(
-                    indexing_task_batch, start=1
-                )
-            ]
-
-            logger.info(f"Gathering indexing tasks for batch #{i}")
-            results = await asyncio.gather(*indexing_tasks, return_exceptions=True)
-            logger.info(f"Gathered indexing tasks for batch #{i}")
-
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.error(
-                        f"failed to process document batch in indexing task batch #{i}: {str(result)}",
-                    )
-                    continue
 
 
 @flow(
@@ -1293,7 +448,8 @@ async def deindex_labelled_passages_from_s3_to_vespa(
 
     logger.info(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
 
-    await deindex_by_s3(
+    await index_by_s3(
+        partial_update_flow=run_partial_updates_of_concepts_for_document_passages__removal,
         aws_env=config.aws_env,
         vespa_search_adapter=config.vespa_search_adapter,
         s3_prefixes=s3_accessor.prefixes,

--- a/flows/deindex.py
+++ b/flows/deindex.py
@@ -451,7 +451,6 @@ def get_updated_passage_concepts(
     It is also, not possible to duplicate a Concept object in the concepts array as we
     are removing all instances where the model is the same.
     """
-
     # Get the models to remove
     concepts_to_remove__models = [concept.model for concept in concepts_to_remove]
 
@@ -554,6 +553,8 @@ def calculate_concepts_counts_from_results(
     results: list[BaseException | None],
     batch: list[tuple[TextBlockId, list[VespaConcept]]],
 ) -> Counter[ConceptModel]:
+    logger = get_run_logger()
+
     # This can handle multiple concepts, but, in practice at the
     # moment, this function is operating on a DocumentImporter,
     # which represents a labelled passages object, which is per
@@ -584,7 +585,8 @@ def calculate_concepts_counts_from_results(
 
         if isinstance(result, Exception):
             # Since we failed to remove them from the spans, make sure
-            # they're accounted for as remaining
+            # they're accounted for as remaining.
+            logger.info(f"partial update failed: {str(result)}")
             concepts_counts.update(concepts_models)
 
     return concepts_counts

--- a/flows/index.py
+++ b/flows/index.py
@@ -1,85 +1,46 @@
 import asyncio
-import base64
-import contextlib
 import json
 import os
-import re
-import tempfile
 from collections import Counter
-from collections.abc import Generator
 from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
-from typing import Any, ContextManager, TypeAlias, TypeVar
+from typing import Any
 
-import boto3
-import vespa.querybuilder as qb
 from cpr_sdk.models.search import Concept as VespaConcept
 from cpr_sdk.models.search import Passage as VespaPassage
-from cpr_sdk.s3 import _get_s3_keys_with_prefix, _s3_object_read_text
 from cpr_sdk.search_adaptors import VespaSearchAdapter
-from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
-from prefect.deployments.deployments import run_deployment
-from prefect.logging import get_logger, get_run_logger
-from pydantic import BaseModel
-from vespa.io import VespaQueryResponse, VespaResponse
+from prefect.logging import get_run_logger
 
+from flows.boundary import (
+    DEFAULT_DOCUMENTS_BATCH_SIZE,
+    DEFAULT_INDEXING_TASK_BATCH_SIZE,
+    ConceptModel,
+    DocumentImporter,
+    TextBlockId,
+    convert_labelled_passage_to_concepts,
+    get_vespa_search_adapter,
+    index_by_s3,
+    load_labelled_passages_by_uri,
+    partial_update_text_block,
+    s3_object_write_text,
+    s3_paths_or_s3_prefixes,
+)
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
 from flows.utils import (
     SlackNotify,
-    get_file_stems_for_document_id,
+    iterate_batch,
     remove_translated_suffix,
 )
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
-    function_to_flow_name,
-    generate_deployment_name,
     get_prefect_job_variable,
 )
 from scripts.update_classifier_spec import parse_spec_file
-from src.concept import Concept
-from src.exceptions import PartialUpdateError, QueryError
 from src.identifiers import WikibaseID
-from src.labelled_passage import LabelledPassage
-from src.span import Span
 
-DEFAULT_DOCUMENTS_BATCH_SIZE = 500
-DEFAULT_INDEXING_TASK_BATCH_SIZE = 20
-HTTP_OK = 200
 CONCEPTS_COUNTS_PREFIX_DEFAULT: str = "concepts_counts"
-CONCEPT_COUNT_SEPARATOR: str = ":"
-
-
-# Needed to get document passages from Vespa
-# Example: CCLW.executive.1813.2418
-DocumentImportId: TypeAlias = str
-# Needed to load the inference results
-# Example: s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json
-DocumentObjectUri: TypeAlias = str
-DocumentStem: TypeAlias = str
-# Passed to a self-sufficient flow run
-DocumentImporter: TypeAlias = tuple[DocumentStem, DocumentObjectUri]
-
-
-class S3Accessor(BaseModel):
-    """Representing S3 paths and prefixes for accessing documents."""
-
-    paths: list[str] | None = None
-    prefixes: list[str] | None = None
-
-
-# AKA LabelledPassage
-TextBlockId: TypeAlias = str
-SpanId: TypeAlias = str
-# The ID used in Vespa, that we don't keep in our models in the CPR
-# SDK, that is in a Hit.
-VespaHitId: TypeAlias = str
-# The same as above, but without the schema
-VespaDataId: TypeAlias = str
-
-T = TypeVar("T")
 
 
 @dataclass()
@@ -120,405 +81,7 @@ class Config:
         return config
 
 
-class ConceptModel(BaseModel):
-    """
-    A concept and the model used to identify it.
-
-    This class represents a pairing of a Wikibase concept ID with the name of the model
-    used to identify that concept in text. It is hashable to allow use in sets and as
-    dictionary keys.
-
-    Attributes:
-        wikibase_id: The Wikibase ID of the concept
-        model_name: The name of the model used to identify the concept
-
-    Example:
-        >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
-        ...                     model_name='KeywordClassifier("professional services sector")')
-        >>> str(model)
-        'Q123:KeywordClassifier("professional services sector")'
-    """
-
-    wikibase_id: WikibaseID
-    model_name: str
-
-    def __str__(self) -> str:
-        """
-        Convert the ConceptModel to a string in the format 'WIKIBASE_ID:MODEL_NAME'.
-
-        Returns:
-            str: String representation in the format 'WIKIBASE_ID:MODEL_NAME'
-        """
-        return f"{self.wikibase_id}{CONCEPT_COUNT_SEPARATOR}{self.concept_name}"
-
-    def __hash__(self) -> int:
-        """
-        Generate a hash value for the ConceptModel.
-
-        The hash is based on both the wikibase_id and model_name to ensure
-        uniqueness when used in sets or as dictionary keys.
-
-        Returns:
-            int: Hash value of the ConceptModel
-        """
-        return hash((self.wikibase_id, self.model_name))
-
-    def __eq__(self, other: object) -> bool:
-        """
-        Compare this ConceptModel with another for equality.
-
-        Two ConceptModels are equal if they have the same wikibase_id and model_name.
-
-        Args:
-            other: The object to compare with
-
-        Returns:
-            bool: True if the objects are equal, False otherwise
-        """
-        if not isinstance(other, ConceptModel):
-            return NotImplemented
-        return (
-            self.wikibase_id == other.wikibase_id
-            and self.model_name == other.model_name
-        )
-
-    @property
-    def concept_name(self) -> str:
-        """
-        Extract the concept name from the model name.
-
-        Examples:
-            >>> model = ConceptModel(wikibase_id=WikibaseID("Q123"),
-            ...                     model_name='KeywordClassifier("professional services sector")')
-            >>> model.concept_name
-            'professional services sector'
-            >>> model2 = ConceptModel(wikibase_id=WikibaseID("Q456"),
-            ...                      model_name='LLMClassifier("agriculture")')
-            >>> model2.concept_name
-            'agriculture'
-            >>> model3 = ConceptModel(wikibase_id=WikibaseID("Q789"),
-            ...                      model_name='InvalidModelName')
-            >>> model3.concept_name  # doctest: +IGNORE_EXCEPTION_DETAIL
-            Traceback (most recent call last):
-                ...
-            ValueError: Could not extract concept name from model name 'InvalidModelName'
-        """
-        match = re.search(r'"([^"]+)"', self.model_name)
-        if match:
-            return match.group(1)
-
-        raise ValueError(
-            f"Could not extract concept name from model name '{self.model_name}'"
-        )
-
-
-def get_vespa_search_adapter_from_aws_secrets(
-    cert_dir: str,
-    vespa_instance_url_param_name: str = "VESPA_INSTANCE_URL",
-    vespa_public_cert_param_name: str = "VESPA_PUBLIC_CERT_READ",
-    vespa_private_key_param_name: str = "VESPA_PRIVATE_KEY_READ",
-) -> VespaSearchAdapter:
-    """
-    Get a VespaSearchAdapter instance by retrieving secrets from AWS Secrets Manager.
-
-    We then save the secrets to local files in the cert_dir directory and instantiate
-    the VespaSearchAdapter.
-    """
-    cert_dir_path = Path(cert_dir)
-    if not cert_dir_path.exists():
-        raise FileNotFoundError(f"Certificate directory does not exist: {cert_dir}")
-
-    vespa_instance_url = get_aws_ssm_param(vespa_instance_url_param_name)
-    vespa_public_cert_encoded = get_aws_ssm_param(vespa_public_cert_param_name)
-    vespa_private_key_encoded = get_aws_ssm_param(vespa_private_key_param_name)
-
-    vespa_public_cert = base64.b64decode(vespa_public_cert_encoded).decode("utf-8")
-    vespa_private_key = base64.b64decode(vespa_private_key_encoded).decode("utf-8")
-
-    cert_path = cert_dir_path / "cert.pem"
-    key_path = cert_dir_path / "key.pem"
-
-    with open(cert_path, "w", encoding="utf-8") as f:
-        _ = f.write(vespa_public_cert)
-
-    with open(key_path, "w", encoding="utf-8") as f:
-        _ = f.write(vespa_private_key)
-
-    return VespaSearchAdapter(
-        instance_url=vespa_instance_url,
-        cert_directory=str(cert_dir_path),
-    )
-
-
-def _s3_object_write_text(s3_uri: str, text: str) -> None:
-    """Write text content to an S3 object."""
-    # Parse the S3 URI
-    s3_path: Path = Path(s3_uri)
-    if len(s3_path.parts) < 3:
-        raise ValueError(f"Invalid S3 path: {s3_path}")
-
-    bucket: str = s3_path.parts[1]
-    key = str(Path(*s3_path.parts[2:]))
-
-    # Create BytesIO buffer with the text content
-    body = BytesIO(text.encode("utf-8"))
-
-    # Upload to S3
-    s3 = boto3.client("s3")
-    _ = s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
-
-
-def s3_obj_generator_from_s3_prefixes(
-    s3_prefixes: list[str],
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """Return a generator that yields keys from a list of S3 prefixes."""
-    logger = get_logger()
-
-    for s3_prefix in s3_prefixes:
-        try:
-            # E.g. Path("s3://bucket/prefix/file.json").parts[1] == "bucket"
-            bucket = Path(s3_prefix).parts[1]
-            object_keys = _get_s3_keys_with_prefix(s3_prefix=s3_prefix)
-            for key in object_keys:
-                stem: DocumentStem = Path(key).stem
-                key: DocumentObjectUri = os.path.join("s3://", bucket, key)
-
-                yield stem, key
-        except Exception as e:
-            logger.error(
-                f"failed to yield from S3 prefix. Error: {str(e)}",
-            )
-            continue
-
-
-def s3_obj_generator_from_s3_paths(
-    s3_paths: list[str],
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """
-    Return a generator that yields keys from a list of S3 paths.
-
-    We extract the key from the S3 path by removing the first two
-    elements in the path.
-
-    E.g. "s3://bucket/prefix/file.json" -> "prefix/file.json"
-    """
-    logger = get_logger()
-    for s3_path in s3_paths:
-        try:
-            stem: DocumentStem = Path(s3_path).stem
-            uri: DocumentObjectUri = s3_path
-            yield stem, uri
-        except Exception as e:
-            logger.error(
-                f"failed to yield from S3 path. Error: {str(e)}",
-            )
-            continue
-
-
-def load_labelled_passages_by_uri(
-    document_object_uri: DocumentObjectUri,
-) -> list[LabelledPassage]:
-    """Load and transforms the S3 object's body into LabelledPassages objects."""
-    object_json = json.loads(_s3_object_read_text(s3_path=document_object_uri))
-
-    return [LabelledPassage(**labelled_passage) for labelled_passage in object_json]
-
-
-def get_document_passages_from_vespa(
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-) -> list[tuple[VespaHitId, VespaPassage]]:
-    """
-    Retrieve all the passages for a document in Vespa.
-
-    params:
-    - document_import_id: The document import id for a unique family document.
-    """
-    logger = get_logger()
-
-    logger.info(f"Getting document passages from Vespa: {document_import_id}")
-
-    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
-        yql=(
-            # trunk-ignore(bandit/B608)
-            "select * from document_passage where family_document_ref contains "
-            f'"id:doc_search:family_document::{document_import_id}"'
-        )
-    )
-
-    if (status_code := vespa_query_response.get_status_code()) != HTTP_OK:
-        raise QueryError(status_code)
-
-    logger.info(
-        (
-            f"Vespa search response for document: {document_import_id} "
-            f"with {len(vespa_query_response.hits)} hits"
-        )
-    )
-
-    return [
-        (passage["id"], VespaPassage.model_validate(passage["fields"]))
-        for passage in vespa_query_response.hits
-    ]
-
-
-def get_document_passage_from_vespa(
-    text_block_id: str,
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-) -> tuple[VespaHitId, VespaPassage]:
-    """Retrieve a passage for a document in Vespa."""
-    logger = get_logger()
-
-    logger.info(
-        f"Getting document passage from Vespa: {document_import_id}, text block: {text_block_id}"
-    )
-
-    condition = qb.QueryField("family_document_ref").contains(
-        f"id:doc_search:family_document::{document_import_id}"
-    ) & qb.QueryField("text_block_id").contains(text_block_id)
-
-    yql = qb.select("*").from_("document_passage").where(condition)
-
-    vespa_query_response: VespaQueryResponse = vespa_search_adapter.client.query(
-        yql=yql
-    )
-
-    if not vespa_query_response.is_successful():
-        raise QueryError(vespa_query_response.get_status_code())
-    if len(vespa_query_response.hits) != 1:
-        raise ValueError(
-            f"Expected 1 document passage for text block `{text_block_id}`, got {len(vespa_query_response.hits)}"
-        )
-
-    logger.info(
-        (
-            f"Vespa search response for document: {document_import_id} "
-            f"with {len(vespa_query_response.hits)} hits"
-        )
-    )
-
-    hit = vespa_query_response.hits[0]
-    passage_id = hit["id"]
-    passage = VespaPassage.model_validate(hit["fields"])
-
-    return passage_id, passage
-
-
-def get_model_from_span(span: Span) -> str:
-    """
-    Get the model used to label the span.
-
-    Labellers are stored in a list, these can contain many labellers as seen in the
-    example below, referring to human and machine annotators.
-
-    [
-        "alice",
-        "bob",
-        "68edec6f-fe74-413d-9cf1-39b1c3dad2c0",
-        'KeywordClassifier("extreme weather")',
-    ]
-
-    In the context of inference the labellers array should only hold the model used to
-    label the span as seen in the example below.
-
-    [
-        'KeywordClassifier("extreme weather")',
-    ]
-    """
-    if len(span.labellers) != 1:
-        raise ValueError(
-            f"Span has more than one labeller. Expected 1, got {len(span.labellers)}."
-        )
-    return span.labellers[0]
-
-
-def get_parent_concepts_from_concept(
-    concept: Concept,
-) -> tuple[list[dict], str]:
-    """
-    Extract parent concepts from a Concept object.
-
-    Currently we pull the name from the Classifier used to label the passage, this
-    doesn't hold the concept id. This is a temporary solution that is not desirable as
-    the relationship between concepts can change frequently and thus shouldn't be
-    coupled with inference.
-    """
-    parent_concepts = [
-        {"id": subconcept, "name": ""} for subconcept in concept.subconcept_of
-    ]
-    parent_concept_ids_flat = (
-        ",".join([parent_concept["id"] for parent_concept in parent_concepts]) + ","
-    )
-
-    return parent_concepts, parent_concept_ids_flat
-
-
-def convert_labelled_passage_to_concepts(
-    labelled_passage: LabelledPassage,
-) -> list[VespaConcept]:
-    """
-    Convert a labelled passage to a list of VespaConcept objects and their text block ID.
-
-    The labelled passage contains a list of spans relating to concepts
-    that we must convert to VespaConcept objects.
-    """
-    logger = get_run_logger()
-
-    concepts: list[VespaConcept] = []
-
-    # The concept used to label the passage holds some information on the parent
-    # concepts and thus this is being used as a temporary solution for providing
-    # the relationship between concepts. This has the downside that it ties a
-    # labelled passage to a particular concept when in fact the Spans that a
-    # labelled passage has can be labelled by multiple concepts.
-    concept = Concept.model_validate(labelled_passage.metadata["concept"])
-    parent_concepts, parent_concept_ids_flat = get_parent_concepts_from_concept(
-        concept=concept
-    )
-
-    # This expands the list from `n` for `LabelledPassages` to `n` for `Spans`
-    for span_idx, span in enumerate(labelled_passage.spans):
-        if span.concept_id is None:
-            # Include the Span index since Span's don't have IDs
-            logger.error(
-                f"span concept ID is missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
-            )
-            continue
-
-        if not span.timestamps:
-            logger.error(
-                f"span timestamps are missing: LabelledPassage.id={labelled_passage.id}, Span index={span_idx}"
-            )
-            continue
-
-        concepts.append(
-            VespaConcept(
-                id=span.concept_id,
-                name=concept.preferred_label,
-                parent_concepts=parent_concepts,
-                parent_concept_ids_flat=parent_concept_ids_flat,
-                model=get_model_from_span(span),
-                end=span.end_index,
-                start=span.start_index,
-                # These timestamps _should_ all be the same,
-                # but just in case, take the latest.
-                timestamp=max(span.timestamps),
-            )
-        )
-
-    return concepts
-
-
-def get_updated_passage_concepts(
+def update_concepts_on_existing_vespa_concepts(
     passage: VespaPassage,
     concepts: list[VespaConcept],
 ) -> list[dict[str, Any]]:
@@ -548,8 +111,12 @@ def get_updated_passage_concepts(
     return [concept_.model_dump(mode="json") for concept_ in updated_concepts]
 
 
+# FIXME: From what I can tell this function should be identical to the related function
+# deindex.py. In deindex.py we need to remove_translated_suffix from the
+# document_import_id and in this function I'm assuming we should add the updates to how
+# we calculate concepts counts from results.
 @flow
-async def run_partial_updates_of_concepts_for_document_passages(
+async def run_partial_updates_of_concepts_for_document_passages__update(
     document_importer: DocumentImporter,
     cache_bucket: str,
     concepts_counts_prefix: str,
@@ -584,7 +151,10 @@ async def run_partial_updates_of_concepts_for_document_passages(
             f"starting partial updates for {len(grouped_concepts)} grouped concepts"
         )
 
-        batches = iterate_batch(list(grouped_concepts.items()))
+        batches = iterate_batch(
+            list(grouped_concepts.items()),
+            batch_size=DEFAULT_DOCUMENTS_BATCH_SIZE,
+        )
 
         concepts_counts: Counter[ConceptModel] = Counter()
 
@@ -603,6 +173,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
                     concepts=concepts,
                     document_import_id=document_import_id,
                     vespa_search_adapter=vespa_search_adapter,
+                    update_function=update_concepts_on_existing_vespa_concepts,
                 )
                 for text_block_id, concepts in batch
             ]
@@ -638,6 +209,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
                     )
                     for concept in concepts
                 ]
+
                 concepts_counts.update(concepts_models)
 
         # Write concepts counts to S3
@@ -656,7 +228,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
             )
 
             # Write to S3
-            _s3_object_write_text(
+            _ = s3_object_write_text(
                 s3_uri=concepts_counts_uri,
                 text=serialised_concepts_counts,
             )
@@ -664,366 +236,6 @@ async def run_partial_updates_of_concepts_for_document_passages(
             logger.error(f"Failed to write concepts counts to S3: {str(e)}")
 
         return concepts_counts
-
-
-def get_vespa_search_adapter(
-    vespa_search_adapter: VespaSearchAdapter | None,
-) -> tuple[
-    ContextManager[str] | ContextManager[None],
-    VespaSearchAdapter,
-]:
-    """
-    Get a Vespa search adapter, if none provided.
-
-    It uses certs fetched, and then, saved to disk, if none was provided.
-    """
-    logger = get_run_logger()
-
-    # We want the directory used for the `VespaSearchAdapter` to be
-    # automatically cleaned up.
-    #
-    # To do this, we rely on the `tempfile.TemporaryDirectory`'s behaviour,
-    # or, a `contextlib.nullcontext` no-op, if a temporary directory
-    # wasn't needed.
-    if vespa_search_adapter is None:
-        logger.info("no Vespa search adapter, getting it from AWS secrets")
-        cm = tempfile.TemporaryDirectory()
-
-        vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
-            cert_dir=cm.name,  # type: ignore
-            vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
-            vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
-        )
-    else:
-        logger.info("Vespa search adapter provided")
-        cm = contextlib.nullcontext()
-
-    return cm, vespa_search_adapter
-
-
-def get_data_id_from_vespa_hit_id(hit_id: VespaHitId) -> VespaDataId:
-    """
-    Extract non-schema namespaced ID (last element after "::")
-
-    Example:
-    "CCLW.executive.10014.4470.623" from document passage ID like
-    "id:doc_search:document_passage::CCLW.executive.10014.4470.623".
-    """
-    splits = hit_id.split("::")
-    if len(splits) != 2:
-        raise ValueError(f"received {len(splits)} splits, when expecting 2: {splits}")
-    return splits[1]
-
-
-async def partial_update_text_block(
-    text_block_id: TextBlockId,
-    concepts: list[VespaConcept],
-    document_import_id: DocumentImportId,
-    vespa_search_adapter: VespaSearchAdapter,
-):
-    """
-    Partial update a singular text block and its concepts.
-
-    Returns true on completion, or false if no passages where found.
-    """
-    document_passage_id, document_passage = get_document_passage_from_vespa(
-        text_block_id, document_import_id, vespa_search_adapter
-    )
-
-    data_id = get_data_id_from_vespa_hit_id(document_passage_id)
-
-    serialised_concepts = get_updated_passage_concepts(
-        document_passage,
-        concepts,
-    )
-
-    response: VespaResponse = vespa_search_adapter.client.update_data(  # pyright: ignore[reportOptionalMemberAccess]
-        schema="document_passage",
-        namespace="doc_search",
-        data_id=data_id,
-        fields={"concepts": serialised_concepts},
-    )
-
-    if (status_code := response.get_status_code()) != HTTP_OK:
-        raise PartialUpdateError(data_id, status_code)
-
-
-def s3_paths_or_s3_prefixes(
-    classifier_specs: list[ClassifierSpec] | None,
-    document_ids: list[str] | None,
-    cache_bucket: str,
-    prefix: str,
-) -> S3Accessor:
-    """
-    Return the paths or prefix for the documents and classifiers.
-
-    - s3_prefix: The S3 prefix (directory) to yield objects from. Example:
-      "s3://cpr-sandbox-data-pipeline-cache/labelled_passages"
-    - s3_paths: A list of S3 object keys to yield objects from. Example:
-      [
-        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.executive.1813.2418.json",
-        "s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/v4/CCLW.legislative.10695.6015.json",
-      ]
-    """
-    logger = get_run_logger()
-
-    match (classifier_specs, document_ids):
-        case (None, None):
-            # Run on all documents, regardless of classifier
-            logger.info("run on all documents, regardless of classifier")
-            s3_prefix: str = "s3://" + os.path.join(
-                cache_bucket,
-                prefix,
-            )
-            return S3Accessor(paths=None, prefixes=[s3_prefix])
-
-        case (list(), None):
-            # Run on all documents, for the specified classifier
-            logger.info("run on all documents, for the specified classifier")
-            s3_prefixes = [
-                "s3://"
-                + os.path.join(
-                    cache_bucket,
-                    prefix,
-                    classifier_spec.name,
-                    classifier_spec.alias,
-                )
-                for classifier_spec in classifier_specs
-            ]
-            return S3Accessor(paths=None, prefixes=s3_prefixes)
-
-        case (list(), list()):
-            # Run on specified documents, for the specified classifier
-            logger.info("run on specified documents, for the specified classifier")
-
-            file_stems = []
-            for doc_id in document_ids:
-                file_stems += get_file_stems_for_document_id(
-                    doc_id, cache_bucket, prefix
-                )
-
-            document_paths = [
-                "s3://"
-                + os.path.join(
-                    cache_bucket,
-                    prefix,
-                    classifier_spec.name,
-                    classifier_spec.alias,
-                    f"{file_stem}.json",
-                )
-                for classifier_spec in classifier_specs
-                for file_stem in file_stems
-            ]
-            return S3Accessor(paths=document_paths, prefixes=None)
-
-        case (None, list()):
-            raise ValueError(
-                "if document IDs are specified, a classifier "
-                "specifcation must also be specified, since they're "
-                "namespaced by classifiers (e.g. "
-                "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
-                "v4/CCLW.legislative.10695.6015.json`)"
-            )
-
-
-def s3_obj_generator(
-    s3_prefixes: list[str] | None,
-    s3_paths: list[str] | None,
-) -> Generator[
-    DocumentImporter,
-    None,
-    None,
-]:
-    """
-    Return a generator that returns S3 objects for each path or prefix.
-
-    These will be for each output from the inference stage, of
-    labelled passages.
-    """
-    logger = get_run_logger()
-
-    match (s3_prefixes, s3_paths):
-        case (list(), list()):
-            raise ValueError(
-                "Either s3_prefixes or s3_paths must be provided, not both."
-            )
-        case (list(), None):
-            logger.info("S3 object generator: prefixes")
-            return s3_obj_generator_from_s3_prefixes(s3_prefixes=s3_prefixes)
-        case (None, list()):
-            logger.info("S3 object generator: paths")
-            return s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
-        case (None, None):
-            raise ValueError("Either s3_prefix or s3_paths must be provided.")
-
-
-@flow
-async def run_partial_updates_of_concepts_for_batch(
-    documents_batch: list[DocumentImporter],
-    documents_batch_num: int,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-) -> None:
-    """Run partial updates for concepts in a batch of documents."""
-
-    logger = get_run_logger()
-    logger.info(
-        f"Updating concepts for batch of documents, documents in batch: {len(documents_batch)}."
-    )
-    for i, document_importer in enumerate(documents_batch):
-        try:
-            _ = await run_partial_updates_of_concepts_for_document_passages(
-                document_importer=document_importer,
-                cache_bucket=cache_bucket,
-                concepts_counts_prefix=concepts_counts_prefix,
-            )
-
-            logger.info(f"processed batch documents #{documents_batch_num}")
-
-        except Exception as e:
-            document_stem: DocumentStem = documents_batch[i][0]
-            logger.error(
-                f"failed to process document `{document_stem}`: {e.__str__()}",
-            )
-            continue
-
-
-async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
-    documents_batch: list[DocumentImporter],
-    documents_batch_num: int,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-    aws_env: AwsEnv,
-    as_deployment: bool,
-) -> None:
-    """Run partial updates for a batch of documents as a sub-flow or deployment."""
-    logger = get_run_logger()
-    logger.info(
-        "Running partial updates of concepts for batch as sub-flow or deployment: "
-        f"batch length {len(documents_batch)}, as_deployment: {as_deployment}"
-    )
-
-    if as_deployment:
-        flow_name = function_to_flow_name(run_partial_updates_of_concepts_for_batch)
-        deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
-
-        return await run_deployment(
-            name=f"{flow_name}/{deployment_name}",
-            parameters={
-                "documents_batch": documents_batch,
-                "documents_batch_num": documents_batch_num,
-                "cache_bucket": cache_bucket,
-                "concepts_counts_prefix": concepts_counts_prefix,
-            },
-            timeout=3600,
-        )
-
-    return await run_partial_updates_of_concepts_for_batch(
-        documents_batch=documents_batch,
-        documents_batch_num=documents_batch_num,
-        cache_bucket=cache_bucket,
-        concepts_counts_prefix=concepts_counts_prefix,
-    )
-
-
-@flow
-async def index_by_s3(
-    aws_env: AwsEnv,
-    cache_bucket: str,
-    concepts_counts_prefix: str,
-    vespa_search_adapter: VespaSearchAdapter | None,
-    s3_prefixes: list[str] | None = None,
-    s3_paths: list[str] | None = None,
-    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
-    indexing_task_batch_size: int = DEFAULT_INDEXING_TASK_BATCH_SIZE,
-    as_deployment: bool = True,
-) -> None:
-    """
-    Asynchronously index concepts from S3 files into Vespa.
-
-    This function retrieves concept documents from files stored in an S3 path and
-    indexes them in a Vespa instance. The name of each file in the specified S3 path is
-    expected to represent the document's import ID.
-
-    When `s3_prefix` is provided, the function will index all files within that S3
-    prefix (directory). When `s3_paths` is provided, the function will index only the
-    files specified in the list of S3 object keys. If both are provided `s3_paths` will
-    be used.
-
-    Assumptions:
-    - The S3 file names represent document import IDs.
-
-    params:
-    - s3_prefix: The S3 prefix (directory) to yield objects from.
-        E.g. "s3://bucket/prefix/"
-    - s3_paths: A list of S3 object keys to yield objects from.
-        E.g. {"s3://bucket/prefix/file1.json", "s3://bucket/prefix/file2.json"}
-    - vespa_search_adapter: An instance of VespaSearchAdapter.
-        E.g. VespaSearchAdapter(
-            instance_url="https://vespa-instance-url.com",
-            cert_directory="certs/"
-        )
-    """
-    logger = get_run_logger()
-
-    cm, vespa_search_adapter = get_vespa_search_adapter(vespa_search_adapter)
-
-    with cm:
-        logger.info("Getting S3 object generator")
-        documents_generator = s3_obj_generator(s3_prefixes, s3_paths)
-        documents_batches = iterate_batch(documents_generator, batch_size=batch_size)
-        indexing_task_batches = iterate_batch(
-            data=documents_batches, batch_size=indexing_task_batch_size
-        )
-
-        for i, indexing_task_batch in enumerate(indexing_task_batches, start=1):
-            logger.info(f"Processing indexing task batch #{i}")
-
-            indexing_tasks = [
-                run_partial_updates_of_concepts_for_batch_flow_or_deployment(
-                    documents_batch=documents_batch,
-                    documents_batch_num=documents_batch_num,
-                    cache_bucket=cache_bucket,
-                    concepts_counts_prefix=concepts_counts_prefix,
-                    aws_env=aws_env,
-                    as_deployment=as_deployment,
-                )
-                for documents_batch_num, documents_batch in enumerate(
-                    indexing_task_batch, start=1
-                )
-            ]
-
-            logger.info(f"Gathering indexing tasks for batch #{i}")
-            results = await asyncio.gather(*indexing_tasks, return_exceptions=True)
-            logger.info(f"Gathered indexing tasks for batch #{i}")
-
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.error(
-                        f"failed to process document batch in indexing task batch #{i}: {str(result)}",
-                    )
-                    continue
-
-
-def iterate_batch(
-    data: list[T] | Generator[T, None, None],
-    batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
-) -> Generator[list[T], None, None]:
-    """Generate batches from a list or generator with a specified size."""
-    if isinstance(data, list):
-        # For lists, we can use list slicing
-        for i in range(0, len(data), batch_size):
-            yield data[i : i + batch_size]
-    else:
-        # For generators, accumulate items until we reach batch size
-        batch: list[T] = []
-        for item in data:
-            batch.append(item)
-            if len(batch) >= batch_size:
-                yield batch
-                batch = []
-        if batch:  # Don't forget to yield the last partial batch
-            yield batch
 
 
 @flow(
@@ -1073,6 +285,7 @@ async def index_labelled_passages_from_s3_to_vespa(
     logger.info(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
 
     await index_by_s3(
+        partial_update_flow=run_partial_updates_of_concepts_for_document_passages__update,
         aws_env=config.aws_env,
         vespa_search_adapter=config.vespa_search_adapter,
         s3_prefixes=s3_accessor.prefixes,

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -55,6 +55,7 @@ def test_wikibase_to_s3_config():
         wikibase_password=SecretStr("test_password"),
         wikibase_username="test_username",
         wikibase_url="https://test.test.test",
+        trigger_deindexing=False,
     )
 
 

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -357,7 +357,7 @@ def s3_prefix_mock_bucket_labelled_passages(
 @pytest.fixture
 def s3_prefix_labelled_passages() -> str:
     """Returns the s3 prefix for the concepts."""
-    return "labelled_passages/Q788/v4"
+    return "labelled_passages/Q788/latest"
 
 
 @pytest.fixture()

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -25,7 +25,7 @@ from pydantic import SecretStr
 from requests.exceptions import ConnectionError
 from vespa.application import Vespa
 
-from flows.index import get_vespa_search_adapter_from_aws_secrets
+from flows.boundary import get_vespa_search_adapter_from_aws_secrets
 from flows.inference import Config as InferenceConfig
 from flows.wikibase_to_s3 import Config as WikibaseToS3Config
 from scripts.cloud import AwsEnv

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -356,7 +356,7 @@ def s3_prefix_mock_bucket_labelled_passages(
 @pytest.fixture
 def s3_prefix_labelled_passages() -> str:
     """Returns the s3 prefix for the concepts."""
-    return "labelled_passages/Q788/latest"
+    return "labelled_passages/Q788/v4"
 
 
 @pytest.fixture()

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -1,0 +1,404 @@
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+from cpr_sdk.models.search import Concept as VespaConcept
+from cpr_sdk.models.search import Passage as VespaPassage
+from cpr_sdk.search_adaptors import VespaSearchAdapter
+from prefect.logging import disable_run_logger
+
+from flows.boundary import (
+    DocumentImporter,
+    convert_labelled_passage_to_concepts,
+    get_data_id_from_vespa_hit_id,
+    get_document_passages_from_vespa,
+    get_parent_concepts_from_concept,
+    get_vespa_search_adapter_from_aws_secrets,
+    s3_obj_generator,
+    s3_obj_generator_from_s3_paths,
+    s3_obj_generator_from_s3_prefixes,
+    s3_paths_or_s3_prefixes,
+)
+from flows.index import Config
+from scripts.cloud import ClassifierSpec
+from src.concept import Concept
+from src.identifiers import WikibaseID
+from src.labelled_passage import LabelledPassage
+from src.span import Span
+
+DOCUMENT_PASSAGE_ID_PATTERN = re.compile(
+    r"id:doc_search:document_passage::[a-zA-Z]+.[a-zA-Z]+.\d+.\d+.\d+"
+)
+DATA_ID_PATTERN = re.compile(r"[a-zA-Z]+.[a-zA-Z]+.\d+.\d+.\d+")
+
+
+def test_get_data_id_from_vespa_hit_id() -> None:
+    """Test that we can extract the data ID from a vespa hit id."""
+    assert (
+        DATA_ID_PATTERN.match(
+            get_data_id_from_vespa_hit_id(
+                "id:doc_search:document_passage::CCLW.executive.00000.0000.001"
+            )
+        )
+        is not None
+    )
+
+
+def test_vespa_search_adapter_from_aws_secrets(
+    create_vespa_params,
+    mock_vespa_credentials,
+    tmp_path,
+) -> None:
+    """Test that we can successfully instantiate the VespaSearchAdpater from ssm params."""
+    vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
+        cert_dir=str(tmp_path),
+        vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
+        vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
+    )
+
+    cert_path = tmp_path / "cert.pem"
+    assert cert_path.exists()
+
+    key_path = tmp_path / "key.pem"
+    assert key_path.exists()
+
+    with open(cert_path, "r", encoding="utf-8") as f:
+        assert f.read() == "Public cert content\n"
+    with open(key_path, "r", encoding="utf-8") as f:
+        assert f.read() == "Private key content\n"
+    assert (
+        vespa_search_adapter.instance_url
+        == mock_vespa_credentials["VESPA_INSTANCE_URL"]
+    )
+    assert vespa_search_adapter.client.cert == str(cert_path)
+    assert vespa_search_adapter.client.key == str(key_path)
+
+
+def test_s3_obj_generator_from_s3_prefixes(
+    mock_bucket,
+    mock_bucket_b,
+    mock_bucket_labelled_passages,
+    mock_bucket_labelled_passages_b,
+    s3_prefix_labelled_passages,
+    labelled_passage_fixture_files,
+) -> None:
+    """Test the s3 object generator."""
+    gen = s3_obj_generator_from_s3_prefixes(
+        [
+            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages),
+            os.path.join("s3://", mock_bucket_b, s3_prefix_labelled_passages),
+        ],
+    )
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{b}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
+        )
+        for b in [mock_bucket, mock_bucket_b]
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
+
+
+def test_s3_obj_generator_from_s3_paths(
+    mock_bucket,
+    mock_bucket_labelled_passages,
+    s3_prefix_labelled_passages,
+    labelled_passage_fixture_files,
+) -> None:
+    """Test the s3 object generator."""
+    s3_paths = [
+        os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
+        for f in labelled_passage_fixture_files
+    ]
+    gen = s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
+        )
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
+
+
+def test_convert_labelled_passges_to_concepts(
+    example_labelled_passages: list[LabelledPassage],
+) -> None:
+    """Test that we can correctly convert labelled passages to concepts."""
+    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
+    assert all([isinstance(concept, VespaConcept) for concept in concepts])
+
+
+def test_convert_labelled_passges_to_concepts_raises_error(
+    example_labelled_passages: list[LabelledPassage],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that we correctly log errors when a Span has no concept ID or timestamps."""
+    # Add a span without concept_id
+    example_labelled_passages[0].spans.append(
+        Span(
+            text="Test text.",
+            start_index=0,
+            end_index=8,
+            concept_id=None,
+            labellers=[],
+        )
+    )
+    # Add a span without timestamps
+    example_labelled_passages[0].spans.append(
+        Span(
+            text="Test text.",
+            start_index=0,
+            end_index=8,
+            concept_id="Q123",
+            labellers=[],
+            timestamps=[],  # Empty timestamps
+        )
+    )
+
+    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
+
+    # Check that appropriate error messages were logged
+    error_messages = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert any("span concept ID is missing" in msg for msg in error_messages)
+    assert any("span timestamps are missing" in msg for msg in error_messages)
+
+    # Verify that the problematic spans were skipped but valid one was processed
+    assert len(concepts) == 1
+
+
+def test_get_parent_concepts_from_concept() -> None:
+    """Test that we can correctly retrieve the parent concepts from a concept."""
+    assert get_parent_concepts_from_concept(
+        concept=Concept(
+            preferred_label="forestry sector",
+            alternative_labels=[],
+            negative_labels=[],
+            wikibase_id=WikibaseID("Q10014"),
+            subconcept_of=[WikibaseID("Q4470")],
+            has_subconcept=[WikibaseID("Q4471")],
+            labelled_passages=[],
+        )
+    ) == ([{"id": "Q4470", "name": ""}], "Q4470,")
+
+
+def test_s3_paths_or_s3_prefixes_no_classifier(
+    mock_bucket,
+    mock_bucket_labelled_passages,
+):
+    """Test s3_paths_or_s3_prefixes returns base prefix when no classifier spec provided."""
+    config = Config(cache_bucket=mock_bucket)
+
+    s3_accessor = s3_paths_or_s3_prefixes(
+        classifier_specs=None,
+        document_ids=None,
+        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
+        prefix=config.document_source_prefix,
+    )
+
+    assert s3_accessor.prefixes == [f"s3://{mock_bucket}/labelled_passages"]
+    assert s3_accessor.paths is None
+
+
+def test_s3_paths_or_s3_prefixes_no_classifier_and_docs(
+    mock_bucket,
+    mock_bucket_labelled_passages,
+    labelled_passage_fixture_ids,
+    labelled_passage_fixture_files,
+    s3_prefix_mock_bucket_labelled_passages,
+):
+    config = Config(cache_bucket=mock_bucket)
+
+    with (
+        pytest.raises(
+            ValueError,
+            match="if document IDs are specified, a classifier "
+            "specifcation must also be specified, since they're "
+            "namespaced by classifiers \\(e\\.g\\. "
+            "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
+            "v4/CCLW\\.legislative\\.10695\\.6015\\.json`\\)",
+        ),
+        disable_run_logger(),
+    ):
+        s3_paths_or_s3_prefixes(
+            classifier_specs=None,
+            document_ids=labelled_passage_fixture_ids,
+            cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
+            prefix=config.document_source_prefix,
+        )
+
+
+def test_s3_paths_or_s3_prefixes_with_classifier_no_docs(
+    mock_bucket,
+):
+    """Test s3_paths_or_s3_prefixes returns classifier-specific prefix when no document IDs provided."""
+    config = Config(cache_bucket=mock_bucket)
+    classifier_spec_q788 = ClassifierSpec(name="Q788", alias="latest")
+    classifier_spec_q699 = ClassifierSpec(name="Q699", alias="latest")
+
+    s3_accessor = s3_paths_or_s3_prefixes(
+        classifier_specs=[classifier_spec_q788, classifier_spec_q699],
+        document_ids=None,
+        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
+        prefix=config.document_source_prefix,
+    )
+
+    assert s3_accessor.prefixes == [
+        f"s3://{mock_bucket}/labelled_passages/Q788/latest",
+        f"s3://{mock_bucket}/labelled_passages/Q699/latest",
+    ]
+    assert s3_accessor.paths is None
+
+
+def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
+    mock_bucket,
+    mock_bucket_labelled_passages,
+    labelled_passage_fixture_ids,
+    labelled_passage_fixture_files,
+    s3_prefix_mock_bucket_labelled_passages,
+):
+    """Test s3_paths_or_s3_prefixes returns specific paths when both classifier and document IDs provided."""
+    config = Config(cache_bucket=mock_bucket)
+    classifier_spec = ClassifierSpec(name="Q788", alias="latest")
+
+    expected_paths = [
+        f"{s3_prefix_mock_bucket_labelled_passages}/{labelled_passage_fixture_file}"
+        for labelled_passage_fixture_file in labelled_passage_fixture_files
+    ]
+
+    s3_accessor = s3_paths_or_s3_prefixes(
+        classifier_specs=[classifier_spec],
+        document_ids=labelled_passage_fixture_ids,
+        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
+        prefix=config.document_source_prefix,
+    )
+
+    assert s3_accessor.prefixes is None
+    assert sorted(s3_accessor.paths) == sorted(  # pyright: ignore[reportArgumentType]
+        expected_paths
+    )
+
+
+@pytest.mark.parametrize(
+    "s3_prefixes,s3_paths,expected_error,error_match",
+    [
+        # Both provided - should raise error
+        (
+            ["s3://bucket/prefix"],
+            ["s3://bucket/prefix/file.json"],
+            ValueError,
+            "Either s3_prefixes or s3_paths must be provided, not both.",
+        ),
+        # Neither provided - should raise error
+        (
+            None,
+            None,
+            ValueError,
+            "Either s3_prefix or s3_paths must be provided.",
+        ),
+        # Invalid types - should raise error
+        (
+            None,
+            None,
+            ValueError,
+            "Either s3_prefix or s3_paths must be provided.",
+        ),
+    ],
+)
+def test_s3_obj_generator_errors(
+    s3_prefixes: list[str] | None,
+    s3_paths: list[str] | None,
+    expected_error: type[Exception],
+    error_match: str,
+) -> None:
+    """Test s3_obj_generator error cases."""
+    with pytest.raises(expected_error, match=error_match), disable_run_logger():
+        _ = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
+
+
+@pytest.mark.parametrize(
+    "use_prefixes",
+    [True, False],
+    ids=["using_prefixes", "using_paths"],
+)
+def test_s3_obj_generator_valid_cases(
+    mock_bucket: str,
+    mock_bucket_labelled_passages: None,
+    s3_prefix_labelled_passages: str,
+    labelled_passage_fixture_files: list[str],
+    use_prefixes: bool,
+) -> None:
+    """Test s3_obj_generator with valid inputs using either prefixes or paths."""
+    if use_prefixes:
+        s3_prefixes = [os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)]
+        s3_paths = None
+    else:
+        s3_prefixes = None
+        s3_paths = [
+            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
+            for f in labelled_passage_fixture_files
+        ]
+
+    gen = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
+    result = list(gen)
+    expected: list[DocumentImporter] = [
+        (
+            Path(f).stem,
+            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
+        )
+        for f in labelled_passage_fixture_files
+    ]
+    assert expected == result
+
+
+@pytest.mark.vespa
+def test_get_document_passages_from_vespa(
+    local_vespa_search_adapter: VespaSearchAdapter,
+    document_passages_test_data_file_path: str,
+    vespa_app,
+) -> None:
+    """Test that we can retrieve all the passages for a document in vespa."""
+
+    # Test that we retrieve no passages for a document that doesn't exist
+    document_passages = get_document_passages_from_vespa(
+        document_import_id="test.executive.1.1",
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    assert document_passages == []
+
+    # Test that we can retrieve all the passages for a document that does exist
+    document_import_id = "CCLW.executive.10014.4470"
+
+    with open(document_passages_test_data_file_path) as f:
+        document_passage_test_data = json.load(f)
+
+    family_document_passages_count_expected = sum(
+        1
+        for doc in document_passage_test_data
+        if doc["fields"]["family_document_ref"]
+        == f"id:doc_search:family_document::{document_import_id}"
+    )
+
+    document_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    assert len(document_passages) > 0
+    assert len(document_passages) == family_document_passages_count_expected
+    assert all(
+        [
+            (
+                type(passage) is VespaPassage
+                and type(passage_id) is str
+                and bool(DOCUMENT_PASSAGE_ID_PATTERN.fullmatch(passage_id))
+            )
+            for passage_id, passage in document_passages
+        ]
+    )

--- a/tests/flows/test_count_family_document_concepts.py
+++ b/tests/flows/test_count_family_document_concepts.py
@@ -21,7 +21,7 @@ async def test_load_parse_concepts_counts(
 ) -> None:
     """Test that we can load and parse concept counts from S3."""
     mock_concepts_counts_document_uri = sorted(mock_concepts_counts_document_keys)[0]
-    document_object_uri = f"s3://{mock_bucket}/{ mock_concepts_counts_document_uri }"
+    document_object_uri = f"s3://{mock_bucket}/{mock_concepts_counts_document_uri}"
 
     counter = await load_parse_concepts_counts(document_object_uri)
 

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -2,6 +2,7 @@ import json
 from collections import Counter
 from datetime import datetime
 from io import BytesIO
+from typing import Sequence
 
 import pytest
 from botocore.exceptions import ClientError
@@ -9,28 +10,31 @@ from cpr_sdk.models.search import Concept as VespaConcept
 from cpr_sdk.s3 import S3_PATTERN, _s3_object_read_text
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 
+import flows.boundary as boundary
 import flows.count_family_document_concepts as count_family_document_concepts
-import flows.index as index
+from flows.boundary import (
+    DocumentImportId,
+    get_document_from_vespa,
+    get_document_passage_from_vespa,
+    get_document_passages_from_vespa,
+)
 from flows.deindex import (
     CONCEPTS_COUNTS_PREFIX_DEFAULT,
     ConceptModel,
     DocumentImporter,
-    DocumentImportId,
     DocumentObjectUri,
-    _s3_object_write_bytes,
-    _s3_object_write_text,
     calculate_concepts_counts_from_results,
-    get_document_from_vespa,
-    get_document_passage_from_vespa,
-    get_document_passages_from_vespa,
     partial_update_text_block,
-    run_partial_updates_of_concepts_for_document_passages,
+    remove_concepts_from_existing_vespa_concepts,
+    run_partial_updates_of_concepts_for_document_passages__removal,
     serialise_concepts_counts,
     update_s3_with_all_successes,
     update_s3_with_latest_concepts_counts,
     update_s3_with_some_successes,
 )
+from flows.index import update_concepts_on_existing_vespa_concepts
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT, serialise_labels
+from flows.utils import _s3_object_write_bytes, _s3_object_write_text
 from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
@@ -57,18 +61,22 @@ async def test_partial_update_text_block_with_removal(
     except StopIteration:
         raise ValueError("no concepts found in any passages, check the fixtures")
 
+    assert first_passage_with_concepts.concepts
     assert len(first_passage_with_concepts.concepts) >= 2, "must be at least 2 concepts"
 
     # Get a slice of 1 concept
-    concepts_to_remove: list[VespaConcept] = first_passage_with_concepts.concepts[0:1]
-    concepts_to_keep: list[VespaConcept] = first_passage_with_concepts.concepts[1:]
+    concepts_to_remove: Sequence[VespaConcept] = first_passage_with_concepts.concepts[
+        0:1
+    ]
+    concepts_to_keep: Sequence[VespaConcept] = first_passage_with_concepts.concepts[1:]
 
     assert (
         await partial_update_text_block(
             text_block_id=first_passage_with_concepts.text_block_id,
             document_import_id=document_import_id,
-            concepts=concepts_to_remove,
+            concepts=list(concepts_to_remove),
             vespa_search_adapter=local_vespa_search_adapter,
+            update_function=remove_concepts_from_existing_vespa_concepts,
         )
         is None
     )
@@ -103,6 +111,7 @@ async def test_partial_update_text_block_with_empty(
     except StopIteration:
         raise ValueError("no concepts found in any passages, check the fixtures")
 
+    assert first_passage_with_concepts.concepts
     assert len(first_passage_with_concepts.concepts) >= 2, "must be at least 2 concepts"
 
     assert (
@@ -111,6 +120,7 @@ async def test_partial_update_text_block_with_empty(
             document_import_id=document_import_id,
             concepts=[],
             vespa_search_adapter=local_vespa_search_adapter,
+            update_function=remove_concepts_from_existing_vespa_concepts,
         )
         is None
     )
@@ -862,7 +872,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
     # Add them to the document passage in the local Vespa instance for
     # the test.
     assert (
-        await index.partial_update_text_block(
+        await boundary.partial_update_text_block(
             text_block_id="1570",
             document_import_id=document_import_id_remove,
             concepts=[
@@ -878,11 +888,12 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
                 ),
             ],
             vespa_search_adapter=local_vespa_search_adapter,
+            update_function=update_concepts_on_existing_vespa_concepts,
         )
         is None
     )
     assert (
-        await index.partial_update_text_block(
+        await boundary.partial_update_text_block(
             text_block_id="1273",
             document_import_id=document_import_id_remove,
             concepts=[
@@ -898,6 +909,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
                 ),
             ],
             vespa_search_adapter=local_vespa_search_adapter,
+            update_function=update_concepts_on_existing_vespa_concepts,
         )
         is None
     )
@@ -922,7 +934,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
 
     # Run the function
     assert (
-        await run_partial_updates_of_concepts_for_document_passages(
+        await run_partial_updates_of_concepts_for_document_passages__removal(
             document_importer=document_importer_remove,
             cache_bucket=mock_bucket,
             concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -1,0 +1,618 @@
+import json
+from collections import Counter
+from datetime import datetime
+from io import BytesIO
+
+import pytest
+from botocore.exceptions import ClientError
+from cpr_sdk.models.search import Concept as VespaConcept
+from cpr_sdk.s3 import _s3_object_read_text
+from cpr_sdk.search_adaptors import VespaSearchAdapter
+
+from flows.deindex import (
+    CONCEPTS_COUNTS_PREFIX_DEFAULT,
+    ConceptModel,
+    calculate_concepts_counts_from_results,
+    get_document_passage_from_vespa,
+    get_document_passages_from_vespa,
+    partial_update_text_block,
+    run_partial_updates_of_concepts_for_document_passages,
+    update_s3_with_all_successes,
+    update_s3_with_latest_concepts_counts,
+    update_s3_with_some_successes,
+)
+from src.identifiers import WikibaseID
+from src.labelled_passage import LabelledPassage
+from src.span import Span
+
+
+@pytest.mark.asyncio
+@pytest.mark.vespa
+async def test_partial_update_text_block_with_removal(
+    local_vespa_search_adapter: VespaSearchAdapter,
+    vespa_app,
+):
+    document_import_id = "CCLW.executive.10014.4470"
+
+    # Confirm that the concepts to remove are in the document passages
+    initial_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    try:
+        first_passage_with_concepts = next(
+            passage for _, passage in initial_passages if passage.concepts
+        )
+    except StopIteration:
+        raise ValueError("no concepts found in any passages, check the fixtures")
+
+    assert len(first_passage_with_concepts.concepts) >= 2, "must be at least 2 concepts"
+
+    # Get a slice of 1 concept
+    concepts_to_remove: list[VespaConcept] = first_passage_with_concepts.concepts[0:1]
+    concepts_to_keep: list[VespaConcept] = first_passage_with_concepts.concepts[1:]
+
+    assert (
+        await partial_update_text_block(
+            text_block_id=first_passage_with_concepts.text_block_id,
+            document_import_id=document_import_id,
+            concepts=concepts_to_remove,
+            vespa_search_adapter=local_vespa_search_adapter,
+        )
+        is None
+    )
+
+    _hit_id, updated_passage = get_document_passage_from_vespa(
+        text_block_id=first_passage_with_concepts.text_block_id,
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    assert updated_passage.concepts == concepts_to_keep
+
+
+@pytest.mark.asyncio
+@pytest.mark.vespa
+async def test_partial_update_text_block_with_empty(
+    local_vespa_search_adapter: VespaSearchAdapter,
+    vespa_app,
+):
+    document_import_id = "CCLW.executive.10014.4470"
+
+    # Confirm that the concepts to remove are in the document passages
+    initial_passages = get_document_passages_from_vespa(
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    try:
+        first_passage_with_concepts = next(
+            passage for _, passage in initial_passages if passage.concepts
+        )
+    except StopIteration:
+        raise ValueError("no concepts found in any passages, check the fixtures")
+
+    assert len(first_passage_with_concepts.concepts) >= 2, "must be at least 2 concepts"
+
+    assert (
+        await partial_update_text_block(
+            text_block_id=first_passage_with_concepts.text_block_id,
+            document_import_id=document_import_id,
+            concepts=[],
+            vespa_search_adapter=local_vespa_search_adapter,
+        )
+        is None
+    )
+
+    _hit_id, updated_passage = get_document_passage_from_vespa(
+        text_block_id=first_passage_with_concepts.text_block_id,
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    assert updated_passage.concepts == first_passage_with_concepts.concepts
+
+
+def test_update_s3_with_all_successes(
+    mock_bucket,
+    mock_s3_client,
+):
+    """Test that update_s3_with_all_successes correctly deletes both S3 objects."""
+    document_import_id = "CCLW.executive.10014.4470"
+
+    document_object_uri = (
+        f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+
+    expected_concepts_counts_key = (
+        f"{CONCEPTS_COUNTS_PREFIX_DEFAULT}/Q787/v4/{document_import_id}.json"
+    )
+    expected_labelled_passages_key = (
+        f"labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+
+    # Put some objects to be deleted
+    body = BytesIO(json.dumps({}).encode("utf-8"))
+    mock_s3_client.put_object(
+        Bucket=mock_bucket,
+        Key=expected_concepts_counts_key,
+        Body=body,
+        ContentType="application/json",
+    )
+    mock_s3_client.put_object(
+        Bucket=mock_bucket,
+        Key=expected_labelled_passages_key,
+        Body=body,
+        ContentType="application/json",
+    )
+
+    assert (
+        update_s3_with_all_successes(
+            document_object_uri=document_object_uri,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+        )
+        is None
+    )
+
+    # Ensure the objects were deleted
+    with pytest.raises(ClientError):
+        mock_s3_client.head_object(Bucket=mock_bucket, Key=expected_concepts_counts_key)
+    with pytest.raises(ClientError):
+        mock_s3_client.head_object(
+            Bucket=mock_bucket, Key=expected_labelled_passages_key
+        )
+
+
+@pytest.mark.vespa
+def test_update_s3_with_some_successes(
+    mock_bucket: str,
+    mock_s3_client,
+    local_vespa_search_adapter: VespaSearchAdapter,
+):
+    document_import_id = "CCLW.executive.10014.4470"
+
+    document_object_uri = (
+        f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+
+    concept_model_1 = ConceptModel(
+        wikibase_id=WikibaseID("Q123"),
+        model_name='KeywordClassifier("professional services sector")',
+    )
+
+    concept_model_1 = ConceptModel(
+        wikibase_id=WikibaseID("Q456"), model_name='KeywordClassifier("agriculture")'
+    )
+
+    concepts_to_keep = Counter({concept_model_1: 3})
+
+    document_labelled_passages: list[LabelledPassage] = [
+        LabelledPassage(
+            id="lp1",
+            text="once upon a time",
+            spans=[
+                Span(
+                    text="once",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q123"),
+                ),
+                Span(
+                    text="upon",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q456"),
+                ),
+            ],
+        ),
+        LabelledPassage(
+            id="lp2",
+            text="lorem ipsum",
+            spans=[
+                Span(
+                    text="ipsum",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q789"),
+                ),
+            ],
+        ),
+    ]
+
+    assert (
+        update_s3_with_some_successes(
+            document_object_uri,
+            concepts_to_keep,
+            document_labelled_passages,
+            mock_bucket,
+            CONCEPTS_COUNTS_PREFIX_DEFAULT,
+        )
+        is None
+    )
+
+    assert json.loads(
+        _s3_object_read_text(
+            s3_path=f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+        )
+    ) == [
+        '{"id":"lp1","text":"once upon a time","spans":[{"text":"upon","start_index":0,"end_index":1,"concept_id":"Q456","labellers":[],"timestamps":[],"id":"bpp4juku","labelled_text":"u"}],"metadata":{}}',
+        '{"id":"lp2","text":"lorem ipsum","spans":[],"metadata":{}}',
+    ]
+    assert json.loads(
+        _s3_object_read_text(
+            s3_path=f"s3://{mock_bucket}/concepts_counts/Q787/v4/{document_import_id}.json"
+        )
+    ) == {"Q456:agriculture": 3}
+
+
+@pytest.mark.parametrize(
+    "results,batch,expected_counts",
+    [
+        # Case: All successful updates (no exceptions)
+        (
+            [None, None],
+            [
+                (
+                    "text_block_1",
+                    [
+                        VespaConcept(
+                            id="Q123",
+                            name="concept1",
+                            model='KeywordClassifier("concept1")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+                (
+                    "text_block_2",
+                    [
+                        VespaConcept(
+                            id="Q456",
+                            name="concept2",
+                            model='KeywordClassifier("concept2")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+            ],
+            Counter(
+                {
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q123"),
+                        model_name='KeywordClassifier("concept1")',
+                    ): 0,
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q456"),
+                        model_name='KeywordClassifier("concept2")',
+                    ): 0,
+                }
+            ),
+        ),
+        # Case: One failed update (with exception)
+        (
+            [None, Exception("Update failed")],
+            [
+                (
+                    "text_block_1",
+                    [
+                        VespaConcept(
+                            id="Q123",
+                            name="concept1",
+                            model='KeywordClassifier("concept1")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+                (
+                    "text_block_2",
+                    [
+                        VespaConcept(
+                            id="Q456",
+                            name="concept2",
+                            model='KeywordClassifier("concept2")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+            ],
+            Counter(
+                {
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q123"),
+                        model_name='KeywordClassifier("concept1")',
+                    ): 0,
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q456"),
+                        model_name='KeywordClassifier("concept2")',
+                    ): 1,
+                }
+            ),
+        ),
+        # Case: Multiple concepts in one text block
+        (
+            [None],
+            [
+                (
+                    "text_block_1",
+                    [
+                        VespaConcept(
+                            id="Q123",
+                            name="concept1",
+                            model='KeywordClassifier("concept1")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        ),
+                        VespaConcept(
+                            id="Q456",
+                            name="concept2",
+                            model='KeywordClassifier("concept2")',
+                            start=20,
+                            end=30,
+                            timestamp=datetime.now(),
+                        ),
+                    ],
+                )
+            ],
+            Counter(
+                {
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q123"),
+                        model_name='KeywordClassifier("concept1")',
+                    ): 0,
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q456"),
+                        model_name='KeywordClassifier("concept2")',
+                    ): 0,
+                }
+            ),
+        ),
+        # Case: All failed updates
+        (
+            [Exception("Update failed"), Exception("Another failure")],
+            [
+                (
+                    "text_block_1",
+                    [
+                        VespaConcept(
+                            id="Q123",
+                            name="concept1",
+                            model='KeywordClassifier("concept1")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+                (
+                    "text_block_2",
+                    [
+                        VespaConcept(
+                            id="Q456",
+                            name="concept2",
+                            model='KeywordClassifier("concept2")',
+                            start=0,
+                            end=10,
+                            timestamp=datetime.now(),
+                        )
+                    ],
+                ),
+            ],
+            Counter(
+                {
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q123"),
+                        model_name='KeywordClassifier("concept1")',
+                    ): 1,
+                    ConceptModel(
+                        wikibase_id=WikibaseID("Q456"),
+                        model_name='KeywordClassifier("concept2")',
+                    ): 1,
+                }
+            ),
+        ),
+        # Case: Empty batch
+        ([], [], Counter()),
+    ],
+)
+def test_calculate_concepts_counts_from_results(
+    results,
+    batch,
+    expected_counts,
+):
+    """Test that subtract_concepts_counts correctly processes results and batch data."""
+    actual_counts = calculate_concepts_counts_from_results(results, batch)
+
+    assert actual_counts == expected_counts
+
+
+@pytest.mark.asyncio
+async def test_update_s3_with_latest_concepts_counts_all_success(
+    mock_bucket,
+    mock_s3_client,
+):
+    document_import_id = "CCLW.executive.10014.4470"
+    document_object_uri = (
+        f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+    document_importer = (document_import_id, document_object_uri)
+
+    concepts_counter = Counter(
+        {
+            ConceptModel(
+                wikibase_id=WikibaseID("Q123"),
+                model_name='KeywordClassifier("concept1")',
+            ): 0,
+        }
+    )
+
+    assert (
+        await update_s3_with_latest_concepts_counts(
+            document_importer=document_importer,
+            concepts_counts=concepts_counter,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            document_labelled_passages=[],  # Not used in this branch
+        )
+        is None
+    )
+
+    expected_concepts_counts_key = (
+        f"{CONCEPTS_COUNTS_PREFIX_DEFAULT}/Q787/v4/{document_import_id}.json"
+    )
+    expected_labelled_passages_key = (
+        f"labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+
+    # Ensure the objects were deleted
+    with pytest.raises(ClientError):
+        mock_s3_client.head_object(Bucket=mock_bucket, Key=expected_concepts_counts_key)
+    with pytest.raises(ClientError):
+        mock_s3_client.head_object(
+            Bucket=mock_bucket, Key=expected_labelled_passages_key
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_s3_with_latest_concepts_counts_some_success(
+    mock_bucket,
+    mock_s3_client,
+):
+    document_import_id = "CCLW.executive.10014.4470"
+    document_object_uri = (
+        f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+    )
+    document_importer = (document_import_id, document_object_uri)
+
+    document_labelled_passages: list[LabelledPassage] = [
+        LabelledPassage(
+            id="lp1",
+            text="once upon a time",
+            spans=[
+                Span(
+                    text="once",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q123"),
+                ),
+                Span(
+                    text="upon",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q456"),
+                ),
+            ],
+        ),
+        LabelledPassage(
+            id="lp2",
+            text="lorem ipsum",
+            spans=[
+                Span(
+                    text="ipsum",
+                    start_index=0,
+                    end_index=1,
+                    concept_id=WikibaseID("Q789"),
+                ),
+            ],
+        ),
+    ]
+
+    concepts_counter = Counter(
+        {
+            ConceptModel(
+                wikibase_id=WikibaseID("Q123"),
+                model_name='KeywordClassifier("concept1")',
+            ): 1,
+            ConceptModel(
+                wikibase_id=WikibaseID("Q456"),
+                model_name='KeywordClassifier("concept2")',
+            ): 0,
+        }
+    )
+
+    assert (
+        await update_s3_with_latest_concepts_counts(
+            document_importer=document_importer,
+            concepts_counts=concepts_counter,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            document_labelled_passages=document_labelled_passages,
+        )
+        is None
+    )
+
+    assert json.loads(
+        _s3_object_read_text(
+            s3_path=f"s3://{mock_bucket}/labelled_passages/Q787/v4/{document_import_id}.json"
+        )
+    ) == [
+        '{"id":"lp1","text":"once upon a time","spans":[{"text":"once","start_index":0,"end_index":1,"concept_id":"Q123","labellers":[],"timestamps":[],"id":"z55va9eh","labelled_text":"o"}],"metadata":{}}',
+        '{"id":"lp2","text":"lorem ipsum","spans":[],"metadata":{}}',
+    ]
+    assert json.loads(
+        _s3_object_read_text(
+            s3_path=f"s3://{mock_bucket}/concepts_counts/Q787/v4/{document_import_id}.json"
+        )
+    ) == {"Q123:concept1": 1}
+
+
+@pytest.mark.asyncio
+async def test_run_partial_updates_of_concepts_for_document_passages(
+    mock_bucket,
+    mock_s3_client,
+    mock_bucket_labelled_passages,
+    labelled_passage_fixture_ids,
+    labelled_passage_fixture_files,
+    s3_prefix_labelled_passages,
+    local_vespa_search_adapter: VespaSearchAdapter,
+):
+    document_import_id = labelled_passage_fixture_ids[0]
+    document_object_uri = f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{labelled_passage_fixture_files[0]}"
+    document_importer = (document_import_id, document_object_uri)
+
+    # TODO: Get S3 state before
+    # - Concepts counts
+    # - Labelled passages
+
+    # TODO: Get Vespa state before
+    # - Document passages
+
+    assert (
+        await run_partial_updates_of_concepts_for_document_passages(
+            document_importer=document_importer,
+            cache_bucket=mock_bucket,
+            concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            vespa_search_adapter=local_vespa_search_adapter,
+        )
+        is None
+    )
+
+    # TODO: Test Vespa state after
+    # - Document passages
+
+    # TODO: Test S3 state after
+    # - Concepts counts
+    # - Labelled passages
+
+
+# TODO:
+# @pytest.mark.asyncio
+# async def test_run_partial_updates_of_concepts_for_batch(
+#     mock_bucket,
+#     mock_s3_client,
+# ):
+#     await run_partial_updates_of_concepts_for_batch()
+
+
+# TODO: deindex_by_s3
+# TODO: deindex_labelled_passages_from_s3_to_vespa

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -12,131 +11,26 @@ from cpr_sdk.models.search import Passage as VespaPassage
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from prefect.logging import disable_run_logger
 
-from flows.index import (
-    CONCEPTS_COUNTS_PREFIX_DEFAULT,
-    ClassifierSpec,
+from flows.boundary import (
     ConceptModel,
-    Config,
-    DocumentImporter,
-    convert_labelled_passage_to_concepts,
-    get_data_id_from_vespa_hit_id,
     get_document_passage_from_vespa,
     get_document_passages_from_vespa,
-    get_parent_concepts_from_concept,
-    get_updated_passage_concepts,
-    get_vespa_search_adapter_from_aws_secrets,
     index_by_s3,
-    index_labelled_passages_from_s3_to_vespa,
-    iterate_batch,
     partial_update_text_block,
-    run_partial_updates_of_concepts_for_document_passages,
-    s3_obj_generator,
-    s3_obj_generator_from_s3_paths,
-    s3_obj_generator_from_s3_prefixes,
-    s3_paths_or_s3_prefixes,
 )
-from scripts.cloud import AwsEnv
-from src.concept import Concept
+from flows.index import (
+    CONCEPTS_COUNTS_PREFIX_DEFAULT,
+    Config,
+    index_labelled_passages_from_s3_to_vespa,
+    run_partial_updates_of_concepts_for_document_passages__update,
+    update_concepts_on_existing_vespa_concepts,
+)
+from scripts.cloud import (
+    AwsEnv,
+    ClassifierSpec,
+)
 from src.identifiers import WikibaseID
-from src.labelled_passage import LabelledPassage
-from src.span import Span
-
-DOCUMENT_PASSAGE_ID_PATTERN = re.compile(
-    r"id:doc_search:document_passage::[a-zA-Z]+.[a-zA-Z]+.\d+.\d+.\d+"
-)
-DATA_ID_PATTERN = re.compile(r"[a-zA-Z]+.[a-zA-Z]+.\d+.\d+.\d+")
-
-
-def test_get_data_id_from_vespa_hit_id() -> None:
-    """Test that we can extract the data ID from a vespa hit id."""
-    assert (
-        DATA_ID_PATTERN.match(
-            get_data_id_from_vespa_hit_id(
-                "id:doc_search:document_passage::CCLW.executive.00000.0000.001"
-            )
-        )
-        is not None
-    )
-
-
-def test_vespa_search_adapter_from_aws_secrets(
-    create_vespa_params,
-    mock_vespa_credentials,
-    tmp_path,
-) -> None:
-    """Test that we can successfully instantiate the VespaSearchAdpater from ssm params."""
-    vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
-        cert_dir=str(tmp_path),
-        vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",
-        vespa_private_key_param_name="VESPA_PRIVATE_KEY_FULL_ACCESS",
-    )
-
-    cert_path = tmp_path / "cert.pem"
-    assert cert_path.exists()
-
-    key_path = tmp_path / "key.pem"
-    assert key_path.exists()
-
-    with open(cert_path, "r", encoding="utf-8") as f:
-        assert f.read() == "Public cert content\n"
-    with open(key_path, "r", encoding="utf-8") as f:
-        assert f.read() == "Private key content\n"
-    assert (
-        vespa_search_adapter.instance_url
-        == mock_vespa_credentials["VESPA_INSTANCE_URL"]
-    )
-    assert vespa_search_adapter.client.cert == str(cert_path)
-    assert vespa_search_adapter.client.key == str(key_path)
-
-
-def test_s3_obj_generator_from_s3_prefixes(
-    mock_bucket,
-    mock_bucket_b,
-    mock_bucket_labelled_passages,
-    mock_bucket_labelled_passages_b,
-    s3_prefix_labelled_passages,
-    labelled_passage_fixture_files,
-) -> None:
-    """Test the s3 object generator."""
-    gen = s3_obj_generator_from_s3_prefixes(
-        [
-            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages),
-            os.path.join("s3://", mock_bucket_b, s3_prefix_labelled_passages),
-        ],
-    )
-    result = list(gen)
-    expected: list[DocumentImporter] = [
-        (
-            Path(f).stem,
-            f"s3://{b}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
-        )
-        for b in [mock_bucket, mock_bucket_b]
-        for f in labelled_passage_fixture_files
-    ]
-    assert expected == result
-
-
-def test_s3_obj_generator_from_s3_paths(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-    s3_prefix_labelled_passages,
-    labelled_passage_fixture_files,
-) -> None:
-    """Test the s3 object generator."""
-    s3_paths = [
-        os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
-        for f in labelled_passage_fixture_files
-    ]
-    gen = s3_obj_generator_from_s3_paths(s3_paths=s3_paths)
-    result = list(gen)
-    expected: list[DocumentImporter] = [
-        (
-            Path(f).stem,
-            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
-        )
-        for f in labelled_passage_fixture_files
-    ]
-    assert expected == result
+from tests.flows.test_boundary import DOCUMENT_PASSAGE_ID_PATTERN
 
 
 @pytest.mark.vespa
@@ -264,7 +158,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
 
     assert (
         test_counts
-        == await run_partial_updates_of_concepts_for_document_passages.fn(
+        == await run_partial_updates_of_concepts_for_document_passages__update.fn(
             document_importer=(document_import_id, document_object_uri),
             vespa_search_adapter=local_vespa_search_adapter,
             cache_bucket=mock_bucket,
@@ -323,7 +217,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages_task_failur
         # Run the update
         assert (
             Counter()
-            == await run_partial_updates_of_concepts_for_document_passages.fn(
+            == await run_partial_updates_of_concepts_for_document_passages__update.fn(
                 document_importer=(document_import_id, document_object_uri),
                 vespa_search_adapter=local_vespa_search_adapter,
                 cache_bucket=mock_bucket,
@@ -364,6 +258,7 @@ async def test_index_by_s3_with_s3_prefixes(
     )
 
     await index_by_s3(
+        partial_update_flow=run_partial_updates_of_concepts_for_document_passages__update,
         aws_env=AwsEnv.sandbox,
         vespa_search_adapter=local_vespa_search_adapter,
         s3_prefixes=[os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)],
@@ -409,6 +304,7 @@ async def test_index_by_s3_with_s3_paths(
     ]
 
     await index_by_s3(
+        partial_update_flow=run_partial_updates_of_concepts_for_document_passages__update,
         aws_env=AwsEnv.sandbox,
         vespa_search_adapter=local_vespa_search_adapter,
         s3_prefixes=None,
@@ -449,10 +345,11 @@ async def test_index_by_s3_task_failure(
         raise Exception("Forced update failure")
 
     with patch(
-        "flows.index.run_partial_updates_of_concepts_for_batch_flow_or_deployment",
+        "flows.boundary.run_partial_updates_of_concepts_for_batch_flow_or_deployment",
         side_effect=mock_run_partial_updates_of_concepts_for_batch_flow_or_deployment,
     ):
         await index_by_s3(
+            partial_update_flow=run_partial_updates_of_concepts_for_document_passages__update,
             aws_env=AwsEnv.sandbox,
             vespa_search_adapter=local_vespa_search_adapter,
             s3_prefixes=[
@@ -508,6 +405,7 @@ async def test_partial_update_text_block(
         [concept_a],
         document_import_id,
         local_vespa_search_adapter,
+        update_concepts_on_existing_vespa_concepts,
     )
 
     assert result_a is None
@@ -532,6 +430,7 @@ async def test_partial_update_text_block(
         [concept_b],
         document_import_id,
         local_vespa_search_adapter,
+        update_concepts_on_existing_vespa_concepts,
     )
 
     assert result_b is None
@@ -608,10 +507,14 @@ async def test_index_labelled_passages_from_s3_to_vespa_with_document_ids_with_d
     local_vespa_search_adapter: VespaSearchAdapter,
     vespa_app,
 ) -> None:
-    with patch("flows.index.get_prefect_job_variable", return_value=mock_bucket), patch(
-        "flows.index.get_vespa_search_adapter_from_aws_secrets",
-        return_value=local_vespa_search_adapter,
-    ), disable_run_logger():
+    with (
+        patch("flows.index.get_prefect_job_variable", return_value=mock_bucket),
+        patch(
+            "flows.boundary.get_vespa_search_adapter_from_aws_secrets",
+            return_value=local_vespa_search_adapter,
+        ),
+        disable_run_logger(),
+    ):
         initial_passages_response = local_vespa_search_adapter.client.query(
             yql="select * from document_passage where true"
         )
@@ -642,14 +545,14 @@ async def test_index_labelled_passages_from_s3_to_vespa_with_document_ids_with_d
     assert final_concepts_count == 3933
 
 
-def test_get_updated_passage_concepts(
+def test_update_concepts_on_existing_vespa_concepts(
     example_vespa_concepts: list[VespaConcept],
 ) -> None:
     """Test that we can retrieve the updated passage concepts dict."""
     for concept in example_vespa_concepts:
         # Test we can add a concept to the passage concepts that doesn't already
         # exist.
-        updated_passage_concepts = get_updated_passage_concepts(
+        updated_passage_concepts = update_concepts_on_existing_vespa_concepts(
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
@@ -663,7 +566,7 @@ def test_get_updated_passage_concepts(
 
         # Test that we can remove old model concepts from the passage concepts and
         # add the new one.
-        updated_passage_concepts = get_updated_passage_concepts(
+        updated_passage_concepts = update_concepts_on_existing_vespa_concepts(
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
@@ -687,7 +590,7 @@ def test_get_updated_passage_concepts(
         assert updated_passage_concepts[0] == concept.model_dump(mode="json")
 
         # Test that we can add new concepts and retain concepts from other models
-        updated_passage_concepts = get_updated_passage_concepts(
+        updated_passage_concepts = update_concepts_on_existing_vespa_concepts(
             passage=VespaPassage(
                 text_block="Test text.",
                 text_block_id="1",
@@ -709,248 +612,3 @@ def test_get_updated_passage_concepts(
         )
         assert len(updated_passage_concepts) == 2
         assert concept.model_dump(mode="json") in updated_passage_concepts
-
-
-def test_convert_labelled_passges_to_concepts(
-    example_labelled_passages: list[LabelledPassage],
-) -> None:
-    """Test that we can correctly convert labelled passages to concepts."""
-    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
-    assert all([isinstance(concept, VespaConcept) for concept in concepts])
-
-
-def test_convert_labelled_passges_to_concepts_raises_error(
-    example_labelled_passages: list[LabelledPassage],
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test that we correctly log errors when a Span has no concept ID or timestamps."""
-    # Add a span without concept_id
-    example_labelled_passages[0].spans.append(
-        Span(
-            text="Test text.",
-            start_index=0,
-            end_index=8,
-            concept_id=None,
-            labellers=[],
-        )
-    )
-    # Add a span without timestamps
-    example_labelled_passages[0].spans.append(
-        Span(
-            text="Test text.",
-            start_index=0,
-            end_index=8,
-            concept_id="Q123",
-            labellers=[],
-            timestamps=[],  # Empty timestamps
-        )
-    )
-
-    concepts = convert_labelled_passage_to_concepts(example_labelled_passages[0])
-
-    # Check that appropriate error messages were logged
-    error_messages = [r.message for r in caplog.records if r.levelname == "ERROR"]
-    assert any("span concept ID is missing" in msg for msg in error_messages)
-    assert any("span timestamps are missing" in msg for msg in error_messages)
-
-    # Verify that the problematic spans were skipped but valid one was processed
-    assert len(concepts) == 1
-
-
-def test_get_parent_concepts_from_concept() -> None:
-    """Test that we can correctly retrieve the parent concepts from a concept."""
-    assert get_parent_concepts_from_concept(
-        concept=Concept(
-            preferred_label="forestry sector",
-            alternative_labels=[],
-            negative_labels=[],
-            wikibase_id=WikibaseID("Q10014"),
-            subconcept_of=[WikibaseID("Q4470")],
-            has_subconcept=[WikibaseID("Q4471")],
-            labelled_passages=[],
-        )
-    ) == ([{"id": "Q4470", "name": ""}], "Q4470,")
-
-
-def test_s3_paths_or_s3_prefixes_no_classifier(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-):
-    """Test s3_paths_or_s3_prefixes returns base prefix when no classifier spec provided."""
-    config = Config(cache_bucket=mock_bucket)
-
-    s3_accessor = s3_paths_or_s3_prefixes(
-        classifier_specs=None,
-        document_ids=None,
-        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
-        prefix=config.document_source_prefix,
-    )
-
-    assert s3_accessor.prefixes == [f"s3://{mock_bucket}/labelled_passages"]
-    assert s3_accessor.paths is None
-
-
-def test_s3_paths_or_s3_prefixes_no_classifier_and_docs(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-    labelled_passage_fixture_ids,
-    labelled_passage_fixture_files,
-    s3_prefix_mock_bucket_labelled_passages,
-):
-    config = Config(cache_bucket=mock_bucket)
-
-    with pytest.raises(
-        ValueError,
-        match="if document IDs are specified, a classifier "
-        "specifcation must also be specified, since they're "
-        "namespaced by classifiers \\(e\\.g\\. "
-        "`s3://cpr-sandbox-data-pipeline-cache/labelled_passages/Q787/"
-        "v4/CCLW\\.legislative\\.10695\\.6015\\.json`\\)",
-    ), disable_run_logger():
-        s3_paths_or_s3_prefixes(
-            classifier_specs=None,
-            document_ids=labelled_passage_fixture_ids,
-            cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
-            prefix=config.document_source_prefix,
-        )
-
-
-def test_s3_paths_or_s3_prefixes_with_classifier_no_docs(
-    mock_bucket,
-):
-    """Test s3_paths_or_s3_prefixes returns classifier-specific prefix when no document IDs provided."""
-    config = Config(cache_bucket=mock_bucket)
-    classifier_spec_q788 = ClassifierSpec(name="Q788", alias="latest")
-    classifier_spec_q699 = ClassifierSpec(name="Q699", alias="latest")
-
-    s3_accessor = s3_paths_or_s3_prefixes(
-        classifier_specs=[classifier_spec_q788, classifier_spec_q699],
-        document_ids=None,
-        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
-        prefix=config.document_source_prefix,
-    )
-
-    assert s3_accessor.prefixes == [
-        f"s3://{mock_bucket}/labelled_passages/Q788/latest",
-        f"s3://{mock_bucket}/labelled_passages/Q699/latest",
-    ]
-    assert s3_accessor.paths is None
-
-
-def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
-    mock_bucket,
-    mock_bucket_labelled_passages,
-    labelled_passage_fixture_ids,
-    labelled_passage_fixture_files,
-    s3_prefix_mock_bucket_labelled_passages,
-):
-    """Test s3_paths_or_s3_prefixes returns specific paths when both classifier and document IDs provided."""
-    config = Config(cache_bucket=mock_bucket)
-    classifier_spec = ClassifierSpec(name="Q788", alias="latest")
-
-    expected_paths = [
-        f"{s3_prefix_mock_bucket_labelled_passages}/{labelled_passage_fixture_file}"
-        for labelled_passage_fixture_file in labelled_passage_fixture_files
-    ]
-
-    s3_accessor = s3_paths_or_s3_prefixes(
-        classifier_specs=[classifier_spec],
-        document_ids=labelled_passage_fixture_ids,
-        cache_bucket=config.cache_bucket,  # pyright: ignore[reportArgumentType]
-        prefix=config.document_source_prefix,
-    )
-
-    assert s3_accessor.prefixes is None
-    assert sorted(s3_accessor.paths) == sorted(  # pyright: ignore[reportArgumentType]
-        expected_paths
-    )
-
-
-@pytest.mark.parametrize(
-    "s3_prefixes,s3_paths,expected_error,error_match",
-    [
-        # Both provided - should raise error
-        (
-            ["s3://bucket/prefix"],
-            ["s3://bucket/prefix/file.json"],
-            ValueError,
-            "Either s3_prefixes or s3_paths must be provided, not both.",
-        ),
-        # Neither provided - should raise error
-        (
-            None,
-            None,
-            ValueError,
-            "Either s3_prefix or s3_paths must be provided.",
-        ),
-        # Invalid types - should raise error
-        (
-            None,
-            None,
-            ValueError,
-            "Either s3_prefix or s3_paths must be provided.",
-        ),
-    ],
-)
-def test_s3_obj_generator_errors(
-    s3_prefixes: list[str] | None,
-    s3_paths: list[str] | None,
-    expected_error: type[Exception],
-    error_match: str,
-) -> None:
-    """Test s3_obj_generator error cases."""
-    with pytest.raises(expected_error, match=error_match), disable_run_logger():
-        _ = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
-
-
-@pytest.mark.parametrize(
-    "use_prefixes",
-    [True, False],
-    ids=["using_prefixes", "using_paths"],
-)
-def test_s3_obj_generator_valid_cases(
-    mock_bucket: str,
-    mock_bucket_labelled_passages: None,
-    s3_prefix_labelled_passages: str,
-    labelled_passage_fixture_files: list[str],
-    use_prefixes: bool,
-) -> None:
-    """Test s3_obj_generator with valid inputs using either prefixes or paths."""
-    if use_prefixes:
-        s3_prefixes = [os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages)]
-        s3_paths = None
-    else:
-        s3_prefixes = None
-        s3_paths = [
-            os.path.join("s3://", mock_bucket, s3_prefix_labelled_passages, f)
-            for f in labelled_passage_fixture_files
-        ]
-
-    gen = s3_obj_generator(s3_prefixes=s3_prefixes, s3_paths=s3_paths)
-    result = list(gen)
-    expected: list[DocumentImporter] = [
-        (
-            Path(f).stem,
-            f"s3://{mock_bucket}/{s3_prefix_labelled_passages}/{Path(f).stem}.json",
-        )
-        for f in labelled_passage_fixture_files
-    ]
-    assert expected == result
-
-
-@pytest.mark.parametrize(
-    "data, expected_lengths",
-    [
-        # Lists
-        (list(range(50)), [50]),
-        (list(range(850)), [400, 400, 50]),
-        ([], [0]),
-        # Generators
-        ((x for x in range(50)), [50]),
-        ((x for x in range(850)), [400, 400, 50]),
-        ((x for x in []), [0]),
-    ],
-)
-def test_iterate_batch(data, expected_lengths):
-    for batch, expected in zip(list(iterate_batch(data, 400)), expected_lengths):
-        assert len(batch) == expected

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -9,6 +9,7 @@ from flows.utils import (
     SlackNotify,
     file_name_from_path,
     get_file_stems_for_document_id,
+    iterate_batch,
     remove_translated_suffix,
     s3_file_exists,
 )
@@ -59,6 +60,24 @@ def test_remove_translated_suffix(file_name: str, expected: str) -> None:
     """Test that we can remove the translated suffix from a file name."""
 
     assert remove_translated_suffix(file_name) == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected_lengths",
+    [
+        # Lists
+        (list(range(50)), [50]),
+        (list(range(850)), [400, 400, 50]),
+        ([], [0]),
+        # Generators
+        ((x for x in range(50)), [50]),
+        ((x for x in range(850)), [400, 400, 50]),
+        ((x for x in []), [0]),
+    ],
+)
+def test_iterate_batch(data, expected_lengths):
+    for batch, expected in zip(list(iterate_batch(data, 400)), expected_lengths):
+        assert len(batch) == expected
 
 
 def test_s3_file_exists(test_config, mock_bucket_documents) -> None:


### PR DESCRIPTION
We now wipe the concepts from S3 (the CDN).

Along with this, we trigger the new de-indexing pipeline, to remove the concepts' inference and concepts counts objects, and labelled passages (spans) in Vespa.

TOWARDS PLA-481
TOWARDS PLA-469
