### PR TITLE
fix: Surface tasks failures in inference

### DIFF
--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -294,8 +294,7 @@ async def test_run_classifier_inference_on_document(
         classifier=classifier,
     )
 
-    # Check the return value is a tuple with the expected values
-    assert result == (document_id, classifier_name, classifier_alias)
+    assert result is None
 
     # Verify that labels were stored in S3
     labels = helper_list_labels_in_bucket(test_config, mock_bucket)


### PR DESCRIPTION
I did an inference run[^1] and everything succeeded! jk, none that I sampled did. Similar to changes yesterday, this change surfaces failures for tasks.

TOWARDS PLA-481

[^1]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/9c17ae1c-a9b6-4fa6-b1c7-c6d7e6a61994?entity_id=f3afae10-f141-44ae-b969-ad695df5b74c
