### PR TITLE
Feature/pla 528 update pipeline to remove value error raised on non english

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -419,11 +419,24 @@ async def run_classifier_inference_on_document(
     document = load_document(config, file_stem)
     print(f"Loaded document with file stem {file_stem}")
 
-    if document.languages != ["en"] and (
-        document.pdf_data is not None or document.html_data is not None
+    # Handle documents with no text or language
+    if (
+        not document.languages
+        and document.pdf_data is None
+        and document.html_data is None
     ):
+        store_labels(
+            config=config,
+            labels=[],
+            file_stem=file_stem,
+            classifier_name=classifier_name,
+            classifier_alias=classifier_alias,
+        )
+
+    # Raise on non-english documents
+    if document.languages != ["en"]:
         raise ValueError(
-            f"Cannot run inference on {file_stem}, it has text and non-english language: "
+            f"Cannot run inference on {file_stem}, it has non-english language: "
             f"{document.languages}"
         )
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -436,7 +436,7 @@ async def run_classifier_inference_on_document(
     # Raise on non-english documents
     if document.languages != ["en"]:
         raise ValueError(
-            f"Cannot run inference on {file_stem}, it has non-english language: "
+            f"Cannot run inference on {file_stem} as it has non-english language: "
             f"{document.languages}"
         )
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 import boto3
 import prefect.artifacts as artifacts
+import wandb
 from cpr_sdk.parser_models import BaseParserOutput, BlockType
 from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
@@ -21,8 +22,8 @@ from prefect.deployments import run_deployment
 from prefect.logging import get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
 from pydantic import SecretStr
+from wandb.sdk.wandb_run import Run
 
-import wandb
 from flows.utils import (
     SlackNotify,
     filter_non_english_language_file_stems,
@@ -40,7 +41,6 @@ from scripts.update_classifier_spec import parse_spec_file
 from src.classifier import Classifier
 from src.labelled_passage import LabelledPassage
 from src.span import Span
-from wandb.sdk.wandb_run import Run
 
 # The "parent" AKA the higher level flows that do multiple things
 PARENT_TIMEOUT_S: int = int(timedelta(hours=5).total_seconds())

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -419,11 +419,11 @@ async def run_classifier_inference_on_document(
     document = load_document(config, file_stem)
     print(f"Loaded document with file stem {file_stem}")
 
-    # FIXME: This makes the logs look like the run has failed and can happen like 300
-    # times per batch.
-    if document.languages != ["en"]:
+    if document.languages != ["en"] and (
+        document.pdf_data is not None or document.html_data is not None
+    ):
         raise ValueError(
-            f"Cannot run inference on {file_stem} as it has non-english language: "
+            f"Cannot run inference on {file_stem}, it has text and non-english language: "
             f"{document.languages}"
         )
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -433,6 +433,8 @@ async def run_classifier_inference_on_document(
             classifier_alias=classifier_alias,
         )
 
+        return None
+
     # Raise on non-english documents
     if document.languages != ["en"]:
         raise ValueError(

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -419,7 +419,7 @@ async def run_classifier_inference_on_document(
     document = load_document(config, file_stem)
     print(f"Loaded document with file stem {file_stem}")
 
-    # Handle documents with no text or language
+    # Handle documents with no text and no language
     if (
         not document.languages
         and document.pdf_data is None
@@ -435,10 +435,10 @@ async def run_classifier_inference_on_document(
 
         return None
 
-    # Raise on non-english documents
+    # Raise on non-English documents
     if document.languages != ["en"]:
         raise ValueError(
-            f"Cannot run inference on {file_stem} as it has non-english language: "
+            f"Cannot run inference on {file_stem} as it has non-English language: "
             f"{document.languages}"
         )
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -12,7 +12,6 @@ from uuid import UUID
 
 import boto3
 import prefect.artifacts as artifacts
-import wandb
 from cpr_sdk.parser_models import BaseParserOutput, BlockType
 from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
@@ -22,9 +21,13 @@ from prefect.deployments import run_deployment
 from prefect.logging import get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
 from pydantic import SecretStr
-from wandb.sdk.wandb_run import Run
 
-from flows.utils import SlackNotify, get_file_stems_for_document_id
+import wandb
+from flows.utils import (
+    SlackNotify,
+    filter_non_english_language_file_stems,
+    get_file_stems_for_document_id,
+)
 from scripts.cloud import (
     AwsEnv,
     ClassifierSpec,
@@ -37,6 +40,7 @@ from scripts.update_classifier_spec import parse_spec_file
 from src.classifier import Classifier
 from src.labelled_passage import LabelledPassage
 from src.span import Span
+from wandb.sdk.wandb_run import Run
 
 # The "parent" AKA the higher level flows that do multiple things
 PARENT_TIMEOUT_S: int = int(timedelta(hours=5).total_seconds())
@@ -198,7 +202,10 @@ def determine_file_stems(
     elif use_new_and_updated:
         requested_document_ids = get_latest_ingest_documents(config)
     elif requested_document_ids is None:
-        return current_bucket_file_stems
+        current_bucket_file_stems__filtered = filter_non_english_language_file_stems(
+            file_stems=current_bucket_file_stems
+        )
+        return current_bucket_file_stems__filtered
 
     assert config.cache_bucket
 

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -17,6 +17,8 @@ from scripts.cloud import ClassifierSpec
 DocumentImportId: TypeAlias = str
 DocumentStem: TypeAlias = str
 
+DOCUMENT_ID_PATTERN = re.compile(r"^((?:[^.]+\.){3}[^._]+)")
+
 
 def file_name_from_path(path: str) -> str:
     """Get the file name from a path without the path or extension"""
@@ -242,8 +244,6 @@ def filter_non_english_language_file_stems(
     file_stems: list[DocumentStem],
 ) -> list[DocumentStem]:
     """Filter non-english related file stems."""
-
-    DOCUMENT_ID_PATTERN = re.compile(r"^((?:[^.]+\.){3}[^._]+)")
 
     grouped = defaultdict(list)
 

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -262,9 +262,9 @@ def filter_non_english_language_file_stems(
 
     filtered_file_stems = []
     for group in grouped.values():
-        group_file_stems = [f for f in group if "_translated" in f]
-        if group_file_stems:
-            filtered_file_stems.extend(group_file_stems)
+        translated_file_stems = [f for f in group if "_translated" in f]
+        if translated_file_stems:
+            filtered_file_stems.extend(translated_file_stems)
         else:
             filtered_file_stems.extend(group)
 

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -70,7 +70,7 @@ def test_determine_file_stems(test_config, doc_ids, bucket_ids, expected):
 
 
 def test_determine_file_stems__error(test_config):
-    with pytest.raises(ValueError, match="Requested document_ids not found in bucket:"):
+    with pytest.raises(ValueError):
         determine_file_stems(
             config=test_config,
             use_new_and_updated=False,

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -47,8 +47,16 @@ def test_list_bucket_file_stems(test_config, mock_bucket_documents):
 @pytest.mark.parametrize(
     ("doc_ids", "bucket_ids", "expected"),
     [
-        (["1"], ["1", "2", "3"], ["1"]),
-        (None, ["1"], ["1"]),
+        (
+            ["AF.document.002MMUCR.n0000"],
+            [
+                "AF.document.002MMUCR.n0000",
+                "AF.document.AFRDG00038.n0000",
+                "CCLW.document.i00001313.n0000",
+            ],
+            ["AF.document.002MMUCR.n0000"],
+        ),
+        (None, ["AF.document.002MMUCR.n0000"], ["AF.document.002MMUCR.n0000"]),
     ],
 )
 def test_determine_file_stems(test_config, doc_ids, bucket_ids, expected):
@@ -62,12 +70,18 @@ def test_determine_file_stems(test_config, doc_ids, bucket_ids, expected):
 
 
 def test_determine_file_stems__error(test_config):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Requested document_ids not found in bucket:"):
         determine_file_stems(
             config=test_config,
             use_new_and_updated=False,
-            requested_document_ids=["1", "2"],
-            current_bucket_file_stems=["3", "4"],
+            requested_document_ids=[
+                "AF.document.002MMUCR.n0000",
+                "AF.document.AFRDG00038.n00002",
+            ],
+            current_bucket_file_stems=[
+                "CCLW.document.i00001313.n0000",
+                "AF.document.002MMUCR.n0000",
+            ],
         )
 
 

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 from io import BytesIO
 from pathlib import Path
 
@@ -9,6 +10,7 @@ import pytest
 from flows.utils import (
     SlackNotify,
     file_name_from_path,
+    filter_non_english_language_file_stems,
     get_file_stems_for_document_id,
     get_labelled_passage_paths,
     iterate_batch,
@@ -167,3 +169,56 @@ def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) ->
             f"s3://{test_config.cache_bucket}/{test_config.document_target_prefix}/{classifier_spec.name}/{classifier_spec.alias}/CCLW.executive.10083.rtl_190.json",
         ]
     )
+
+
+def test_filter_non_english_file_stems() -> None:
+    """Test that we can successfully filter out non-english file stems."""
+    file_stems = [
+        "AF.document.002MMUCR.n0000",
+        "AF.document.AFRDG00038.n0000_translated_en",
+        "AF.document.AFRDG00038.n0000",
+        "CCLW.document.i00001313.n0000",
+        "CCLW.executive.10491.5394",
+        "CCLW.executive.rtl_98.rtl_338",
+        "CCLW.executive.rtl_98.rtl_338_translated_en",
+        "CCLW.legislative.1046.0",
+        "CPR.document.i00000918.n0000",
+        "GCF.document.FP018_13290.6302",
+        "GEF.document.2480.n0000_translated_en",
+        "GEF.document.2480.n0000",
+        "OEP.document.i00000157.n0000",
+        "UNFCCC.document.i00000546.n0000",
+        "UNFCCC.non-party.1243.0",
+    ]
+
+    filtered_file_stems = filter_non_english_language_file_stems(file_stems=file_stems)
+
+    assert filtered_file_stems == [
+        "AF.document.002MMUCR.n0000",
+        "AF.document.AFRDG00038.n0000_translated_en",
+        "CCLW.document.i00001313.n0000",
+        "CCLW.executive.10491.5394",
+        "CCLW.executive.rtl_98.rtl_338_translated_en",
+        "CCLW.legislative.1046.0",
+        "CPR.document.i00000918.n0000",
+        "GCF.document.FP018_13290.6302",
+        "GEF.document.2480.n0000_translated_en",
+        "OEP.document.i00000157.n0000",
+        "UNFCCC.document.i00000546.n0000",
+        "UNFCCC.non-party.1243.0",
+    ]
+
+    with pytest.raises(ValueError, match="File stems that do not match the pattern"):
+        filter_non_english_language_file_stems(file_stems=["no_match"])
+
+    file_stems = []
+    for i in list(range(7_000)):
+        file_stems.append(f"AF.document.{i}.n0000")
+        if i % 2 == 0:
+            file_stems.append(f"AF.document.{i}.n0000_translated_en")
+
+    start_time = time.time()
+    _ = filter_non_english_language_file_stems(file_stems=file_stems)
+    end_time = time.time()
+
+    assert end_time - start_time < 1, "Filtering took too long"

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -173,6 +173,8 @@ def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) ->
 
 def test_filter_non_english_file_stems() -> None:
     """Test that we can successfully filter out non-english file stems."""
+
+    # Test we can filter out non-english file stems
     file_stems = [
         "AF.document.002MMUCR.n0000",
         "AF.document.AFRDG00038.n0000_translated_en",
@@ -208,9 +210,11 @@ def test_filter_non_english_file_stems() -> None:
         "UNFCCC.non-party.1243.0",
     ]
 
+    # Test that we raise an error for invalid file stems
     with pytest.raises(ValueError, match="File stems that do not match the pattern"):
         filter_non_english_language_file_stems(file_stems=["no_match"])
 
+    # Test that we can filter quickly even on very long lists
     file_stems = []
     for i in list(range(7_000)):
         file_stems.append(f"AF.document.{i}.n0000")

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -172,9 +172,9 @@ def test_get_labelled_passage_paths(test_config, mock_s3_client, mock_bucket) ->
 
 
 def test_filter_non_english_file_stems() -> None:
-    """Test that we can successfully filter out non-english file stems."""
+    """Test that we can successfully filter out non-English file stems."""
 
-    # Test we can filter out non-english file stems
+    # Test we can filter out non-English file stems
     file_stems = [
         "AF.document.002MMUCR.n0000",
         "AF.document.AFRDG00038.n0000_translated_en",
@@ -209,10 +209,6 @@ def test_filter_non_english_file_stems() -> None:
         "UNFCCC.document.i00000546.n0000",
         "UNFCCC.non-party.1243.0",
     ]
-
-    # Test that we raise an error for invalid file stems
-    with pytest.raises(ValueError, match="File stems that do not match the pattern"):
-        filter_non_english_language_file_stems(file_stems=["no_match"])
 
     # Test that we can filter quickly even on very long lists
     file_stems = []


### PR DESCRIPTION
This Pull Request: 
---
- Updates the inference pipeline to no longer run on non-english documents when the run configuration that's provided is all/some classifier specs. 
- This is as we are raising a ValueError when inference is attempted on non-english documents and thus in the prefect console the runs look failed which is confusing. 
- An example of this can be seen [here](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/5f8502ac-6ecc-4979-8650-b4d60c749425). 
- Testing on staging: [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/b80e96f6-a582-4c25-a2bc-236cfb0234ef?entity_id=b80e96f6-a582-4c25-a2bc-236cfb0234ef)