### PR TITLE
Adding in a bug fix for the scenario when we have no concepts.

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -475,6 +475,22 @@ def convert_labelled_passage_to_concepts(
 
     concepts: list[VespaConcept] = []
 
+    if not labelled_passage.metadata.get("concept") and not labelled_passage.spans:
+        logger.info(
+            "Inference didn't identify any results.",
+            extra={"labelled_passage_id": labelled_passage.id},
+        )
+        return concepts
+
+    if not labelled_passage.metadata.get("concept") and labelled_passage.spans:
+        logger.error(
+            "We have spans but no concept metadata.",
+            extra={"labelled_passage_id": labelled_passage.id},
+        )
+        raise ValueError(
+            "We have spans but no concept metadata.",
+        )
+
     # The concept used to label the passage holds some information on the parent
     # concepts and thus this is being used as a temporary solution for providing
     # the relationship between concepts. This has the downside that it ties a


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for a key error seen in staging related to empty metadata (e.g. no concepts). 
- This is as we have updated inference to now output labelled passages with no results. 

[prefect run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/3164c898-19e2-4f1e-9a2a-555337e32780?entity_id=143073b1-3128-437e-882c-d9cd6e0706a2)

Example empty labelled pasasge: 

```json 
{"id": "0", "text": "Vintage 2018", "spans": [], "metadata": {}}, {"id": "1", "text": "Official Gazette of the Kingdom of the Netherlands", "spans": [], "metadata": {}}
```