### PR TITLE
fix: Don't allow misleading `latest` version

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -269,7 +269,7 @@ def s3_paths_or_s3_prefixes(
                     cache_bucket,
                     prefix,
                     classifier_spec.name,
-                    classifier_spec.alias,
+                    str(classifier_spec.alias),
                 )
                 for classifier_spec in classifier_specs
             ]

--- a/flows/count_family_document_concepts.py
+++ b/flows/count_family_document_concepts.py
@@ -26,6 +26,7 @@ from flows.utils import SlackNotify, iterate_batch
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
+    disallow_latest_alias,
     function_to_flow_name,
     generate_deployment_name,
     get_prefect_job_variable,
@@ -322,6 +323,8 @@ async def count_family_document_concepts(
     if classifier_specs is None:
         logger.info("no classifier specs. passed in, loading from file")
         classifier_specs = parse_spec_file(config.aws_env)
+
+    disallow_latest_alias(classifier_specs)
 
     logger.info(f"running with classifier specs.: {classifier_specs}")
 

--- a/flows/deindex.py
+++ b/flows/deindex.py
@@ -30,6 +30,7 @@ from scripts.cloud import (
     get_prefect_job_variable,
 )
 from src.identifiers import WikibaseID
+from src.version import Semantic, Version
 
 DEFAULT_DOCUMENTS_BATCH_SIZE = 250
 DEFAULT_DEINDEXING_TASK_BATCH_SIZE = 10
@@ -116,7 +117,7 @@ def find_all_classifier_specs_for_latest(
             raise ValueError(f"already have {classifier_spec} as a primary")
 
         # If it's not the `latest`, then we don't need to do look-ups
-        if classifier_spec.alias != "latest":
+        if classifier_spec.alias.value != Semantic.Latest:
             seen_primaries.add(classifier_spec.name)
 
             with_primary.append(classifier_spec)
@@ -124,7 +125,7 @@ def find_all_classifier_specs_for_latest(
             continue
 
         # Find all the aliases in S3 for `classifier_spec.name`
-        aliases: list[str] = search_s3_for_aliases(
+        aliases: list[Version] = search_s3_for_aliases(
             WikibaseID(classifier_spec.name),
             cache_bucket=cache_bucket,
             document_source_prefix=document_source_prefix,
@@ -153,9 +154,9 @@ def search_s3_for_aliases(
     cache_bucket: str,
     document_source_prefix: str,
     s3_client,
-) -> list[str]:
+) -> list[Version]:
     """Find all aliases for a concept that are in our artifacts."""
-    aliases: set[str] = set()
+    aliases: set[Version] = set()
 
     # Ensure trailing slash for accurate prefix matching
     prefix = str(os.path.join(document_source_prefix, concept)) + "/"
@@ -180,9 +181,9 @@ def search_s3_for_aliases(
                     f"alias parts length was {len(key_parts)} and not {expected_length}: {key_parts}"
                 )
 
-            alias: str = key_parts[2]
+            alias: Version = Version.from_str(key_parts[2])
 
-            if alias == "latest":
+            if alias.value == Semantic.Latest:
                 continue
 
             aliases.add(alias)

--- a/flows/index.py
+++ b/flows/index.py
@@ -20,6 +20,7 @@ from flows.utils import (
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
+    disallow_latest_alias,
     get_prefect_job_variable,
 )
 from scripts.update_classifier_spec import parse_spec_file
@@ -97,6 +98,8 @@ async def index_labelled_passages_from_s3_to_vespa(
     if classifier_specs is None:
         logger.info("no classifier specs. passed in, loading from file")
         classifier_specs = parse_spec_file(config.aws_env)
+
+    disallow_latest_alias(classifier_specs)
 
     logger.info(f"running with classifier specs: {classifier_specs}")
 

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -177,7 +177,7 @@ def get_labelled_passage_paths(
             document_key = os.path.join(
                 labelled_passages_prefix,
                 classifier_spec.name,
-                classifier_spec.alias,
+                str(classifier_spec.alias),
                 f"{document_id}.json",
             )
 
@@ -194,7 +194,7 @@ def get_labelled_passage_paths(
                         cache_bucket,
                         labelled_passages_prefix,
                         classifier_spec.name,
-                        classifier_spec.alias,
+                        str(classifier_spec.alias),
                         f"{file_stem}.json",
                     )
                 )

--- a/flows/wikibase_to_s3.py
+++ b/flows/wikibase_to_s3.py
@@ -14,6 +14,7 @@ from scripts.cloud import AwsEnv, function_to_flow_name, generate_deployment_nam
 from scripts.update_classifier_spec import ClassifierSpec
 from src.concept import Concept
 from src.identifiers import WikibaseID
+from src.version import Semantic, Version
 from src.wikibase import WikibaseSession
 
 CDN_BUCKET_NAME_SSM_NAME = "/S3/CDNBucketName"
@@ -161,7 +162,7 @@ async def trigger_deindexing(extras_in_s3: list[str], config: Config):
                 name=concept_id,
                 # If a concept has been removed, we'll wipe all versions
                 # of results, so just use the 'latest' version alias here.
-                alias="latest",
+                alias=Version(value=Semantic.Latest),
             )
         )
         for concept_id in extras_in_s3

--- a/scripts/cloud.py
+++ b/scripts/cloud.py
@@ -11,6 +11,7 @@ from prefect.blocks.system import JSON
 from pydantic import BaseModel, Field
 
 from src.identifiers import WikibaseID
+from src.version import Semantic, Version
 
 PROJECT_NAME = "knowledge-graph"
 
@@ -18,21 +19,29 @@ PROJECT_NAME = "knowledge-graph"
 class ClassifierSpec(BaseModel):
     """Details for a classifier to run."""
 
-    name: str = Field(
-        description="The reference of the classifier in wandb. e.g. 'Q992'",
-        min_length=1,
+    name: WikibaseID = Field(
+        description="The reference of the classifier in W&B. E.g. 'Q992' or 'latest'",
     )
-    alias: str = Field(
-        description=(
-            "The alias tag for the version to use for inference. e.g 'latest' or 'v2'"
-        ),
-        default="latest",
-        min_length=1,
+    alias: Version = Field(
+        description="The alias tag for the version to use for inference. E.g 'v2'",
     )
+
+    def __str__(self) -> str:
+        """Return a string representation"""
+        return f"{self.name}:{self.alias}"
 
     def __hash__(self):
         """Make ClassifierSpec hashable for use in sets and as dict keys."""
         return hash((self.name, self.alias))
+
+
+def disallow_latest_alias(classifier_specs: list[ClassifierSpec]):
+    if any(
+        classifier_spec.alias.value == Semantic.Latest
+        for classifier_spec in classifier_specs
+    ):
+        raise ValueError(f"`{Semantic.Latest}` is not allowed")
+    return None
 
 
 async def get_prefect_job_variable(param_name: str) -> str:

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -26,7 +26,7 @@ from scripts.cloud import (
     validate_transition,
 )
 from src.identifiers import WikibaseID
-from src.version import Version
+from src.version import Semantic, Version
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -311,7 +311,7 @@ def main(
         Version,
         typer.Option(
             help="Version of the model (e.g., v3)",
-            parser=Version,
+            parser=Version.from_str,
         ),
     ],
     from_aws_env: Annotated[
@@ -352,6 +352,9 @@ def main(
     log.info("Starting model promotion process")
 
     log.info("Parsing promotion...")
+
+    if isinstance(version.value, Semantic):
+        raise ValueError("semantic versions not yet supported")
 
     promotion = Promotion.validate_python(
         {

--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -11,6 +11,7 @@ from wandb.apis.public.artifacts import ArtifactCollection, ArtifactType
 
 from scripts.cloud import AwsEnv, ClassifierSpec
 from src.identifiers import WikibaseID
+from src.version import Version
 
 load_dotenv()
 
@@ -41,7 +42,9 @@ def parse_spec_file(aws_env: AwsEnv) -> list[ClassifierSpec]:
     for item in contents:
         try:
             name, alias = item.split(":")
-            classifier_specs.append(ClassifierSpec(name=name, alias=alias))
+            classifier_specs.append(
+                ClassifierSpec(name=WikibaseID(name), alias=Version.from_str(alias))
+            )
         except ValueError:
             raise ValueError(f"Invalid format in spec file: {item}")
 
@@ -149,8 +152,8 @@ def get_all_available_classifiers(
                     )
                 classifier_specs[model_env].append(
                     ClassifierSpec(
-                        name=model_parts[0],
-                        alias=model_parts[1],
+                        name=WikibaseID(model_parts[0]),
+                        alias=Version.from_str(model_parts[1]),
                     )
                 )
 

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -34,6 +34,7 @@ from src.concept import Concept
 from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
+from src.version import Version
 from tests.flows.conftest import load_fixture
 
 DOCUMENT_PASSAGE_ID_PATTERN = re.compile(
@@ -240,8 +241,12 @@ def test_s3_paths_or_s3_prefixes_with_classifier_no_docs(
 ):
     """Test s3_paths_or_s3_prefixes returns classifier-specific prefix when no document IDs provided."""
     config = Config(cache_bucket=mock_bucket)
-    classifier_spec_q788 = ClassifierSpec(name="Q788", alias="v4")
-    classifier_spec_q699 = ClassifierSpec(name="Q699", alias="v4")
+    classifier_spec_q788 = ClassifierSpec(
+        name=WikibaseID("Q788"), alias=Version.from_str("v4")
+    )
+    classifier_spec_q699 = ClassifierSpec(
+        name=WikibaseID("Q699"), alias=Version.from_str("v4")
+    )
 
     s3_accessor = s3_paths_or_s3_prefixes(
         classifier_specs=[classifier_spec_q788, classifier_spec_q699],
@@ -266,7 +271,9 @@ def test_s3_paths_or_s3_prefixes_with_classifier_and_docs(
 ):
     """Test s3_paths_or_s3_prefixes returns specific paths when both classifier and document IDs provided."""
     config = Config(cache_bucket=mock_bucket)
-    classifier_spec = ClassifierSpec(name="Q788", alias="v4")
+    classifier_spec = ClassifierSpec(
+        name=WikibaseID("Q788"), alias=Version.from_str("v4")
+    )
 
     expected_paths = [
         f"{s3_prefix_mock_bucket_labelled_passages}/{labelled_passage_fixture_file}"

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -50,6 +50,7 @@ from src.concept import Concept
 from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
+from src.version import Semantic, Version
 
 
 def test_remove_concepts_from_existing_vespa_concepts():
@@ -1284,7 +1285,11 @@ async def test_deindex_labelled_passages_from_s3_to_vespa(
     )
 
     await deindex_labelled_passages_from_s3_to_vespa(
-        classifier_specs=[ClassifierSpec(name="Q760", alias="latest")],
+        classifier_specs=[
+            ClassifierSpec(
+                name=WikibaseID("Q760"), alias=Version(value=Semantic.Latest)
+            )
+        ],
         document_ids=[document_import_id_remove],
         config=config,
     )
@@ -1373,12 +1378,12 @@ def put_empty_document_artifact(
     bucket: str,
     prefix: str,
     concept: WikibaseID,
-    alias: str,
+    alias: Version,
     document_id: str,
 ) -> None:
     body = BytesIO(json.dumps({}).encode("utf-8"))
 
-    key = str(os.path.join(prefix, concept, alias, f"{document_id}.json"))
+    key = str(os.path.join(prefix, concept, str(alias), f"{document_id}.json"))
     print(f"putting empty document artifact at bucket: `{bucket}`, key: `{key}`")
 
     s3_client.put_object(
@@ -1394,49 +1399,53 @@ def put_empty_document_artifact(
     [
         (
             [
-                ClassifierSpec(name="Q200", alias="latest"),
-                ClassifierSpec(name="Q300", alias="latest"),
-                ClassifierSpec(name="Q400", alias="v6"),
+                ClassifierSpec(
+                    name=WikibaseID("Q200"), alias=Version(value=Semantic.Latest)
+                ),
+                ClassifierSpec(
+                    name=WikibaseID("Q300"), alias=Version(value=Semantic.Latest)
+                ),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
             ],
             [
-                ClassifierSpec(name="Q100", alias="v5"),
-                ClassifierSpec(name="Q200", alias="v9"),
-                ClassifierSpec(name="Q300", alias="v2"),
-                ClassifierSpec(name="Q400", alias="v6"),
-                ClassifierSpec(name="Q500", alias="v13"),
+                ClassifierSpec(name=WikibaseID("Q100"), alias=Version.from_str("v5")),
+                ClassifierSpec(name=WikibaseID("Q200"), alias=Version.from_str("v9")),
+                ClassifierSpec(name=WikibaseID("Q300"), alias=Version.from_str("v2")),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
+                ClassifierSpec(name=WikibaseID("Q500"), alias=Version.from_str("v13")),
             ],
             [
-                ClassifierSpec(name="Q200", alias="v9"),
-                ClassifierSpec(name="Q300", alias="v2"),
-                ClassifierSpec(name="Q400", alias="v6"),
+                ClassifierSpec(name=WikibaseID("Q200"), alias=Version.from_str("v9")),
+                ClassifierSpec(name=WikibaseID("Q300"), alias=Version.from_str("v2")),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
             ],
             [
-                ClassifierSpec(name="Q200", alias="v5"),
-                ClassifierSpec(name="Q200", alias="v6"),
-                ClassifierSpec(name="Q300", alias="v1"),
+                ClassifierSpec(name=WikibaseID("Q200"), alias=Version.from_str("v5")),
+                ClassifierSpec(name=WikibaseID("Q200"), alias=Version.from_str("v6")),
+                ClassifierSpec(name=WikibaseID("Q300"), alias=Version.from_str("v1")),
             ],
             None,
         ),
         (
             [
-                ClassifierSpec(name="Q400", alias="v6"),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
             ],
             [],
             [],
             [],
-            "classifier spec. name='Q400' alias='v6' was not found in the maintained list",
+            "classifier spec. Q400:v6 was not found in the maintained list",
         ),
         (
             [
-                ClassifierSpec(name="Q400", alias="v6"),
-                ClassifierSpec(name="Q400", alias="v6"),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
             ],
             [
-                ClassifierSpec(name="Q400", alias="v6"),
+                ClassifierSpec(name=WikibaseID("Q400"), alias=Version.from_str("v6")),
             ],
             [],
             [],
-            "already have name='Q400' alias='v6' as a primary",
+            "already have Q400:v6 as a primary",
         ),
     ],
 )
@@ -1509,13 +1518,22 @@ def test_find_all_classifier_specs_for_latest(
     "aliases,expected,exception",
     [
         (
-            ["v2", "v3", "latest", "v7"],
-            ["v2", "v3", "v7"],
+            [
+                Version.from_str("v2"),
+                Version.from_str("v3"),
+                Version(value=Semantic.Latest),
+                Version.from_str("v7"),
+            ],
+            [
+                Version.from_str("v2"),
+                Version.from_str("v3"),
+                Version.from_str("v7"),
+            ],
             None,
         ),
         (
-            ["v9", "v3"],
-            ["v3", "v9"],
+            [Version.from_str("v9"), Version.from_str("v3")],
+            [Version.from_str("v3"), Version.from_str("v9")],
             None,
         ),
         (
@@ -1528,8 +1546,8 @@ def test_find_all_classifier_specs_for_latest(
 def test_search_s3_for_aliases(
     mock_bucket: str,
     mock_s3_client,
-    aliases: list[str],
-    expected: list[str],
+    aliases: list[Version],
+    expected: list[Version],
     exception: str | None,
 ):
     concept = WikibaseID("Q100")
@@ -1576,8 +1594,8 @@ async def test_cleanups_by_s3(
     document_ids: list[str] = [document_id]
     concept = WikibaseID("Q100")
     classifier_specs_cleanup: list[ClassifierSpec] = [
-        ClassifierSpec(name=str(concept), alias="v1"),
-        ClassifierSpec(name=str(concept), alias="v2"),
+        ClassifierSpec(name=concept, alias=Version.from_str("v1")),
+        ClassifierSpec(name=concept, alias=Version.from_str("v2")),
     ]
 
     put = partial(
@@ -1589,7 +1607,7 @@ async def test_cleanups_by_s3(
     )
 
     # Primary to be left alone
-    primary_alias = "v9"
+    primary_alias = Version.from_str("v9")
     put(alias=primary_alias, prefix=DOCUMENT_TARGET_PREFIX_DEFAULT)
     put(alias=primary_alias, prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT)
 
@@ -1625,7 +1643,7 @@ async def test_cleanups_by_s3(
                 os.path.join(
                     DOCUMENT_TARGET_PREFIX_DEFAULT,
                     concept,
-                    classifier_spec.alias,
+                    str(classifier_spec.alias),
                     f"{document_id}.json",
                 )
             )
@@ -1635,7 +1653,7 @@ async def test_cleanups_by_s3(
         os.path.join(
             DOCUMENT_TARGET_PREFIX_DEFAULT,
             concept,
-            primary_alias,
+            str(primary_alias),
             f"{document_id}.json",
         )
     )

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -16,6 +16,8 @@ from flows.utils import (
     s3_file_exists,
 )
 from scripts.cloud import ClassifierSpec
+from src.identifiers import WikibaseID
+from src.version import Version
 
 
 @pytest.mark.parametrize(
@@ -132,7 +134,9 @@ def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> N
 def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) -> None:
     """Test that we can get all document paths from a list of document IDs."""
 
-    classifier_spec = ClassifierSpec(name="Q123", alias="v1")
+    classifier_spec = ClassifierSpec(
+        name=WikibaseID("Q123"), alias=Version.from_str("v1")
+    )
     body = BytesIO('{"some_key": "some_value"}'.encode("utf-8"))
     s3_file_names = [
         "CCLW.executive.1.1_translated_en.json",
@@ -147,7 +151,7 @@ def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) ->
             Key=os.path.join(
                 test_config.document_target_prefix,
                 classifier_spec.name,
-                classifier_spec.alias,
+                str(classifier_spec.alias),
                 file_name,
             ),
             Body=body,

--- a/tests/scripts/test_update_classifier_spec.py
+++ b/tests/scripts/test_update_classifier_spec.py
@@ -15,6 +15,7 @@ from scripts.update_classifier_spec import (
     read_spec_file,
     sort_specs,
 )
+from src.version import Version
 
 
 @pytest.fixture
@@ -73,8 +74,8 @@ def test_is_concept_model():
 
 def test_is_latest_model_in_env():
     classifier_specs = [
-        ClassifierSpec(name="Q22", alias="v1"),
-        ClassifierSpec(name="Q11", alias="v2"),
+        ClassifierSpec(name="Q22", alias=Version.from_str("v1")),
+        ClassifierSpec(name="Q11", alias=Version.from_str("v2")),
     ]
     assert not is_latest_model_in_env(classifier_specs, model_name="Q11")
     assert is_latest_model_in_env(classifier_specs, model_name="Q33")
@@ -95,13 +96,13 @@ def test_get_all_available_classifiers(mock_wandb_api):
     "spec_contents,expected_specs",
     [
         # Test valid single entry
-        (["Q123:v1"], [ClassifierSpec(name="Q123", alias="v1")]),
+        (["Q123:v1"], [ClassifierSpec(name="Q123", alias=Version.from_str("v1"))]),
         # Test valid multiple entries
         (
             ["Q123:v1", "Q456:v2"],
             [
-                ClassifierSpec(name="Q123", alias="v1"),
-                ClassifierSpec(name="Q456", alias="v2"),
+                ClassifierSpec(name="Q123", alias=Version.from_str("v1")),
+                ClassifierSpec(name="Q456", alias=Version.from_str("v2")),
             ],
         ),
         # Test empty list
@@ -158,17 +159,17 @@ def test_parse_spec_file_invalid_format(invalid_contents, tmp_path):
 
 def test_sort_specs():
     unsorted_specs = [
-        ClassifierSpec(name="Q123", alias="v4"),
-        ClassifierSpec(name="Q789", alias="v1"),
-        ClassifierSpec(name="Q456", alias="v30"),
-        ClassifierSpec(name="Q999", alias="v3"),
-        ClassifierSpec(name="Q111", alias="v3"),
+        ClassifierSpec(name="Q123", alias=Version.from_str("v4")),
+        ClassifierSpec(name="Q789", alias=Version.from_str("v1")),
+        ClassifierSpec(name="Q456", alias=Version.from_str("v30")),
+        ClassifierSpec(name="Q999", alias=Version.from_str("v3")),
+        ClassifierSpec(name="Q111", alias=Version.from_str("v3")),
     ]
 
     assert sort_specs(unsorted_specs) == [
-        ClassifierSpec(name="Q111", alias="v3"),
-        ClassifierSpec(name="Q123", alias="v4"),
-        ClassifierSpec(name="Q456", alias="v30"),
-        ClassifierSpec(name="Q789", alias="v1"),
-        ClassifierSpec(name="Q999", alias="v3"),
+        ClassifierSpec(name="Q111", alias=Version.from_str("v3")),
+        ClassifierSpec(name="Q123", alias=Version.from_str("v4")),
+        ClassifierSpec(name="Q456", alias=Version.from_str("v30")),
+        ClassifierSpec(name="Q789", alias=Version.from_str("v1")),
+        ClassifierSpec(name="Q999", alias=Version.from_str("v3")),
     ]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -47,12 +47,12 @@ def test_print_metrics(capsys, metrics_df: pd.DataFrame):
         ),
         (
             None,
-            Version("v1"),
+            Version.from_str("v1"),
             "classifier and version should not be specified",
         ),
         (
             "TestClassifier",
-            Version("v1"),
+            Version.from_str("v1"),
             "classifier and version should not be specified",
         ),
     ],
@@ -69,7 +69,7 @@ def test_validate_local_args(classifier, version, expected_error):
 @pytest.mark.parametrize(
     "track,classifier,version,expected_error",
     [
-        (True, "TestClassifier", Version("v1"), None),
+        (True, "TestClassifier", Version.from_str("v1"), None),
         (False, None, None, None),
         (
             False,
@@ -80,13 +80,13 @@ def test_validate_local_args(classifier, version, expected_error):
         (
             False,
             None,
-            Version("v1"),
+            Version.from_str("v1"),
             "script was told not to track",
         ),
         (
             True,
             None,
-            Version("v1"),
+            Version.from_str("v1"),
             "without a classifier name",
         ),
         (
@@ -110,13 +110,18 @@ def test_validate_remote_args(track, classifier, version, expected_error):
     "track,classifier,version,expected_exception",
     [
         (True, None, None, None),
-        (True, None, Version("v1"), pytest.raises(typer.BadParameter)),
+        (True, None, Version.from_str("v1"), pytest.raises(typer.BadParameter)),
         (True, "TestClassifier", None, pytest.raises(typer.BadParameter)),
-        (True, "TestClassifier", Version("v1"), None),
-        (False, None, Version("v1"), pytest.raises(typer.BadParameter)),
+        (True, "TestClassifier", Version.from_str("v1"), None),
+        (False, None, Version.from_str("v1"), pytest.raises(typer.BadParameter)),
         (False, "TestClassifier", None, pytest.raises(typer.BadParameter)),
         (False, None, None, None),
-        (False, "TestClassifier", Version("v1"), pytest.raises(typer.BadParameter)),
+        (
+            False,
+            "TestClassifier",
+            Version.from_str("v1"),
+            pytest.raises(typer.BadParameter),
+        ),
     ],
 )
 def test_validate_args(
@@ -214,7 +219,7 @@ def test_load_classifier_remote(mock_classifier):
     run = Mock(spec=Run)
     run.config = {}  # Add dict for config
     classifier_name = "TestClassifier"
-    version = Version("v1")
+    version = Version.from_str("v1")
     wikibase_id = WikibaseID("Q123")
 
     # Mock the artifact

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -10,24 +10,18 @@ from scripts.infer import app, convert_classifier_specs, main
 runner = CliRunner()
 
 
-def test_convert_classifier_specs_with_name_only():
-    input_specs = ["Q123"]
-    result = convert_classifier_specs(input_specs)
-    assert result == [{"name": "Q123", "alias": "latest"}]
-
-
 def test_convert_classifier_specs_with_name_and_alias():
     input_specs = ["Q123:v1"]
     result = convert_classifier_specs(input_specs)
-    assert result == [{"name": "Q123", "alias": "v1"}]
+    assert result == [{"name": "Q123", "alias": {"value": 1}}]
 
 
 def test_convert_classifier_specs_multiple_specs():
-    input_specs = ["Q123", "Q456:v2"]
+    input_specs = ["Q123:v0", "Q456:v2"]
     result = convert_classifier_specs(input_specs)
     assert result == [
-        {"name": "Q123", "alias": "latest"},
-        {"name": "Q456", "alias": "v2"},
+        {"name": "Q123", "alias": {"value": 0}},
+        {"name": "Q456", "alias": {"value": 2}},
     ]
 
 
@@ -42,13 +36,13 @@ def test_cli_basic():
     mock_run.return_value.id = "test-id"
 
     with patch("scripts.infer.run_deployment", new=mock_run):
-        result = runner.invoke(app, ["--aws-env", "staging", "-c", "Q123"])
+        result = runner.invoke(app, ["--aws-env", "staging", "-c", "Q123:v3"])
         assert result.exit_code == 0
 
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["parameters"]["classifier_specs"] == [
-            {"name": "Q123", "alias": "latest"}
+            {"name": "Q123", "alias": {"value": 3}}
         ]
         assert call_kwargs["parameters"]["document_ids"] is None
 
@@ -77,7 +71,7 @@ def test_cli_with_documents():
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["parameters"]["classifier_specs"] == [
-            {"name": "Q123", "alias": "v1"}
+            {"name": "Q123", "alias": {"value": 1}}
         ]
         assert call_kwargs["parameters"]["document_ids"] == ["doc1", "doc2"]
 
@@ -105,14 +99,14 @@ def test_main_function_basic():
     with patch("scripts.infer.run_deployment", new=mock_run):
         main(
             aws_env=AwsEnv.staging,
-            classifiers=convert_classifier_specs(["Q123"]),
+            classifiers=convert_classifier_specs(["Q123:v0"]),
             documents=[],
         )
 
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["parameters"]["classifier_specs"] == [
-            {"name": "Q123", "alias": "latest"}
+            {"name": "Q123", "alias": {"value": 0}}
         ]
         assert call_kwargs["parameters"]["document_ids"] is None
 
@@ -132,7 +126,7 @@ def test_main_function_with_documents():
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["parameters"]["classifier_specs"] == [
-            {"name": "Q123", "alias": "v1"}
+            {"name": "Q123", "alias": {"value": 1}}
         ]
         assert call_kwargs["parameters"]["document_ids"] == ["doc1", "doc2"]
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -23,13 +23,13 @@ from scripts.promote import (
 
 @pytest.mark.parametrize("input_version", ["v1", "v10", "v0"])
 def test_version_valid(input_version):
-    assert str(Version(input_version)) == input_version
+    assert str(Version.from_str(input_version)) == input_version
 
 
-@pytest.mark.parametrize("invalid_version", ["1", "v", "v1.0", "latest"])
+@pytest.mark.parametrize("invalid_version", ["1", "v", "v1.0"])
 def test_version_invalid(invalid_version):
     with pytest.raises(ValueError):
-        Version(invalid_version)
+        Version.from_str(invalid_version)
 
 
 @pytest.mark.parametrize(
@@ -41,22 +41,27 @@ def test_version_invalid(invalid_version):
     ],
 )
 def test_version_comparison(version_a, version_b, expected):
-    assert (Version(version_a) < Version(version_b)) == expected
+    assert (Version.from_str(version_a) < Version.from_str(version_b)) == expected
 
 
 def test_version_sorting():
-    versions = [Version("v3"), Version("v1"), Version("v10"), Version("v2")]
+    versions = [
+        Version.from_str("v3"),
+        Version.from_str("v1"),
+        Version.from_str("v10"),
+        Version.from_str("v2"),
+    ]
     sorted_versions = sorted(versions)
     assert [str(v) for v in sorted_versions] == ["v1", "v2", "v3", "v10"]
 
 
 def test_version_sorting_with_larger_numbers():
     versions = [
-        Version("v3"),
-        Version("v1"),
-        Version("v10"),
-        Version("v2"),
-        Version("v20"),
+        Version.from_str("v3"),
+        Version.from_str("v1"),
+        Version.from_str("v10"),
+        Version.from_str("v2"),
+        Version.from_str("v20"),
     ]
     sorted_versions = sorted(versions)
     assert [str(v) for v in sorted_versions] == ["v1", "v2", "v3", "v10", "v20"]
@@ -68,7 +73,7 @@ def test_version_sorting_with_larger_numbers():
         (
             "Q123",
             "TestClassifier",
-            Version("v1"),
+            Version.from_str("v1"),
             AwsEnv.labs,
             AwsEnv.staging,
             None,
@@ -78,7 +83,7 @@ def test_version_sorting_with_larger_numbers():
         (
             "Q456",
             "AnotherClassifier",
-            Version("v2"),
+            Version.from_str("v2"),
             AwsEnv.staging,
             AwsEnv.production,
             None,
@@ -88,12 +93,22 @@ def test_version_sorting_with_larger_numbers():
         (
             "Q789",
             "ThirdClassifier",
-            Version("v3"),
+            Version.from_str("v3"),
             None,
             None,
             AwsEnv.labs,
             False,
             None,
+        ),
+        (
+            "Q789",
+            "ThirdClassifier",
+            Version.from_str("latest"),
+            None,
+            None,
+            AwsEnv.labs,
+            False,
+            ValueError,
         ),
     ],
 )
@@ -168,20 +183,19 @@ def test_main(
                 )
 
 
-def test_version_latest_not_supported():
-    with pytest.raises(ValueError, match="`latest` isn't yet supported"):
-        Version("latest")
-
-
 def test_version_equality():
-    assert Version("v1") == Version("v1")
-    assert Version("v1") == "v1"
-    assert Version("v1") != Version("v2")
-    assert Version("v1") != "v2"
+    assert Version.from_str("v1") == Version.from_str("v1")
+    assert Version.from_str("v1").value == 1
+    assert Version.from_str("v1") != Version.from_str("v2")
+    assert Version.from_str("v1").value != 2
 
 
 def test_version_hash():
-    versions = {Version("v1"), Version("v2"), Version("v1")}
+    versions = {
+        Version.from_str("v1"),
+        Version.from_str("v2"),
+        Version.from_str("v1"),
+    }
     assert len(versions) == 2
 
 
@@ -219,17 +233,17 @@ def test_get_bucket_name_for_aws_env(aws_env, expected_bucket):
         (
             "Q123",
             "TestClassifier",
-            Version("v1"),
+            Version.from_str("v1"),
         ),
         (
             "Q456",
             "AnotherClassifier",
-            Version("v2"),
+            Version.from_str("v2"),
         ),
         (
             "Q789",
             "ThirdClassifier",
-            Version("v10"),
+            Version.from_str("v10"),
         ),
     ],
 )
@@ -290,7 +304,7 @@ def test_validate_logins(promotion, login_states, expected_exception):
         (
             False,
             [],
-            Version("v1"),
+            Version.from_str("v1"),
             Within(value=AwsEnv.labs, primary=True),
             "test/path",
             None,
@@ -299,7 +313,7 @@ def test_validate_logins(promotion, login_states, expected_exception):
         (
             True,
             ["labs"],
-            Version("v1"),
+            Version.from_str("v1"),
             Within(value=AwsEnv.labs, primary=True),
             "test/path",
             None,
@@ -308,7 +322,7 @@ def test_validate_logins(promotion, login_states, expected_exception):
         (
             True,
             ["staging"],
-            Version("v1"),
+            Version.from_str("v1"),
             Within(value=AwsEnv.labs, primary=True),
             "test/path",
             "An artifact already exists with AWS environment aliases {'staging'}",
@@ -382,7 +396,7 @@ def test_find_artifact_by_version(artifacts, version, expected):
     mock_collection = Mock()
     mock_collection.artifacts.return_value = artifacts
 
-    result = find_artifact_by_version(mock_collection, Version(version))
+    result = find_artifact_by_version(mock_collection, Version.from_str(version))
 
     if expected is None:
         assert result is None
@@ -397,14 +411,14 @@ def test_find_artifact_by_version(artifacts, version, expected):
             Across(src=AwsEnv.labs, dst=AwsEnv.staging),
             "Q123",
             "TestClassifier",
-            Version("v1"),
+            Version.from_str("v1"),
             b"test content",
         ),
         (
             Across(src=AwsEnv.staging, dst=AwsEnv.production),
             "Q456",
             "AnotherClassifier",
-            Version("v2"),
+            Version.from_str("v2"),
             b"another test content",
         ),
     ],


### PR DESCRIPTION
It's now strict on when this is allowed.

FIXES PLA-515
