### PR TITLE
Bugfix: Timeout of flows

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -31,6 +31,8 @@ from flows.inference import (
     classifier_inference,
     run_classifier_inference_on_batch_of_documents,
     timeout_investigation,
+    timeout_investigation_async,
+    timeout_investigation_async_parent,
     timeout_investigation_parent,
 )
 from flows.wikibase_to_s3 import wikibase_to_s3
@@ -207,4 +209,14 @@ create_deployment(
 create_deployment(
     flow=timeout_investigation_parent,
     description="Parent of an example flow to test deployment",
+)
+
+create_deployment(
+    flow=timeout_investigation_async,
+    description="Investigate timeouts in Prefect async",
+)
+
+create_deployment(
+    flow=timeout_investigation_async_parent,
+    description="Parent of an example async flow to test deployment",
 )

--- a/deployments.py
+++ b/deployments.py
@@ -30,6 +30,7 @@ from flows.index import (
 from flows.inference import (
     classifier_inference,
     run_classifier_inference_on_batch_of_documents,
+    timeout_investigation,
 )
 from flows.wikibase_to_s3 import wikibase_to_s3
 from scripts.cloud import PROJECT_NAME, AwsEnv, generate_deployment_name
@@ -192,4 +193,12 @@ create_deployment(
     env_schedules={
         AwsEnv.labs: "0 0 * * *",  # Every day at midnight
     },
+)
+
+
+# Investigation of timeouts (temp)
+
+create_deployment(
+    flow=timeout_investigation,
+    description="Investigate timeouts in Prefect",
 )

--- a/deployments.py
+++ b/deployments.py
@@ -31,6 +31,7 @@ from flows.inference import (
     classifier_inference,
     run_classifier_inference_on_batch_of_documents,
     timeout_investigation,
+    timeout_investigation_parent,
 )
 from flows.wikibase_to_s3 import wikibase_to_s3
 from scripts.cloud import PROJECT_NAME, AwsEnv, generate_deployment_name
@@ -201,4 +202,9 @@ create_deployment(
 create_deployment(
     flow=timeout_investigation,
     description="Investigate timeouts in Prefect",
+)
+
+create_deployment(
+    flow=timeout_investigation_parent,
+    description="Parent of an example flow to test deployment",
 )

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -654,16 +654,22 @@ async def timeout_investigation_async_parent():
         flow_name=flow_name, aws_env=AwsEnv.sandbox
     )
     print(f"Running child flow: {flow_name}/{deployment_name}")
-    tasks = [
-        run_deployment(
-            name=f"{flow_name}/{deployment_name}",
-            # Rely on the flow's own timeout
-            timeout=None,
-            as_subflow=True,
-        )
-    ]
 
-    _ = await asyncio.gather(*tasks)
+    for i in [1, 2, 3]:
+        print(f"Running bath{i}")
+
+        tasks = [
+            run_deployment(
+                name=f"{flow_name}/{deployment_name}",
+                # Rely on the flow's own timeout
+                timeout=None,
+                as_subflow=True,
+            )
+        ] * 10
+
+        _ = await asyncio.gather(*tasks)
+
+        print("Finished running batch" + str(i))
 
     print("Finished running parent flow")
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -646,20 +646,25 @@ async def timeout_investigation_async():
     print("Flow completed successfully!")
 
 
-@flow(timeout_seconds=60)
-def timeout_investigation_async_parent():
+@flow(timeout_seconds=60 * 5)
+async def timeout_investigation_async_parent():
     print("Running parent flow async")
     flow_name = function_to_flow_name(timeout_investigation_async)
     deployment_name = generate_deployment_name(
         flow_name=flow_name, aws_env=AwsEnv.sandbox
     )
     print(f"Running child flow: {flow_name}/{deployment_name}")
-    run_deployment(
-        name=f"{flow_name}/{deployment_name}",
-        # Rely on the flow's own timeout
-        timeout=None,
-        as_subflow=True,
-    )
+    tasks = [
+        run_deployment(
+            name=f"{flow_name}/{deployment_name}",
+            # Rely on the flow's own timeout
+            timeout=None,
+            as_subflow=True,
+        )
+    ]
+
+    _ = await asyncio.gather(*tasks)
+
     print("Finished running parent flow")
 
 
@@ -669,7 +674,7 @@ def timeout_investigation():
     print("Flow completed successfully!")
 
 
-@flow(timeout_seconds=60)
+@flow(timeout_seconds=60 * 5)
 def timeout_investigation_parent():
     print("Running parent flow")
     flow_name = function_to_flow_name(timeout_investigation)

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -694,8 +694,9 @@ async def timeout_investigation_async_parent():
 
 
 @flow(timeout_seconds=10)
-def timeout_investigation():
-    time.sleep(15)
+async def timeout_investigation():
+    print("Flow started successfully!")
+    time.sleep(60)
     print("Flow completed successfully!")
 
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -467,7 +467,7 @@ def iterate_batch(data: list[str], batch_size: int = 400) -> Generator:
         yield data[i : i + batch_size]
 
 
-@flow(timeout_seconds=TASK_TIMEOUT_S)
+@flow
 async def run_classifier_inference_on_batch_of_documents(
     batch: list[str],
     config_json: dict,
@@ -613,7 +613,7 @@ async def classifier_inference(
                     "classifier_alias": classifier_spec.alias,
                 },
                 # Rely on the flow's own timeout
-                timeout=None,
+                timeout=20 * 60,
                 as_subflow=True,
             )
             for batch in batches
@@ -650,9 +650,16 @@ async def rate_limited_func() -> None:
 @flow(timeout_seconds=10)
 async def timeout_investigation_async(x: int):
     print("Starting async flow")
-    await rate_limited_func()
-    print("Loaded mock classifier")
-    await asyncio.sleep(25)
+
+    async def some_long_async_function():
+        print("Starting long async function")
+        await asyncio.sleep(25_000)
+        print("Long async function completed!")
+
+    tasks = [some_long_async_function()]
+
+    await asyncio.gather(*tasks)
+
     print("Flow completed successfully!")
 
 

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -613,7 +613,7 @@ async def classifier_inference(
                     "classifier_alias": classifier_spec.alias,
                 },
                 # Rely on the flow's own timeout
-                timeout=20 * 60,
+                timeout=2 * 60,
                 as_subflow=True,
             )
             for batch in batches

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import time
 from collections import defaultdict
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -636,3 +637,26 @@ async def classifier_inference(
         )
 
     print("Finished running classifier inference.")
+
+
+@flow(timeout_seconds=10)
+def timeout_investigation():
+    time.sleep(15)
+    print("Flow completed successfully!")
+
+
+@flow(timeout_seconds=60)
+def timeout_investigation_parent():
+    print("Running parent flow")
+    flow_name = function_to_flow_name(timeout_investigation)
+    deployment_name = generate_deployment_name(
+        flow_name=flow_name, aws_env=AwsEnv.sandbox
+    )
+    print(f"Running child flow: {flow_name}/{deployment_name}")
+    run_deployment(
+        name=f"{flow_name}/{deployment_name}",
+        # Rely on the flow's own timeout
+        timeout=None,
+        as_subflow=True,
+    )
+    print("Finished running parent flow")


### PR DESCRIPTION
This Pull Request: 
---
- Is a bugfix for the scenario seen upon running the inference pipeline where flows invoked from deployments are taking longer than the timout. 

_Currently this PR is just to investigate how timeouts are passed from flow invocations of deployments._ 