### PR TITLE
Bugfix/fix logger instantiation

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -12,6 +12,7 @@ from collections.abc import Generator
 from datetime import timedelta
 from enum import Enum
 from io import BytesIO
+from logging import Logger
 from pathlib import Path
 from typing import Any, Iterable, Protocol, TypeAlias, TypedDict, TypeVar, Union
 
@@ -29,6 +30,7 @@ from prefect import flow, get_run_logger
 from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.deployments import run_deployment
 from prefect.logging import get_logger
+from prefect.logging.loggers import LoggingAdapter
 from pydantic import BaseModel, NonNegativeInt, PositiveInt
 from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.package import Document, Schema
@@ -806,6 +808,7 @@ class _FeedResultCallback(Protocol):
         grouped_concepts: dict[TextBlockId, list[VespaConcept]],
         response: VespaResponse,
         data_id: VespaDataId,
+        logger: Union[Logger, LoggingAdapter],
     ) -> None: ...
 
 
@@ -1173,6 +1176,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
             grouped_concepts,
             response,
             data_id,
+            logger,
         )
 
     # The previously established connection pool isn't used since
@@ -1213,9 +1217,8 @@ def update_feed_result_callback(
     grouped_concepts: dict[TextBlockId, list[VespaConcept]],
     response: VespaResponse,
     data_id: VespaDataId,
+    logger: Union[Logger, LoggingAdapter],
 ) -> None:
-    logger = get_run_logger()
-
     if not response.is_successful():
         logger.error(
             f"Vespa feed result wasn't successful. Error: {json.dumps(response.get_json())}"
@@ -1308,7 +1311,9 @@ def remove_feed_result_callback(
     grouped_concepts: dict[TextBlockId, list[VespaConcept]],
     response: VespaResponse,
     data_id: VespaDataId,
+    logger: Union[Logger, LoggingAdapter],
 ) -> None:
+    # FIXME: logger
     logger = get_run_logger()
 
     # Update concepts counts

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1313,9 +1313,6 @@ def remove_feed_result_callback(
     data_id: VespaDataId,
     logger: Union[Logger, LoggingAdapter],
 ) -> None:
-    # FIXME: logger
-    logger = get_run_logger()
-
     # Update concepts counts
     text_block_id = get_text_block_id_from_vespa_data_id(data_id)
     concepts = grouped_concepts[text_block_id]


### PR DESCRIPTION
This Pull Request: 
---
- Is in response to failures seen during an indexing run.
- Issue is from trying to create a prefect logger from a vanilla python function with no flow or task decorator. 
- Errors are not exposed to the prefect console but can be seen in the ecs [logs](https://eu-west-1.console.aws.amazon.com/ecs/v2/clusters/prefect-fargate-cluster-prefect-mvp-staging-e0738bb/tasks/89e5a149250f46248c12d6dfd33a56fc/logs?region=eu-west-1).  
- The fix aims to solve the issue by passing in the logger object.
- This was deemed better than printing the errors (we'd lose the logging level functionality), converting the function to a flow or task (we may hit up against prefect api limits due to this being called many times). 