### PR TITLE
fix: Safely access shared data across Vespa feed callbacks

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -7,6 +7,7 @@ import math
 import os
 import re
 import tempfile
+import threading
 from collections import Counter
 from collections.abc import Generator
 from datetime import timedelta
@@ -1306,18 +1307,29 @@ async def run_partial_updates_of_concepts_for_document_passages(
         map(lambda x: dict(_to_data(*x)), grouped_concepts.items())
     )
 
+    response_cb_lock: threading.Lock = threading.Lock()
+
     # Wrap the callback with the appropriate state and make it match
     # the expected signature.
     def _vespa_response_handler_cb_with_state(
         response: VespaResponse, data_id: VespaDataId
     ):
-        vespa_response_handler_cb(
-            failures,
-            concepts_counts,
-            grouped_concepts,
-            response,
-            data_id,
-        )
+        try:
+            response_cb_lock.acquire(
+                blocking=True,
+                timeout=timedelta(seconds=60).total_seconds(),
+            )
+
+            vespa_response_handler_cb(
+                failures,
+                concepts_counts,
+                grouped_concepts,
+                response,
+                data_id,
+            )
+        finally:
+            if response_cb_lock.locked():
+                response_cb_lock.release()
 
     @vespa_retry()
     def _feed_updates(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.1.7"
+version = "0.1.8"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Whilst we don't have reproducible steps for the memory issue, and thus I'm not certain if this will fix the issue, it has at least led me to identify this issue.

While list operations are atomic[^1], I have some doubts about relying on the bytecode ordering, and they do suggest to use a mutex if in doubt, so here's a mutex in the form of a lock.

There will be _a_ performance hit, though around that area, the slowest code would be the network call, and updating a list and a counter should be quick.

TOWARS PLA-573

[^1]: https://docs.python.org/3/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe
