### PR TITLE
build: Separate CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,60 +1,17 @@
-name: CI/CD
+name: CD
+
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: write
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Install poetry
-        shell: bash
-        run: pipx install poetry==1.8.2
-
-      - name: Install just
-        run: pipx install rust-just
-
-      - name: Install python or load from cache with dependencies
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
-          cache: poetry
-
-      - name: Install dependencies
-        run: just install
-
-      - name: Lint
-        run: just lint-all
-
-      - name: Install latest Vespa CLI
-        env:
-          VESPA_CLI_VERSION: 8.250.43
-        run: |
-          mkdir vespa-cli
-          curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | \
-            tar -zxf - -C vespa-cli --strip-component=1
-          echo "vespa-cli/bin" >> $GITHUB_PATH
-
-      - name: Setup local Vespa
-        run: just vespa_dev_setup
-
-      - name: Test
-        run: just test -v -m "'not flaky_on_ci and not transformers'" --ignore tests/test_argilla_v2.py
-
   deploy_docs:
-    if: github.ref == 'refs/heads/main'
-    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -79,7 +36,6 @@ jobs:
 
   deploy_prefect_sandbox:
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    needs: [test]
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: sandbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: "Lint"
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry==1.8.2
+
+      - name: Install just
+        run: pipx install rust-just
+
+      - name: Install python or load from cache with dependencies
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+          cache: poetry
+
+      - name: Install dependencies
+        run: just install
+
+      - name: Run linting
+        run: just lint-all
+
+  test:
+    runs-on: ubuntu-latest
+    name: "Test"
+    needs: [lint]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry==1.8.2
+
+      - name: Install just
+        run: pipx install rust-just
+
+      - name: Install python or load from cache with dependencies
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+          cache: poetry
+
+      - name: Install dependencies
+        run: just install
+
+      - name: Install latest Vespa CLI
+        env:
+          VESPA_CLI_VERSION: 8.250.43
+        run: |
+          mkdir vespa-cli
+          curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | \
+            tar -zxf - -C vespa-cli --strip-component=1
+          echo "vespa-cli/bin" >> $GITHUB_PATH
+
+      - name: Setup local Vespa
+        run: just vespa_dev_setup
+
+      - name: Run tests
+        run: just test -v -m "'not flaky_on_ci and not transformers'" --ignore tests/test_argilla_v2.py


### PR DESCRIPTION
I've found it slightly distasteful to have checks permanently skipped for PRs, as it makes it slightly less clear on PRs when looking at checks, and I think it's neater to explicitly have the dependency as "iff CI passes" checked as few times as possible, and at the highest level possible.

It's now possible to have cross-workflow dependencies[^1]!

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
