### PR TITLE
Run inference on only english documents.

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -407,7 +407,7 @@ async def run_classifier_inference_on_document(
             raise
     print(f"Loaded document with file stem {file_stem}")
 
-    if document.languages and document.languages != ["en"]:
+    if document.languages != ["en"]:
         raise ValueError(
             f"Cannot run inference on {file_stem} as it has non-english language: "
             f"{document.languages}"

--- a/tests/flows/fixtures/PDF.document.0.1.json
+++ b/tests/flows/fixtures/PDF.document.0.1.json
@@ -7,6 +7,7 @@
     "document_metadata": {
         "import_id": "PDF.document.0.1"
     },
+    "languages": ["en"],
     "html_data": null,
     "pdf_data": {
         "page_metadata": [],

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -263,7 +263,6 @@ async def test_run_classifier_inference_on_document(
     # Setup
     _, mock_run, _ = mock_wandb
     test_config.local_classifier_dir = mock_classifiers_dir
-    document_id = Path(mock_bucket_documents[0]).stem
     classifier_name = "Q788"
     classifier_alias = "latest"
 
@@ -272,7 +271,21 @@ async def test_run_classifier_inference_on_document(
         mock_run, test_config, classifier_name, classifier_alias
     )
 
-    # Run the function
+    # Run the function on a document with no language
+    document_id = Path(mock_bucket_documents[1]).stem
+    with pytest.raises(ValueError) as exc_info:
+        result = await run_classifier_inference_on_document(
+            config=test_config,
+            file_stem=document_id,
+            classifier_name=classifier_name,
+            classifier_alias=classifier_alias,
+            classifier=classifier,
+        )
+
+    assert "Cannot run inference on" in str(exc_info.value)
+
+    # Run the function on a document with english language
+    document_id = Path(mock_bucket_documents[0]).stem
     result = await run_classifier_inference_on_document(
         config=test_config,
         file_stem=document_id,


### PR DESCRIPTION
This Pull Request: 
---
- Updates the inference pipeline to run on only english documents. 
- Notably we don't run inference on documents that have no language. 
- This is as there will be a corresponding translated document that has language english. 
- We don't wish to run inference and indexing on both and are preferring the english version. 