### PR TITLE
feat: Add Result type

### DIFF
--- a/flows/result.py
+++ b/flows/result.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, TypeVar
+
+
+class Unit:
+    pass
+
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+@dataclass
+class Ok(Generic[T]):
+    _value: T
+
+    def __str__(self):
+        return f"Ok({self._value})"
+
+
+@dataclass
+class Err(Generic[E]):
+    _error: E
+
+    def __str__(self):
+        return f"Err({self._error})"
+
+
+Result = Ok[T] | Err[E]
+
+
+def map_(result: Result[T, E], fn: Callable[..., T]) -> Result[T, E]:
+    match result:
+        case Ok(value):
+            return Ok(fn(value))
+        case Err(_):
+            return result
+
+
+def unwrap(result: Result[T, E]) -> T:
+    match result:
+        case Ok(value):
+            return value
+        case Err(err):
+            raise ValueError(f"can't unwrap: {err}")
+
+
+def is_ok(result: Result[T, E]) -> bool:
+    match result:
+        case Ok(_):
+            return True
+        case Err(_):
+            return False
+
+
+def is_err(result: Result[T, E]) -> bool:
+    match result:
+        case Ok(_):
+            return False
+        case Err(_):
+            return True
+
+
+@dataclass
+class Error:
+    """A simple and generic error with optional, helpful metadata"""
+
+    msg: str
+    metadata: dict[Any, Any] | None


### PR DESCRIPTION
These adds a classical Result type. It carries the _usual_ benefits.

Here's a few of them:

- Exceptions should be exceptional, not known
- Allows you to continue on (via `map_`) without excessive error handling at that point in time
- Makes it more clear what a function can return, as opposed to invisibly, possibly, returning an exception
- Makes it explicit what the outcome states, and let's us reason about them
- You can optionally have anonymous or typed errors
- Type checking on possible returns from functions becomes checkable

This is intended as an experiment, though as you can see from the example here, it may not be a tedious one to rollback, unless someone is very good at mass refactorings.

As a bonus, if I've introduced the unit type, that's analogous to a `None` value in Python. It's in Haskell, Rust, etc. This is purely an extra, and not required at all. It's hard for me to explain, but after having first come across it in Elm, I found the "no information" that it represents, much more clear and semantic than a `None` type. It also has the benefit of being explicit, since `None` can be implicit, like functions with no returns.

For CPR, I think it's helpful as:

- In our pipelines and general code in the KG repo, even though I've been involved in most of it, I've found it hard to be clear about the control flow and when errors can happen, and how they should be handled
- Some people have a desire to learn FP
- Some people have a desire to use their existing FP experience

Would it be harmful to onboarding new engineers? In my experience, no, it's not. This a very hand-wavey response for now.

