### PR TITLE
Adding in a fix for the slack notification call.

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 from collections.abc import Generator
@@ -41,7 +42,7 @@ class SlackNotify:
     slack_block_name = f"slack-webhook-{slack_channel_name}-prefect-mvp-{environment}"
 
     @classmethod
-    def message(cls, flow, flow_run, state):
+    async def message(cls, flow, flow_run, state):
         """
         Send a notification to a Slack channel about the state of a Prefect flow run.
 
@@ -66,7 +67,11 @@ class SlackNotify:
         )
 
         slack = SlackWebhook.load(cls.slack_block_name)
-        slack.notify(body=msg)
+        if inspect.isawaitable(slack):
+            slack = await slack
+        result = slack.notify(body=msg)
+        if inspect.isawaitable(result):
+            _ = await result
 
 
 def remove_translated_suffix(file_name: str) -> str:

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -30,8 +30,8 @@ def test_file_name_from_path(path, expected):
     assert file_name_from_path(path) == expected
 
 
-def test_message(mock_prefect_slack_webhook, mock_flow, mock_flow_run):
-    SlackNotify.message(mock_flow, mock_flow_run, mock_flow_run.state)
+async def test_message(mock_prefect_slack_webhook, mock_flow, mock_flow_run):
+    await SlackNotify.message(mock_flow, mock_flow_run, mock_flow_run.state)
     mock_SlackWebhook, mock_prefect_slack_block = mock_prefect_slack_webhook
 
     # `.load`


### PR DESCRIPTION
This Pull Request: 
---
- Adds a fix for the slack notification. 
- Essentially the load method can either return the Slack webhook object or a coroutine and thus we need to handle the different scenarios. 
- A coroutine is returned if the async_load function is called which occurs when the object is instantiated within an async function like in the KG pipeline. 
- An example of the traceback that was seen can be seen in the related linear ticket. 