### PR TITLE
test: Set pytest-asyncio scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ env = [
   "WIKIBASE_URL=https://test.test.test"
 ]
 markers = ["vespa", "flaky_on_ci", "transformers"]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
We've had a warning for a while:

```
poetry run pytest --disable-pytest-warnings --color=yes -v -m 'not flaky_on_ci and not transformers' --ignore tests/test_argilla_v2.py --ignore tests/test_task_distribution.py
  12
  /home/runner/.cache/pypoetry/virtualenvs/knowledge-graph-67_EgitM-py3.10/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
  13
  The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop
  scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```

This makes it explicit. In their [documentation](https://pytest-asyncio.readthedocs.io/en/v0.26.0/concepts.html), and based on the default fixtures scoping, this value seems reasonable.
