### PR TITLE
Make it easier to audit gaps in inference results

### DIFF
--- a/scripts/do_classifier_specs_have_results.py
+++ b/scripts/do_classifier_specs_have_results.py
@@ -5,15 +5,25 @@ import typer
 import yaml
 from botocore.exceptions import ClientError
 
+from scripts.cloud import AwsEnv
+
 app = typer.Typer()
 
 PREFIX = os.getenv("LABELLED_PASSAGES_PREFIX", "labelled_passages")
+YAML_FILES_MAP = {
+    "prod": "flows/classifier_specs/prod.yaml",
+    "staging": "flows/classifier_specs/staging.yaml",
+    "sandbox": "flows/classifier_specs/sandbox.yaml",
+    "labs": "flows/classifier_specs/labs.yaml",
+}
 
 
 @app.command()
 def check_classifier_specs(
-    yaml_path: str = typer.Argument(
-        help="Path to the YAML file containing classifier specifications"
+    aws_env: AwsEnv = typer.Argument(
+        help="Which aws environment to look for results in. Determines which spec file"
+        "to use",
+        default="sandbox",
     ),
     bucket_name: str = typer.Argument(
         help=(
@@ -31,7 +41,7 @@ def check_classifier_specs(
 
     This can be used to help us validate that inference has run correctly.
     """
-    with open(yaml_path, "r") as file:
+    with open(YAML_FILES_MAP[aws_env], "r") as file:
         data = yaml.safe_load(file)
 
     s3 = boto3.client("s3")

--- a/scripts/do_classifier_specs_have_results.py
+++ b/scripts/do_classifier_specs_have_results.py
@@ -72,9 +72,10 @@ def write_result(
     result: Result,
     start_time: str,
     parent_dir: Path = INFERENCE_RESULTS_AUDIT_DIR,
+    aws_env: AwsEnv = AwsEnv.sandbox,
 ) -> Path:
     """Write the file names for a given classifier spec to the audit directory."""
-    dir_path = parent_dir / start_time
+    dir_path = parent_dir / aws_env.value / start_time
     if not dir_path.exists():
         dir_path.mkdir(parents=True)
 
@@ -90,7 +91,7 @@ def check_classifier_specs(
     aws_env: AwsEnv = typer.Argument(
         help="Which aws environment to look for results in. Determines which spec file"
         "to use",
-        default="sandbox",
+        default=AwsEnv.sandbox,
     ),
     bucket_name: str = typer.Argument(
         help=(
@@ -130,7 +131,7 @@ def check_classifier_specs(
         for future in as_completed(future_to_spec):
             result = future.result()
             if write_file_names:
-                write_result(result, start_time, INFERENCE_RESULTS_AUDIT_DIR)
+                write_result(result, start_time, INFERENCE_RESULTS_AUDIT_DIR, aws_env)
 
             if not result.path_exists:
                 to_process.append(result.classifier_spec)

--- a/tests/scripts/test_do_classifier_specs_have_results.py
+++ b/tests/scripts/test_do_classifier_specs_have_results.py
@@ -61,6 +61,10 @@ def test_write_result():
             file_names=[test_file_name],
         )
         path = write_result(
-            result=result, start_time="YYYY-MM-DD", parent_dir=Path(temp_dir)
+            result=result,
+            start_time="YYYY-MM-DD",
+            parent_dir=Path(temp_dir),
+            aws_env="sandbox",
         )
         assert path.read_text() == json.dumps([test_file_name])
+        assert path.parent.name == "sandbox"

--- a/tests/scripts/test_do_classifier_specs_have_results.py
+++ b/tests/scripts/test_do_classifier_specs_have_results.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from scripts.cloud import AwsEnv
 from scripts.do_classifier_specs_have_results import (
     Result,
     check_classifier_specs,
@@ -16,7 +17,7 @@ from tests.flows.conftest import *  # noqa: F403
 
 def test_check_classifier_specs(mock_bucket, capsys):
     check_classifier_specs(
-        aws_env="sandbox",
+        aws_env=AwsEnv("sandbox"),
         bucket_name=mock_bucket,
         max_workers=4,
         write_file_names=False,
@@ -64,7 +65,6 @@ def test_write_result():
             result=result,
             start_time="YYYY-MM-DD",
             parent_dir=Path(temp_dir),
-            aws_env="sandbox",
+            aws_env=AwsEnv("sandbox"),
         )
         assert path.read_text() == json.dumps([test_file_name])
-        assert path.parent.name == "sandbox"

--- a/tests/scripts/test_do_classifier_specs_have_results.py
+++ b/tests/scripts/test_do_classifier_specs_have_results.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.do_classifier_specs_have_results import (
+    Result,
+    check_classifier_specs,
+    check_single_spec,
+    collect_file_names,
+    write_result,
+)
+
+# the flows conftest wouldn't be in scope here (yet?) but it does have what we need
+from tests.flows.conftest import *  # noqa: F403
+
+
+def test_check_classifier_specs(mock_bucket, capsys):
+    check_classifier_specs(
+        aws_env="sandbox",
+        bucket_name=mock_bucket,
+        max_workers=4,
+        write_file_names=False,
+    )
+    stdout, stderr = capsys.readouterr()
+    assert "to_process: " in stdout
+    assert (
+        "Checking sandbox classifier specs in test_bucket/labelled_passages" in stdout
+    )
+    assert stderr == ""
+
+
+def test_check_single_spec(
+    mock_bucket, mock_bucket_labelled_passages, s3_prefix_labelled_passages
+):
+    _, name, alias = s3_prefix_labelled_passages.split("/")
+    classifier_spec = f"{name}:{alias}"
+    result = check_single_spec(bucket_name=mock_bucket, classifier_spec=classifier_spec)
+    assert result.path_exists
+    assert result.classifier_spec == classifier_spec
+
+
+def test_collect_file_names(
+    mock_bucket,
+    s3_prefix_labelled_passages,
+    mock_bucket_labelled_passages,
+    labelled_passage_fixture_ids,
+):
+    file_names = collect_file_names(
+        bucket_name=mock_bucket, prefix=s3_prefix_labelled_passages
+    )
+    expected_file_names = [f"{doc_id}.json" for doc_id in labelled_passage_fixture_ids]
+    assert set(file_names) == set(expected_file_names)
+
+
+def test_write_result():
+    test_file_name = "test-file-name"
+    with TemporaryDirectory() as temp_dir:
+        result = Result(
+            path_exists=True,
+            classifier_spec="test-classifier-spec",
+            file_names=[test_file_name],
+        )
+        path = write_result(
+            result=result, start_time="YYYY-MM-DD", parent_dir=Path(temp_dir)
+        )
+        assert path.read_text() == json.dumps([test_file_name])


### PR DESCRIPTION
This builds on the existing script that checks the output of inference flows to confirm classifiers have actually run. The original checks for files under the classifier prefix and runs sequentially. This sets up the script to run in parallel, and adds the option to write out the file ids (these can then be used for finding gaps in the results).

As a bonus I also added tests and reworked the input aiming to require less typing.