### PR TITLE
build: Disable running workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,13 +1,13 @@
 name: Bump dependencies
 
-on:
-  schedule:
-    - cron: '0 0 1 * *'
-  workflow_dispatch:
+# on:
+#   schedule:
+#     - cron: '0 0 1 * *'
+#   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# permissions:
+#   contents: write
+#   pull-requests: write
 
 jobs:
   pre-commit:


### PR DESCRIPTION
This has a compromised GH Action[^1] that dumps secrets.

For now, this just disables the workflow from running, and then we can refactor it with an alternative approach.

This is the only use within our GitHub organisation[^2].

[^1]: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
[^2]: https://github.com/search?q=org%3Aclimatepolicyradar+uses%3A+tj-actions%2F&type=code
