### PR TITLE
Removing llm group from dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/prefect/knowledge-graph
 # Set up environment
 COPY ./poetry.lock ./pyproject.toml ./
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-root --no-interaction --with transformers --without llm,dev
+RUN poetry install --no-root --no-interaction --with transformers --without dev
 
 # Set up package
 COPY ./flows ./flows/


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for the docker build that was caused by an llm dependency group being present when it is not in the `pyproject.toml`. 
- Failed CI can be seen [here](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14469560735/job/40579978114). 