### PR TITLE
fix: Use Vespa-friendly family document ID

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -989,10 +989,6 @@ async def run_partial_updates_of_concepts_for_document_passages__update(
         for batch_num, batch in enumerate(batches, start=1):
             logger.info(f"processing partial updates batch {batch_num}")
 
-            # We query vespa for document passages that contain a matching import id.
-            # The document imported contains the file stem which could contain a
-            # translated suffix. We remove this suffix to get the document import id.
-            # E.g. CCLW.executive.1.1_translated_en -> CCLW.executive.1.1
             document_import_id = remove_translated_suffix(document_importer[0])
 
             partial_update_tasks = [
@@ -1146,7 +1142,7 @@ async def run_partial_updates_of_concepts_for_document_passages__remove(
             partial_update_tasks = [
                 partial_update_text_block(
                     text_block_id=text_block_id,
-                    document_import_id=document_importer[0],
+                    document_import_id=remove_translated_suffix(document_importer[0]),
                     concepts=concepts,
                     vespa_search_adapter=vespa_search_adapter,
                     update_function=remove_concepts_from_existing_vespa_concepts,

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -73,6 +73,8 @@ def remove_translated_suffix(file_name: str) -> str:
     """
     Remove the suffix from a file name that indicates it has been translated.
 
+    Often used for querying Vespa.
+
     E.g. "CCLW.executive.1.1_en_translated" -> "CCLW.executive.1.1"
     """
     return re.sub(r"(_translated(?:_[a-zA-Z]+)?)$", "", file_name)


### PR DESCRIPTION
We don't store the translated prefeix for the family document ID. Thus, strip it out.

I came across this when investigating a de-index pipeline run[^1].

Some time, we should add tests for the translation scenario.

[^1]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/226ea582-2bcc-465a-99be-e6a85005e1dc?entity_id=a2ec38ff-35eb-4fcf-9443-0cc3c3fc805d
