### PR TITLE
refactor(flows): Use consistent Pydantic function for model dumping to JSON

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1287,7 +1287,7 @@ def update_concepts_on_existing_vespa_concepts(
     are removing all instances where the model is the same.
     """
     if not passage.concepts:
-        return [concept.model_dump(mode="json") for concept in concepts]
+        return [concept.model_dump_json() for concept in concepts]
 
     new_concept_models = {concept.model for concept in concepts}
 
@@ -1299,7 +1299,7 @@ def update_concepts_on_existing_vespa_concepts(
 
     updated_concepts = existing_concepts_to_keep + concepts
 
-    return [concept_.model_dump(mode="json") for concept_ in updated_concepts]
+    return [concept_.model_dump_json() for concept_ in updated_concepts]
 
 
 # De-index ----------------------------------------------------------------------
@@ -1376,7 +1376,7 @@ def remove_concepts_from_existing_vespa_concepts(
         if concept.model not in concepts_to_remove__models
     ]
 
-    return [concept_.model_dump(mode="json") for concept_ in concepts_in_vespa_to_keep]
+    return [concept_.model_dump_json() for concept_ in concepts_in_vespa_to_keep]
 
 
 async def update_s3_with_latest_concepts_counts(

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -462,7 +462,7 @@ def test_update_concepts_on_existing_vespa_concepts(
             concepts=[concept],
         )
         assert len(updated_passage_concepts) == 1
-        assert updated_passage_concepts[0] == concept.model_dump(mode="json")
+        assert updated_passage_concepts[0] == concept.model_dump_json()
 
         # Test that we can remove old model concepts from the passage concepts and
         # add the new one.
@@ -487,7 +487,7 @@ def test_update_concepts_on_existing_vespa_concepts(
             concepts=[concept],
         )
         assert len(updated_passage_concepts) == 1
-        assert updated_passage_concepts[0] == concept.model_dump(mode="json")
+        assert updated_passage_concepts[0] == concept.model_dump_json()
 
         # Test that we can add new concepts and retain concepts from other models
         updated_passage_concepts = update_concepts_on_existing_vespa_concepts(
@@ -511,7 +511,7 @@ def test_update_concepts_on_existing_vespa_concepts(
             concepts=[concept],
         )
         assert len(updated_passage_concepts) == 2
-        assert concept.model_dump(mode="json") in updated_passage_concepts
+        assert concept.model_dump_json() in updated_passage_concepts
 
 
 def test_update_feed_result_callback():


### PR DESCRIPTION
Whilst using the mode is operationally equivalent, this makes our code consistent, and helps encourage avoiding the original problem that motivated this.

FIXES PLA-505