### PR TITLE
fix: Use the primary model version, not the latest

### DIFF
--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -85,12 +85,14 @@ def get_relevant_model_version(
             return model_artifacts.name
 
 
-def is_latest_model_in_env(
-    classifier_specs: list[ClassifierSpec], model_name: str
-) -> bool:
+def model_seen_in_env(classifier_specs: list[ClassifierSpec], model_name: str) -> bool:
     """Check to see if this model already has a version found for the env"""
     env_models = [m.name for m in classifier_specs]
-    return model_name not in env_models
+    return model_name in env_models
+
+
+def model_artifact_is_primary(aliases: list[str], aws_env: AwsEnv) -> bool:
+    return aws_env.value in aliases
 
 
 def sort_specs(specs: list[ClassifierSpec]) -> list[ClassifierSpec]:
@@ -136,23 +138,38 @@ def get_all_available_classifiers(
             continue
 
         console.log(model.name)
-        for model_artifacts in model.artifacts():
-            model_env = AwsEnv(model_artifacts.metadata.get("aws_env"))
-            if model_env not in aws_envs:
+        for model_artifact in model.artifacts():
+            model_env = AwsEnv(model_artifact.metadata.get("aws_env"))
+
+            if (
+                # Is it a known AWS env.?
+                model_env not in aws_envs
+                # Does it have any aliases? If there's none, there's no
+                # way it could be the primary.
+                or not model_artifact.aliases
+                # Is it the primary version or not?
+                or not model_artifact_is_primary(model_artifact.aliases, model_env)
+            ):
                 continue
 
-            if is_latest_model_in_env(classifier_specs[model_env], model.name):
-                model_parts: list[str] = model_artifacts.name.split(":")
-                if len(model_parts) != 2:
-                    raise ValueError(
-                        f"Model name had unexpected format: {model_artifacts.name}"
-                    )
-                classifier_specs[model_env].append(
-                    ClassifierSpec(
-                        name=model_parts[0],
-                        alias=model_parts[1],
-                    )
+            # Has the primary model already been found?
+            if model_seen_in_env(
+                classifier_specs[model_env],
+                model.name,
+            ):
+                break
+
+            model_parts: list[str] = model_artifact.name.split(":")
+            if len(model_parts) != 2:
+                raise ValueError(
+                    f"Model name had unexpected format: {model_artifact.name}"
                 )
+            classifier_specs[model_env].append(
+                ClassifierSpec(
+                    name=model_parts[0],
+                    alias=model_parts[1],
+                )
+            )
 
     for aws_env, specs in classifier_specs.items():
         aws_env = AwsEnv(aws_env)

--- a/tests/scripts/test_update_classifier_spec.py
+++ b/tests/scripts/test_update_classifier_spec.py
@@ -10,7 +10,8 @@ from scripts.cloud import AwsEnv, ClassifierSpec
 from scripts.update_classifier_spec import (
     get_all_available_classifiers,
     is_concept_model,
-    is_latest_model_in_env,
+    model_artifact_is_primary,
+    model_seen_in_env,
     parse_spec_file,
     read_spec_file,
     sort_specs,
@@ -38,6 +39,7 @@ def mock_wandb_api():
             mock_artifact = Mock()
             mock_artifact.name = f"{model_data['name']}:v1"
             mock_artifact.metadata = {"aws_env": model_data["env"]}
+            mock_artifact.aliases = ["latest", "sandbox"]
 
             mock_collection = Mock()
             mock_collection.name = model_data["name"]
@@ -76,8 +78,8 @@ def test_is_latest_model_in_env():
         ClassifierSpec(name="Q22", alias="v1"),
         ClassifierSpec(name="Q11", alias="v2"),
     ]
-    assert not is_latest_model_in_env(classifier_specs, model_name="Q11")
-    assert is_latest_model_in_env(classifier_specs, model_name="Q33")
+    assert model_seen_in_env(classifier_specs, model_name="Q11")
+    assert not model_seen_in_env(classifier_specs, model_name="Q33")
 
 
 def test_get_all_available_classifiers(mock_wandb_api):
@@ -172,3 +174,14 @@ def test_sort_specs():
         ClassifierSpec(name="Q789", alias="v1"),
         ClassifierSpec(name="Q999", alias="v3"),
     ]
+
+
+@pytest.mark.parametrize(
+    "aliases,aws_env,expected",
+    [
+        ([AwsEnv.sandbox.value, "latest"], AwsEnv.sandbox, True),
+        ([], AwsEnv.staging, False),
+    ],
+)
+def test_model_artifact_is_primary(aliases, aws_env, expected):
+    assert model_artifact_is_primary(aliases=aliases, aws_env=aws_env) == expected


### PR DESCRIPTION
Until now, we were effectively relying on the order of model artifacts, to determine what the _right_ verion is to use. The implicit ordering reliance is for newest to oldest.

As part of promotion, the AWS env. is attached to a model version, to indicate this _the_ one to use by default.

This change now looks for the model version that has the appropriate AWS env. label, that indicates primariness.

FIXES PLA-584
