### PR TITLE
Script: Run passages generator with continuation tokens 

### DIFF
--- a/scripts/run_document_passages_generator.py
+++ b/scripts/run_document_passages_generator.py
@@ -1,0 +1,22 @@
+import tempfile
+
+from flows.boundary import (
+    get_document_passages_from_vespa__generator,
+    get_vespa_search_adapter_from_aws_secrets,
+)
+
+temp_dir = tempfile.TemporaryDirectory()
+vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
+    cert_dir=temp_dir.name,
+    # TODO: Checked and these are read only certs used for monitoring
+    vespa_private_key_param_name="VESPA_PRIVATE_KEY",
+    vespa_public_cert_param_name="VESPA_PUBLIC_CERT",
+)
+
+passages_generator = get_document_passages_from_vespa__generator(
+    # Note: This document has 59,000 passages (more than the max hits)
+    document_import_id="UNFCCC.party.1010.0",
+    vespa_search_adapter=vespa_search_adapter,
+    continuation_tokens=["BKAAAAABKBGA"],
+    grouping_max=100,
+)


### PR DESCRIPTION
This Pull Request: 
---
- Adds a script for running retrieval from vespa with continuation tokens.
- This was useful for isolating the functionality and proving efficacy. 
- As we can see we successfully retrieved all passages for a document with greater than the 50,000 max hits. 
- The generator yielded 593 lists of passages each up to 100 passages.

```python
(Pdb) all = list(passages_generator)
(Pdb) len(all)
593
```

_Note: This script can be parameterised if we want it and isn't necessarily for merge in this state. Maybe this goes on the ticket._ 
