### PR TITLE
Data backup transient errors

### DIFF
--- a/flows/data_backup.py
+++ b/flows/data_backup.py
@@ -34,6 +34,7 @@ def data_backup():
     argilla_session = ArgillaSession()
     hf_session = HuggingfaceSession()
 
+    error = False
     datasets = argilla_session.get_all_datasets("knowledge-graph")
     for dataset in datasets:
         labelled_passages = argilla_session.dataset_to_labelled_passages(dataset)
@@ -43,9 +44,15 @@ def data_backup():
                 dataset.name, KNOWLEDGE_GRAPH_COLLECTION
             )
         except exceptions.ReadTimeout:
+            error = True
             logger.warning(
                 f"Read timeout while pushing to Huggingface. Skipping dataset {dataset.name}"
             )
+
+    if error:
+        raise exceptions.ReadTimeout(
+            "Read timeout while pushing to Huggingface. Check logs for details."
+        )
 
 
 if __name__ == "__main__":

--- a/flows/data_backup.py
+++ b/flows/data_backup.py
@@ -19,6 +19,9 @@ def setup_environment():
     os.environ["HF_TOKEN"] = get_aws_ssm_param("/Huggingface/Token")
 
 
+KNOWLEDGE_GRAPH_COLLECTION = "knowledge-graph-67bf0c90f3d898533e66cfaf"
+
+
 @flow
 def data_backup():
     """Flow to deploy all our static sites."""
@@ -30,6 +33,7 @@ def data_backup():
     for dataset in datasets:
         labelled_passages = argilla_session.dataset_to_labelled_passages(dataset)
         hf_session.push(dataset.name, labelled_passages)
+        hf_session.add_dataset_to_collection(dataset.name, KNOWLEDGE_GRAPH_COLLECTION)
 
 
 if __name__ == "__main__":

--- a/src/huggingface.py
+++ b/src/huggingface.py
@@ -64,6 +64,7 @@ class HuggingfaceSession:
         add_collection_item(
             collection_slug=f"{self.organisation}/{collection_slug}",
             item_id=dataset_name,
+            exists_ok=True,
             item_type="dataset",
             token=self.token,
         )

--- a/src/huggingface.py
+++ b/src/huggingface.py
@@ -1,8 +1,10 @@
 import os
+
+from tenacity import retry, stop_after_attempt, wait_fixed
 from typing import Optional
 
 from datasets import Dataset, load_dataset
-from huggingface_hub import get_collection, add_collection_item
+from huggingface_hub import add_collection_item
 
 from src.labelled_passage import LabelledPassage
 from src.span import Span
@@ -66,6 +68,7 @@ class HuggingfaceSession:
             token=self.token,
         )
 
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3))
     def push(self, dataset_name: str, labelled_passages: list[LabelledPassage]) -> None:
         """Pushes the dataset to the hub"""
         dataset = Dataset.from_dict(

--- a/src/huggingface.py
+++ b/src/huggingface.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional
 
 from datasets import Dataset, load_dataset
+from huggingface_hub import get_collection, add_collection_item
 
 from src.labelled_passage import LabelledPassage
 from src.span import Span
@@ -52,6 +53,17 @@ class HuggingfaceSession:
             text=row["text"],
             spans=[Span(**s) for s in row["spans"]],
             metadata=row["metadata"],
+        )
+
+    def add_dataset_to_collection(
+        self, dataset_name: str, collection_slug: str
+    ) -> None:
+        """Adds the dataset to a collection"""
+        add_collection_item(
+            collection_slug=f"{self.organisation}/{collection_slug}",
+            item_id=dataset_name,
+            item_type="dataset",
+            token=self.token,
         )
 
     def push(self, dataset_name: str, labelled_passages: list[LabelledPassage]) -> None:


### PR DESCRIPTION
## What this PR does
Occasionally the backup prefect flow for knowledge graph labelled data is failing ([example](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/0f9104fb-a41a-4f53-9c54-996a6e44fe0b?entity_id=0f9104fb-a41a-4f53-9c54-996a6e44fe0b)). As far as I could tell from the logs, this is a transient issue, which relates to downloading the dataset cards from the hub, if they already exist. 

I've done the following to work around this:
- added retries to the hf push method (that's failing) -- 3 second wait, and 3 times 
- catching this exception in the loop over the knowledge-graph datasets: making sure, that if 1 errors out, we're backing up all others regardless. This error is then raised in the end of the process, which is for us to be able to monitor failing backups. 
