### PR TITLE
refactor: Use Vespa connection pool

### DIFF
--- a/flows/deindex.py
+++ b/flows/deindex.py
@@ -452,4 +452,5 @@ async def deindex_labelled_passages_from_s3_to_vespa(
         as_deployment=config.as_deployment,
         cache_bucket=config.cache_bucket,
         concepts_counts_prefix=config.concepts_counts_prefix,
+        vespa_search_adapter=config.vespa_search_adapter,
     )

--- a/flows/index.py
+++ b/flows/index.py
@@ -127,4 +127,5 @@ async def index_labelled_passages_from_s3_to_vespa(
         as_deployment=config.as_deployment,
         cache_bucket=config.cache_bucket,
         concepts_counts_prefix=config.concepts_counts_prefix,
+        vespa_search_adapter=config.vespa_search_adapter,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.1.6"
+version = "0.1.7"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -19,7 +18,6 @@ from flows.boundary import (
     DocumentObjectUri,
     Operation,
     TextBlockId,
-    connections_from_batch_size,
     convert_labelled_passage_to_concepts,
     get_data_id_from_vespa_hit_id,
     get_document_passage_from_vespa,
@@ -1010,26 +1008,3 @@ def test_load_labelled_passages_by_uri_raw(mock_bucket, mock_s3_client):
             },
         )
     ]
-
-
-@pytest.mark.parametrize(
-    "items,batch_size,connections",
-    [
-        ([], 10, 1),
-        ([1, 2, 3, 4], 2, 2),
-        ([1, 2], 10, 1),
-        ([1] * 11, 5, 3),
-        ([1] * 10, 10, 1),
-        ([1] * 0, 1, 1),
-        ([1] * 25, 10, 3),
-        ([1] * 10, 3, 4),
-        ([1] * 9, 3, 3),
-        ([1], 100, 1),
-    ],
-)
-def test_connections_from_batch_size(
-    items: list[Any],
-    batch_size: int,
-    connections: int,
-) -> None:
-    assert connections_from_batch_size(items, batch_size) == connections

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,7 @@ from flows.boundary import (
     DocumentObjectUri,
     Operation,
     TextBlockId,
+    connections_from_batch_size,
     convert_labelled_passage_to_concepts,
     get_data_id_from_vespa_hit_id,
     get_document_passage_from_vespa,
@@ -391,7 +393,8 @@ def test_get_document_passage_from_vespa(
 
 
 @pytest.mark.vespa
-def test_get_some_document_passages_from_vespa(
+@pytest.mark.asyncio
+async def test_get_some_document_passages_from_vespa(
     local_vespa_search_adapter: VespaSearchAdapter,
     document_passages_test_data_file_path: str,
     vespa_app,
@@ -399,11 +402,12 @@ def test_get_some_document_passages_from_vespa(
     """Test that we can retrieve some of the passages for a document in vespa."""
 
     # Test that we retrieve no passages for a document that doesn't exist
-    document_passages = get_document_passages_from_vespa(
-        text_blocks_ids=["test_33"],
-        document_import_id="test.executive.1.1",
-        vespa_search_adapter=local_vespa_search_adapter,
-    )
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        document_passages = await get_document_passages_from_vespa(
+            text_blocks_ids=["test_33"],
+            document_import_id="test.executive.1.1",
+            vespa_connection_pool=vespa_connection_pool,
+        )
 
     assert document_passages == []
 
@@ -422,11 +426,12 @@ def test_get_some_document_passages_from_vespa(
 
     family_document_passages_count_expected = len(text_blocks_ids)
 
-    document_passages = get_document_passages_from_vespa(
-        document_import_id=document_import_id,
-        text_blocks_ids=text_blocks_ids,
-        vespa_search_adapter=local_vespa_search_adapter,
-    )
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        document_passages = await get_document_passages_from_vespa(
+            document_import_id=document_import_id,
+            text_blocks_ids=text_blocks_ids,
+            vespa_connection_pool=vespa_connection_pool,
+        )
 
     assert len(document_passages) == family_document_passages_count_expected
     assert all(
@@ -446,11 +451,12 @@ def test_get_some_document_passages_from_vespa(
         family_document_passages_count_expected - less_expected
     )
 
-    document_passages = get_document_passages_from_vespa(
-        document_import_id=document_import_id,
-        text_blocks_ids=text_blocks_ids[less_expected:],
-        vespa_search_adapter=local_vespa_search_adapter,
-    )
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        document_passages = await get_document_passages_from_vespa(
+            document_import_id=document_import_id,
+            text_blocks_ids=text_blocks_ids[less_expected:],
+            vespa_connection_pool=vespa_connection_pool,
+        )
 
     assert len(document_passages) == family_document_passages_count_expected
     assert all(
@@ -466,7 +472,8 @@ def test_get_some_document_passages_from_vespa(
 
 
 @pytest.mark.vespa
-def test_all_get_document_passages_from_vespa(
+@pytest.mark.asyncio
+async def test_all_get_document_passages_from_vespa(
     local_vespa_search_adapter: VespaSearchAdapter,
     document_passages_test_data_file_path: str,
     vespa_app,
@@ -486,11 +493,12 @@ def test_all_get_document_passages_from_vespa(
 
     family_document_passages_count_expected = len(text_blocks_ids)
 
-    document_passages = get_document_passages_from_vespa(
-        document_import_id=document_import_id,
-        text_blocks_ids=None,
-        vespa_search_adapter=local_vespa_search_adapter,
-    )
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        document_passages = await get_document_passages_from_vespa(
+            document_import_id=document_import_id,
+            text_blocks_ids=None,
+            vespa_connection_pool=vespa_connection_pool,
+        )
 
     assert len(document_passages) == family_document_passages_count_expected
     assert all(
@@ -506,16 +514,18 @@ def test_all_get_document_passages_from_vespa(
 
 
 @pytest.mark.vespa
-def test_get_document_passages_from_vespa_over_limit(
+@pytest.mark.asyncio
+async def test_get_document_passages_from_vespa_over_limit(
     local_vespa_search_adapter: VespaSearchAdapter,
     vespa_app,
 ) -> None:
     with pytest.raises(ValueError, match="50001 text block IDs exceeds 50000"):
-        get_document_passages_from_vespa(
-            text_blocks_ids=["test_33"] * (VESPA_MAX_LIMIT + 1),
-            document_import_id="test.executive.1.1",
-            vespa_search_adapter=local_vespa_search_adapter,
-        )
+        async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+            _ = await get_document_passages_from_vespa(
+                text_blocks_ids=["test_33"] * (VESPA_MAX_LIMIT + 1),
+                document_import_id="test.executive.1.1",
+                vespa_connection_pool=vespa_connection_pool,
+            )
 
 
 @pytest.mark.asyncio
@@ -549,6 +559,7 @@ async def test_updates_by_s3_with_s3_paths(
         as_deployment=False,
         cache_bucket=mock_bucket,
         concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+        vespa_search_adapter=local_vespa_search_adapter,
     )
 
     final_passages_response = local_vespa_search_adapter.client.query(
@@ -589,6 +600,7 @@ async def test_updates_by_s3_with_s3_prefixes(
         as_deployment=False,
         cache_bucket=mock_bucket,
         concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+        vespa_search_adapter=local_vespa_search_adapter,
     )
 
     final_passages_response = local_vespa_search_adapter.client.query(
@@ -637,6 +649,7 @@ async def test_updates_by_s3_task_failure(
             as_deployment=False,
             cache_bucket=mock_bucket,
             concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            vespa_search_adapter=local_vespa_search_adapter,
         )
 
 
@@ -669,6 +682,7 @@ async def test_updates_by_s3_task_unexpected_result(
             as_deployment=False,
             cache_bucket=mock_bucket,
             concepts_counts_prefix=CONCEPTS_COUNTS_PREFIX_DEFAULT,
+            vespa_search_adapter=local_vespa_search_adapter,
         )
 
 
@@ -996,3 +1010,26 @@ def test_load_labelled_passages_by_uri_raw(mock_bucket, mock_s3_client):
             },
         )
     ]
+
+
+@pytest.mark.parametrize(
+    "items,batch_size,connections",
+    [
+        ([], 10, 1),
+        ([1, 2, 3, 4], 2, 2),
+        ([1, 2], 10, 1),
+        ([1] * 11, 5, 3),
+        ([1] * 10, 10, 1),
+        ([1] * 0, 1, 1),
+        ([1] * 25, 10, 3),
+        ([1] * 10, 3, 4),
+        ([1] * 9, 3, 3),
+        ([1], 100, 1),
+    ],
+)
+def test_connections_from_batch_size(
+    items: list[Any],
+    batch_size: int,
+    connections: int,
+) -> None:
+    assert connections_from_batch_size(items, batch_size) == connections

--- a/tests/local_vespa/README.md
+++ b/tests/local_vespa/README.md
@@ -1,8 +1,8 @@
-# Local Vespa 
+# Local Vespa
 
 ## Setup for tests
 
-This folder has the config for a local vespa instance that is used for testing.
+This folder has the config for a local Vespa instance that is used for testing.
 
 Some tests require this in order to run. You can spin up a local version by running:
 
@@ -10,7 +10,7 @@ Some tests require this in order to run. You can spin up a local version by runn
 just vespa_dev_setup
 ```
 
-This requires the [vespa cli](https://docs.vespa.ai/en/vespa-cli.html). It also expects the docker daemon to be running.
+This requires the [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html). It also expects the Docker daemon to be running.
 
 ## Skip vespa tests instead
 


### PR DESCRIPTION
Instead of creating new connections every time we interact with Vespa, create a pool instead. This is intended to reduce the overhead of creating a new network connection and the Python objects. This would've had a larger effect when we were doing per-document passage read requests, but is still helpful.

**Testing**

Successful run: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/92adf6f0-8547-4010-becf-3d6f695ec39f?entity_id=92adf6f0-8547-4010-becf-3d6f695ec39f

FIXES PLA-522
