### PR TITLE
fix: Re-allow table cells

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -48,7 +48,6 @@ DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "embeddings_input"
 BLOCKED_BLOCK_TYPES: Final[set[BlockType]] = {
     BlockType.PAGE_NUMBER,
     BlockType.TABLE,
-    BlockType.TABLE_CELL,
     BlockType.FIGURE,
 }
 DOCUMENT_TARGET_PREFIX_DEFAULT: str = "labelled_passages"


### PR DESCRIPTION
Reverts climatepolicyradar/knowledge-graph#348

Matyas pointed out that there is a lot of good content in these text blocks. Mark is hopeful that with all the other work around improving read/write times, reduced batch sizes, increased Vespa resources, not trying to run on every document at first, this would be insufficient.

It's something we can keep in our back pocket, and possibly apply per document.

I was very hasty in merging it in, as it immediately appealed to solving the load issue!

FIXES PLA-523