### PR TITLE
Removing the parent timeout for indexing.

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -72,7 +72,7 @@ VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
 
 # The "parent" AKA the higher level flows that do multiple things.
-PARENT_TIMEOUT_S: int = int(timedelta(hours=2).total_seconds())
+PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())
 
 # Needed to get document passages from Vespa
 # Example: CCLW.executive.1813.2418

--- a/flows/index.py
+++ b/flows/index.py
@@ -71,7 +71,7 @@ class Config:
 @flow(
     on_failure=[SlackNotify.message],
     on_crashed=[SlackNotify.message],
-    timeout_seconds=PARENT_TIMEOUT_S,
+    # timeout_seconds=PARENT_TIMEOUT_S,
 )
 async def index_labelled_passages_from_s3_to_vespa(
     classifier_specs: list[ClassifierSpec] | None = None,

--- a/flows/index.py
+++ b/flows/index.py
@@ -71,7 +71,7 @@ class Config:
 @flow(
     on_failure=[SlackNotify.message],
     on_crashed=[SlackNotify.message],
-    # timeout_seconds=PARENT_TIMEOUT_S,
+    timeout_seconds=None,
 )
 async def index_labelled_passages_from_s3_to_vespa(
     classifier_specs: list[ClassifierSpec] | None = None,


### PR DESCRIPTION
This Pull Request:
---
Removes the parent timeout from the indexing deployment/flow.

Keeps the timeout on the run_partial_updates_of_concepts_for_batch flow in place. This timeout continues to protect against spawning too many child indexing jobs.

Reason for Change:
This adjustment is a response to a timeout encountered during [this run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/8580f2ce-a5bb-46dd-810d-39685ef14f46?entity_id=8580f2ce-a5bb-46dd-810d-39685ef14f46&state=cancelled&state=cancelling&state=completed&state=crashed&state=failed&state=paused&state=pending&state=running&state=scheduled&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts), where the run exceeded the configured 2-hour timeout.
Despite the timeout configuration, the run continued past the expected duration, highlighting that the parent timeout was not effectively enforced.

By removing the parent timeout, we reduce the risk of runs being unpredictably cancelled several hours in. The child flow still retains a timeout to prevent uncontrolled scaling.
