### PR TITLE
Bugfix: Failing CD due to deployment import paths 

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -123,7 +123,7 @@ create_deployment(
 # Index
 
 create_deployment(
-    flow=boundary.run_partial_updates_of_concepts_for_document_passages__update,
+    flow=boundary.run_partial_updates_of_concepts_for_document_passages,
     description="Co-ordinate updating inference results for concepts in Vespa",
 )
 
@@ -137,11 +137,6 @@ create_deployment(
 create_deployment(
     flow=deindex.run_cleanup_objects_for_batch,
     description="Clean-up a concept's versions for a document",
-)
-
-create_deployment(
-    flow=boundary.run_partial_updates_of_concepts_for_document_passages__remove,
-    description="Co-ordinate removing inference results for concepts in Vespa",
 )
 
 create_deployment(


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix in response to a failing [deployment](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14856928830/job/41712382062) to staging due to invalid import paths. 
- Rather than having a removal and update deployment we now handle both within the `run_partial_updates_of_concepts_for_document_passages` deployment. 
- Now passing prefect staging [deployment](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14857371668/job/41713789188). 