### PR TITLE
don't run on table cell

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -41,6 +41,7 @@ DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "embeddings_input"
 BLOCKED_BLOCK_TYPES: Final[set[BlockType]] = {
     BlockType.PAGE_NUMBER,
     BlockType.TABLE,
+    BlockType.TABLE_CELL,
     BlockType.FIGURE,
 }
 DOCUMENT_TARGET_PREFIX_DEFAULT: str = "labelled_passages"


### PR DESCRIPTION
text blocks are stored as type `TableCell`. These are 60% of all text blocks [[1](https://www.notion.so/climatepolicyradar/3-TableCells-eeeb3f4453744e5b8fd70d8f6a5adf3f)].

As a shortcut, we should skip running on these (although it wouldn't be a bad idea to run inference on them in the long run.