### PR TITLE
refactor: Batch read document passages

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -76,7 +76,7 @@ class SlackNotify:
             _ = await result
 
 
-def remove_translated_suffix(file_name: str) -> str:
+def remove_translated_suffix(file_name: DocumentStem) -> DocumentImportId:
     """
     Remove the suffix from a file name that indicates it has been translated.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.1.5"
+version = "0.1.6"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/src/identifiers.py
+++ b/src/identifiers.py
@@ -1,6 +1,9 @@
 import hashlib
 import re
+from enum import Enum
 from functools import total_ordering
+
+from pydantic import BaseModel, Field
 
 
 @total_ordering
@@ -48,6 +51,37 @@ class WikibaseID(str):
         """Create a new instance of WikibaseID after validation"""
         validated_value = cls._validate(value)
         return str.__new__(cls, validated_value)
+
+
+class VespaSchema(Enum):
+    """Schema definitions' names for Vespa"""
+
+    FamilyDocument = "family_document"
+    DocumentPassage = "document_passage"
+
+
+class VespaID(BaseModel):
+    """Base class for a Vespa schema ID"""
+
+    prefix: str = Field(description="TODO", frozen=True, default="id:doc_search")
+    kind: VespaSchema = Field(description="TODO")
+    id: str = Field(description="TODO")
+
+    def __str__(self) -> str:
+        """String representation of a Vespa ID, ready to be used with Vespa queries"""
+        return f"{self.prefix}:{self.kind.value}::{self.id}"
+
+
+class FamilyDocumentID(VespaID):
+    """An ID for a family document in Vespa"""
+
+    kind: VespaSchema = Field(default=VespaSchema.FamilyDocument, exclude=True)
+
+
+class DocumentPassageID(VespaID):
+    """An ID for a document passage in Vespa"""
+
+    kind: VespaSchema = Field(default=VespaSchema.DocumentPassage, exclude=True)
 
 
 def deterministic_hash(*args) -> int:

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -236,12 +236,15 @@ async def test_partial_update_text_block_with_removal(
     # Confirm that the concepts to remove are in the document passages
     initial_passages = get_document_passages_from_vespa(
         document_import_id=document_import_id,
+        text_blocks_ids=None,
         vespa_search_adapter=local_vespa_search_adapter,
     )
 
     try:
-        first_passage_with_concepts = next(
-            passage for _, passage in initial_passages if passage.concepts
+        first_passage_hit_id, first_passage_with_concepts = next(
+            (hit_id, passage)
+            for hit_id, passage in initial_passages
+            if passage.concepts
         )
     except StopIteration:
         raise ValueError("no concepts found in any passages, check the fixtures")
@@ -257,8 +260,7 @@ async def test_partial_update_text_block_with_removal(
 
     assert (
         await partial_update_text_block(
-            text_block_id=first_passage_with_concepts.text_block_id,
-            document_import_id=document_import_id,
+            text_block=(first_passage_hit_id, first_passage_with_concepts),
             concepts=list(concepts_to_remove),
             vespa_search_adapter=local_vespa_search_adapter,
             update_function=remove_concepts_from_existing_vespa_concepts,
@@ -286,12 +288,15 @@ async def test_partial_update_text_block_with_empty(
     # Confirm that the concepts to remove are in the document passages
     initial_passages = get_document_passages_from_vespa(
         document_import_id=document_import_id,
+        text_blocks_ids=None,
         vespa_search_adapter=local_vespa_search_adapter,
     )
 
     try:
-        first_passage_with_concepts = next(
-            passage for _, passage in initial_passages if passage.concepts
+        first_passage_hit_id, first_passage_with_concepts = next(
+            (hit_id, passage)
+            for hit_id, passage in initial_passages
+            if passage.concepts
         )
     except StopIteration:
         raise ValueError("no concepts found in any passages, check the fixtures")
@@ -301,8 +306,7 @@ async def test_partial_update_text_block_with_empty(
 
     assert (
         await partial_update_text_block(
-            text_block_id=first_passage_with_concepts.text_block_id,
-            document_import_id=document_import_id,
+            text_block=(first_passage_hit_id, first_passage_with_concepts),
             concepts=[],
             vespa_search_adapter=local_vespa_search_adapter,
             update_function=remove_concepts_from_existing_vespa_concepts,
@@ -864,7 +868,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
     # To be kept
     labelled_passages_keep: list[LabelledPassage] = [
         LabelledPassage(
-            id="p_37_b_6",
+            id="197",
             text="Some random text on climate change.",
             spans=[
                 Span(
@@ -952,7 +956,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
 
     # Vespa state before
     # Document passages
-    _hit_id, passage_remove_1_pre = get_document_passage_from_vespa(
+    hit_id_1, passage_remove_1_pre = get_document_passage_from_vespa(
         text_block_id=labelled_passages_remove[0].id,
         document_import_id=document_import_id_remove,
         vespa_search_adapter=local_vespa_search_adapter,
@@ -968,8 +972,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
     # in the local Vespa instance for the test.
     assert (
         await boundary.partial_update_text_block(
-            text_block_id=labelled_passages_remove[0].id,
-            document_import_id=document_import_id_remove,
+            text_block=(hit_id_1, passage_remove_1_pre),
             concepts=[
                 VespaConcept(
                     id="Q760",
@@ -1142,7 +1145,7 @@ async def test_deindex_labelled_passages_from_s3_to_vespa(
     # To be kept
     labelled_passages_keep: list[LabelledPassage] = [
         LabelledPassage(
-            id="p_37_b_6",
+            id="197",
             text="Some random text on climate change.",
             spans=[
                 Span(
@@ -1240,7 +1243,7 @@ async def test_deindex_labelled_passages_from_s3_to_vespa(
 
     # Vespa state before
     # Document passages
-    _hit_id, passage_remove_1_pre = get_document_passage_from_vespa(
+    hit_id_1, passage_remove_1_pre = get_document_passage_from_vespa(
         text_block_id=labelled_passages_remove[0].id,
         document_import_id=document_import_id_remove,
         vespa_search_adapter=local_vespa_search_adapter,
@@ -1256,8 +1259,7 @@ async def test_deindex_labelled_passages_from_s3_to_vespa(
     # in the local Vespa instance for the test.
     assert (
         await boundary.partial_update_text_block(
-            text_block_id=labelled_passages_remove[0].id,
-            document_import_id=document_import_id_remove,
+            text_block=(hit_id_1, passage_remove_1_pre),
             concepts=[
                 VespaConcept(
                     id="Q760",


### PR DESCRIPTION
Instead of doing 1 read per document passage, get the most possible at once.

It uses paging as well. If there's > max limit for 1 read, then it'll use paging to break up the text blocks, and do `n` reads, with the max limit each time.

**Validation**

- [x] Deployment to staging [[1](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14472669359)] [[2](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14492822623)] [[3](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14493343470)]
- [x] Run indexing in staging [[1](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/b4aa05a2-d7ba-480a-bb87-0f19094f6223?entity_id=b4aa05a2-d7ba-480a-bb87-0f19094f6223) 🔴] [[2](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/1cbf4b4d-4ef0-4bf6-bf45-a70766b71113?entity_id=1cbf4b4d-4ef0-4bf6-bf45-a70766b71113) 🟢]
- [x] Run de-indexing in staging [[1](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/08631c51-4c0a-4748-8371-e791b95c7c68?entity_id=08631c51-4c0a-4748-8371-e791b95c7c68) 🔴] [[2](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/739b3392-7107-4cce-9a22-986de61bcb52?entity_id=739b3392-7107-4cce-9a22-986de61bcb52) 🟢]

FIXES PLA-520
