### PR TITLE
Bugfix: Reduce noise from non-english docs presented to inference

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -598,7 +598,7 @@ async def classifier_inference(
         for result in results:
             # We'd never expect the flow run name to be missing, but
             # Prefect does account for that in their class.
-            name: str | UUID = result.flow_run_name or result.name
+            name: str | UUID = result.name
             if result.state is None:
                 failures[classifier_spec].append(name)
             else:

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -598,7 +598,7 @@ async def classifier_inference(
         for result in results:
             # We'd never expect the flow run name to be missing, but
             # Prefect does account for that in their class.
-            name: str | UUID = result.name
+            name: str = result.name
             if result.state is None:
                 failures[classifier_spec].append(name)
             else:

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -127,8 +127,8 @@ def get_file_stems_for_document_id(
     Example:
     "CCLW.executive.1.1" -> ["CCLW.executive.1.1_translated_en"]
 
-    Note that we don't include the original documemt id in the list of stems.
-    This is because we are looking for only english language documents.
+    Note that we don't include the original document ID in the list of stems.
+    This is because we are looking for only English language documents.
     """
     stems = []
 

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -125,9 +125,12 @@ def get_file_stems_for_document_id(
     find any translated documents in a directory for a document id as follows:
 
     Example:
-    "CCLW.executive.1.1" -> ["CCLW.executive.1.1_translated_en", "CCLW.executive.1.1"]
+    "CCLW.executive.1.1" -> ["CCLW.executive.1.1_translated_en"]
+
+    Note that we don't include the original documemt id in the list of stems.
+    This is because we are looking for only english language documents.
     """
-    stems = [document_id]
+    stems = []
 
     for target_language in ["en"]:
         translated_file_key = (
@@ -141,6 +144,9 @@ def get_file_stems_for_document_id(
         )
         if file_exists:
             stems.append(translated_file_key.stem)
+
+    if not stems:
+        stems.append(document_id)
 
     return stems
 

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -126,7 +126,7 @@ def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> N
         ),
     )
 
-    assert file_stems == [document_id, f"{document_id}_translated_en"]
+    assert file_stems == [f"{document_id}_translated_en"]
 
 
 def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) -> None:

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -163,9 +163,7 @@ def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) ->
     )
     assert sorted(document_paths) == sorted(
         [
-            f"s3://{test_config.cache_bucket}/"
-            f"{test_config.document_target_prefix}/"
-            f"{classifier_spec.name}/{classifier_spec.alias}/{file_name}"
-            for file_name in s3_file_names
+            f"s3://{test_config.cache_bucket}/{test_config.document_target_prefix}/{classifier_spec.name}/{classifier_spec.alias}/CCLW.executive.1.1_translated_en.json",
+            f"s3://{test_config.cache_bucket}/{test_config.document_target_prefix}/{classifier_spec.name}/{classifier_spec.alias}/CCLW.executive.10083.rtl_190.json",
         ]
     )


### PR DESCRIPTION
This Pull Request: 
---
Updates the KG pipelines to: 
- Remove non translated file stems if we find a translated one.
- This should reduce noise from trying to run inference on non-english documents as documents with no language or a non english language will have a relating translated one which we do present for inference. 
- Also integrates a bug fix for an error that was observed in [staging](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/1f494e56-d870-4cfe-b068-8b625e15a3de?entity_id=1f494e56-d870-4cfe-b068-8b625e15a3de). 

```shell
Failed due to a(n) AttributeError in the Prefect flow run. The error occurred because the 'FlowRun' object does not have an attribute 'flow_run_name', leading to a failure in the flow execution.
```

Successful prefect [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/a4663db2-4bbf-4548-8918-580160d330eb?entity_id=a4663db2-4bbf-4548-8918-580160d330eb).

Labelled passage produced today: 
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/aa2233ed-05b6-4f14-b72f-b1c86d402fc3" />
