### PR TITLE
fix: Properly timeout on Prefect

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -25,6 +25,7 @@ from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow, get_run_logger
 from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.deployments.deployments import run_deployment
+from prefect.flow_runs import wait_for_flow_run
 from prefect.logging import get_logger
 from pydantic import BaseModel
 from vespa.io import VespaQueryResponse, VespaResponse
@@ -815,19 +816,14 @@ async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
     aws_env: AwsEnv,
     as_deployment: bool,
     partial_update_flow: Operation,
+    ttl_per_task_s: int,
 ) -> FlowRun | None:
     """Run partial updates for a batch of documents as a sub-flow or deployment."""
-    logger = get_run_logger()
-    logger.info(
-        "Running partial updates of concepts for batch as sub-flow or deployment: "
-        f"batch length {len(documents_batch)}, as_deployment: {as_deployment}"
-    )
-
     if as_deployment:
         flow_name = function_to_flow_name(run_partial_updates_of_concepts_for_batch)
         deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
 
-        return await run_deployment(
+        flow_run: FlowRun = await run_deployment(
             name=f"{flow_name}/{deployment_name}",
             parameters={
                 "documents_batch": documents_batch,
@@ -836,7 +832,14 @@ async def run_partial_updates_of_concepts_for_batch_flow_or_deployment(
                 "concepts_counts_prefix": concepts_counts_prefix,
                 "partial_update_flow": partial_update_flow,
             },
-            timeout=3600,
+            # Return the metadata immediately
+            timeout=0,
+        )
+
+        # Now, do the actual waiting, since we have the metadata
+        return await wait_for_flow_run(
+            flow_run_id=flow_run.id,
+            timeout=ttl_per_task_s,  # Seconds
         )
 
     return await run_partial_updates_of_concepts_for_batch(
@@ -895,15 +898,27 @@ async def updates_by_s3(
     for i, updates_task_batch in enumerate(updates_task_batches, start=1):
         logger.info(f"Processing updates task batch #{i}")
 
+        ttl_per_task_s = 30 * 60
+
         updates_tasks = [
-            run_partial_updates_of_concepts_for_batch_flow_or_deployment(
-                documents_batch=documents_batch,
-                documents_batch_num=documents_batch_num,
-                cache_bucket=cache_bucket,
-                concepts_counts_prefix=concepts_counts_prefix,
-                aws_env=aws_env,
-                as_deployment=as_deployment,
-                partial_update_flow=partial_update_flow,
+            asyncio.wait_for(
+                run_partial_updates_of_concepts_for_batch_flow_or_deployment(
+                    documents_batch=documents_batch,
+                    documents_batch_num=documents_batch_num,
+                    cache_bucket=cache_bucket,
+                    concepts_counts_prefix=concepts_counts_prefix,
+                    aws_env=aws_env,
+                    as_deployment=as_deployment,
+                    partial_update_flow=partial_update_flow,
+                    ttl_per_task_s=ttl_per_task_s,
+                ),
+                # We could just rely on the timeout via Prefect, but,
+                # this may also not be running on Prefect.
+                #
+                # Realistically, there is some spin-up time on
+                # Prefect, for the task to actually be executing our
+                # code, so be aware of that.
+                timeout=ttl_per_task_s,  # Seconds
             )
             for documents_batch_num, documents_batch in enumerate(
                 updates_task_batch, start=1


### PR DESCRIPTION
We fundamentally misunderstood what the timeout parameter was for.

> By default, this function blocks until the flow run finishes executing. Specify a timeout (in seconds) to wait for the flow run to execute before returning flow run metadata. To return immediately,
without waiting for the flow run to execute, set timeout=0.[^1]

It’s a timeout for returning metadata, not for execution to finish. E.g. by having 3600, we’re saying “no matter if the `FlowRun` is still executing, return the metadata, and let the `FlowRun` continue on until it finishes, with no actual timeout”.

For an incident[^2], we were confused as to why they hadn't timed out! We actually had been confused before too, and we did set a timeout, or increased it, I don't remember which. We didn't realise this then due to our general sporadic work across many projects.

Now, we properly wait![^3]

An alternative approach is to annotate the decorator:

```python
from prefect import flow
import time

@flow(timeout_seconds=1, log_prints=True)
def show_timeouts():
    print("I will execute")
    time.sleep(5)
    print("I will not execute")
```

The change I'm proposing felt more suitable with the current code.

What if a task actually goes over? I'm not sure. I already know that this timeout will be too short for really big documents.[^4]

[^1]: https://docs-2.prefect.io/latest/api-ref/prefect/deployments/deployments/#prefect.deployments.deployments.run_deployment
[^2]: https://climate-policy-radar.slack.com/archives/C08LN4VA2D8/p1743668576959819
[^3]: https://docs-2.prefect.io/latest/api-ref/prefect/flow_runs/#prefect.flow_runs.wait_for_flow_run
[^4]: If you look at
https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/3a6dbe77-bebb-4788-89d2-f581ce2e948e?entity_id=5bedd38b-8432-4f1b-b792-3a71bbcb4eb7,
you'll see most are relatively quick, but a few are >3, or >6 hours.
