### PR TITLE
fix(flows): Use Prefect v3 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM prefecthq/prefect:2.20.7-python3.10
+FROM prefecthq/prefect:3.3.7-python3.10
 
 RUN pip install --upgrade pip
 RUN pip install "poetry==1.8.3"


### PR DESCRIPTION
This was missed previously. The project is currently on `3.3.11`, but Prefect doesn't publish tags for every version, it seems[^1][^2].

Thought it's better to at least get onto `v3` at least.

**Testing**

Deployed to [staging](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/14888606649/job/41814768981) and ran [a flow successfully](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/14bf0856-08b8-4c6e-8bd4-350505ed5071?entity_id=14bf0856-08b8-4c6e-8bd4-350505ed5071).

FIXES PLA-468

[^1]: https://hub.docker.com/r/prefecthq/prefect/tags?name=3.3.11-python3.10
[^1]: https://hub.docker.com/r/prefecthq/prefect/tags?name=3.3.7-python3.10
