### PR TITLE
fix: Don't pass a logger and print instead

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -12,7 +12,6 @@ from collections.abc import Generator
 from datetime import timedelta
 from enum import Enum
 from io import BytesIO
-from logging import Logger
 from pathlib import Path
 from typing import Any, Iterable, Protocol, TypeAlias, TypedDict, TypeVar, Union
 
@@ -30,7 +29,6 @@ from prefect import flow, get_run_logger
 from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.deployments import run_deployment
 from prefect.logging import get_logger
-from prefect.logging.loggers import LoggingAdapter
 from pydantic import BaseModel, NonNegativeInt, PositiveInt
 from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.package import Document, Schema
@@ -811,7 +809,6 @@ class _FeedResultCallback(Protocol):
         grouped_concepts: dict[TextBlockId, list[VespaConcept]],
         response: VespaResponse,
         data_id: VespaDataId,
-        logger: Union[Logger, LoggingAdapter],
     ) -> None: ...
 
 
@@ -1179,7 +1176,6 @@ async def run_partial_updates_of_concepts_for_document_passages(
             grouped_concepts,
             response,
             data_id,
-            logger,
         )
 
     # The previously established connection pool isn't used since
@@ -1220,10 +1216,9 @@ def update_feed_result_callback(
     grouped_concepts: dict[TextBlockId, list[VespaConcept]],
     response: VespaResponse,
     data_id: VespaDataId,
-    logger: Union[Logger, LoggingAdapter],
 ) -> None:
     if not response.is_successful():
-        logger.error(
+        print(
             f"Vespa feed result wasn't successful. Error: {json.dumps(response.get_json())}"
         )
         failures.append(response)
@@ -1314,7 +1309,6 @@ def remove_feed_result_callback(
     grouped_concepts: dict[TextBlockId, list[VespaConcept]],
     response: VespaResponse,
     data_id: VespaDataId,
-    logger: Union[Logger, LoggingAdapter],
 ) -> None:
     # Update concepts counts
     text_block_id = get_text_block_id_from_vespa_data_id(data_id)
@@ -1340,7 +1334,7 @@ def remove_feed_result_callback(
             concepts_counts[concept_model] = 0
 
     if not response.is_successful():
-        logger.error(
+        print(
             f"Vespa feed result wasn't successful. Error: {json.dumps(response.get_json())}"
         )
         failures.append(response)

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from collections import Counter
 from collections.abc import Callable
@@ -1447,7 +1446,6 @@ def test_remove_feed_result_callback():
             grouped_concepts=grouped_concepts,
             response=response,
             data_id=data_id,
-            logger=logging.getLogger("test"),
         )
         is None
     )
@@ -1493,7 +1491,6 @@ def test_remove_feed_result_callback_not_successful_response():
             grouped_concepts=grouped_concepts,
             response=response,
             data_id=data_id,
-            logger=logging.getLogger("test"),
         )
         is None
     )

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from collections import Counter
 from datetime import datetime
 from functools import partial
@@ -549,7 +548,6 @@ def test_update_feed_result_callback():
             grouped_concepts=grouped_concepts,
             response=response,
             data_id=data_id,
-            logger=logging.getLogger("test"),
         )
         is None
     )
@@ -579,7 +577,6 @@ def test_update_feed_result_callback_not_successful_response():
             grouped_concepts=grouped_concepts,
             response=response,
             data_id=data_id,
-            logger=logging.getLogger("test"),
         )
         is None
     )


### PR DESCRIPTION
It's still not happy that the Prefect logger isn't available due to it not being in a flow or task[^1]:

```
2025-05-06T11:15:53.190Z File "/opt/prefect/knowledge-graph/flows/boundary.py", line 1170, in _vespa_response_handler_cb_with_state
2025-05-06T11:15:53.190Z vespa_response_handler_cb(
2025-05-06T11:15:53.190Z File "/opt/prefect/knowledge-graph/flows/boundary.py", line 1217, in update_feed_result_callback
2025-05-06T11:15:53.190Z logger = get_run_logger()
2025-05-06T11:15:53.190Z File "/usr/local/lib/python3.10/site-packages/prefect/logging/loggers.py", line 155, in get_run_logger
2025-05-06T11:15:53.190Z raise MissingContextError("There is no active flow or task run context.")
2025-05-06T11:15:53.190Z prefect.exceptions.MissingContextError: There is no active flow or task run context.
```

This is a follow-up to https://github.com/climatepolicyradar/knowledge-graph/pull/379.

Instead, it simply prints it. The next level that has a Prefect flow
or task is https://github.com/climatepolicyradar/knowledge-graph/blob/fix%2Fremove-logger-as-arg/flows/boundary.py#L1057 and it logs prints.

TOWARS PLA-573

[^1]: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/prefect-mvp-0b5e2a5/log-events/prefect-mvp$252Fprefect$252Ff44fa2b4c7c14cc0997ef42b73135efc$3Fstart$3D1746721083350$26refEventId$3D38953181814919795403898568736243213537900711389034577968
