### PR TITLE
Bugfix: Query too long 

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -71,7 +71,7 @@ VESPA_MAX_LIMIT: int = 50_000
 VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
 # The maximum number of elements to use in equivalent operator of a vespa yql query.
-VESPA_EQUIV_OPERATOR_LIMIT: int = 2_500
+VESPA_EQUIV_OPERATOR_LIMIT: int = 1_000
 
 # The "parent" AKA the higher level flows that do multiple things.
 PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -71,7 +71,7 @@ VESPA_MAX_LIMIT: int = 50_000
 VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
 # The maximum number of elements to use in equivalent operator of a vespa yql query.
-VESPA_EQUIV_OPERATOR_LIMIT: int = 500
+VESPA_EQUIV_OPERATOR_LIMIT: int = 5_000
 
 # The "parent" AKA the higher level flows that do multiple things.
 PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())
@@ -610,7 +610,6 @@ async def get_document_passages_from_vespa(
         .set_timeout(timeout_ms)
     )
 
-    # FIXME: Query too long during indexing
     vespa_query_response: VespaQueryResponse = await vespa_connection_pool.query(
         yql=query
     )

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -71,7 +71,7 @@ VESPA_MAX_LIMIT: int = 50_000
 VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
 # The maximum number of elements to use in equivalent operator of a vespa yql query.
-VESPA_EQUIV_OPERATOR_LIMIT: int = 5_000
+VESPA_EQUIV_OPERATOR_LIMIT: int = 2_500
 
 # The "parent" AKA the higher level flows that do multiple things.
 PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -71,7 +71,7 @@ VESPA_MAX_LIMIT: int = 50_000
 VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
 # The maximum number of elements to use in equivalent operator of a vespa yql query.
-VESPA_EQUIV_OPERATOR_LIMIT: int = 1_000
+VESPA_MAX_EQUIV_ELEMENTS_IN_QUERY: int = 1_000
 
 # The "parent" AKA the higher level flows that do multiple things.
 PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -70,6 +70,8 @@ VESPA_MAX_LIMIT: int = 50_000
 # [1] https://vespa-engine.github.io/pyvespa/query.html#error-handling
 VESPA_DEFAULT_TIMEOUT_MS: int = total_milliseconds(timedelta(milliseconds=500))
 VESPA_MAX_TIMEOUT_MS: int = total_milliseconds(timedelta(minutes=5))
+# The maximum number of elements to use in equivalent operator of a vespa yql query.
+VESPA_EQUIV_OPERATOR_LIMIT: int = 500
 
 # The "parent" AKA the higher level flows that do multiple things.
 PARENT_TIMEOUT_S: int = int(timedelta(hours=4).total_seconds())
@@ -608,6 +610,7 @@ async def get_document_passages_from_vespa(
         .set_timeout(timeout_ms)
     )
 
+    # FIXME: Query too long during indexing
     vespa_query_response: VespaQueryResponse = await vespa_connection_pool.query(
         yql=query
     )
@@ -1104,7 +1107,9 @@ async def run_partial_updates_of_concepts_for_document_passages(
         # Read all the document passages from Vespa in as fewer reads as possible
         text_blocks: dict[TextBlockId, tuple[VespaHitId, VespaPassage]] = {}
 
-        for text_blocks_ids_batch in iterate_batch(text_blocks_ids, VESPA_MAX_LIMIT):
+        for text_blocks_ids_batch in iterate_batch(
+            text_blocks_ids, VESPA_EQUIV_OPERATOR_LIMIT
+        ):
             results = await get_document_passages_from_vespa(
                 document_import_id=document_import_id,
                 text_blocks_ids=text_blocks_ids_batch,

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1107,7 +1107,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
         text_blocks: dict[TextBlockId, tuple[VespaHitId, VespaPassage]] = {}
 
         for text_blocks_ids_batch in iterate_batch(
-            text_blocks_ids, VESPA_EQUIV_OPERATOR_LIMIT
+            text_blocks_ids, VESPA_MAX_EQUIV_ELEMENTS_IN_QUERY
         ):
             results = await get_document_passages_from_vespa(
                 document_import_id=document_import_id,

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -13,7 +13,7 @@ from prefect.logging import disable_run_logger
 
 from flows.boundary import (
     CONCEPTS_COUNTS_PREFIX_DEFAULT,
-    VESPA_EQUIV_OPERATOR_LIMIT,
+    VESPA_MAX_EQUIV_ELEMENTS_IN_QUERY,
     VESPA_MAX_LIMIT,
     DocumentImporter,
     DocumentObjectUri,

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -13,6 +13,7 @@ from prefect.logging import disable_run_logger
 
 from flows.boundary import (
     CONCEPTS_COUNTS_PREFIX_DEFAULT,
+    VESPA_EQUIV_OPERATOR_LIMIT,
     VESPA_MAX_LIMIT,
     DocumentImporter,
     DocumentObjectUri,
@@ -484,6 +485,15 @@ async def test_get_some_document_passages_from_vespa(
             for passage_id, passage in document_passages[less_expected:]
         ]
     )
+
+    # Test that we can construct a query with the configured total text blocks for use
+    # in the equivalent operator part of the query.
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        _ = await get_document_passages_from_vespa(
+            document_import_id="test.executive.1.1",
+            text_blocks_ids=["test_33"] * VESPA_EQUIV_OPERATOR_LIMIT,
+            vespa_connection_pool=vespa_connection_pool,
+        )
 
 
 @pytest.mark.vespa

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -491,7 +491,7 @@ async def test_get_some_document_passages_from_vespa(
     async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
         _ = await get_document_passages_from_vespa(
             document_import_id="test.executive.1.1",
-            text_blocks_ids=["test_33"] * VESPA_EQUIV_OPERATOR_LIMIT,
+            text_blocks_ids=["test_33"] * VESPA_MAX_EQUIV_ELEMENTS_IN_QUERY,
             vespa_connection_pool=vespa_connection_pool,
         )
 


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for failed queries during indexing raised during this prefect [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/c8e7199e-9c54-43f3-8653-62297ad0e4c9?entity_id=c8e7199e-9c54-43f3-8653-62297ad0e4c9&state=cancelled&state=cancelling&state=completed&state=crashed&state=failed&state=paused&state=pending&state=running&state=scheduled&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts). 
- The proposed fix is an update to how many text block ids we append to the equiv operator query.
- Validated what the limit should be using the added test by incrementally reducing the limit. 
- Staging [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/e3a3bf09-7654-4c8c-adfb-eb586071572b?entity_id=e3a3bf09-7654-4c8c-adfb-eb586071572b&state=cancelled&state=cancelling&state=completed&state=crashed&state=failed&state=paused&state=pending&state=running&state=scheduled&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts). 

_Note: In the staging run we still see some errors but these aren't related to the query length. I'm seeing the following errors in the logs `raise MissingContextError("There is no active flow or task run context.")` which are due to an attempt at creating a prefect logger with no flow or task decorator declared on the function. An example of this is`update_feed_result_callback`_