### PR TITLE
Feature/pla 592 add retrys

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -45,6 +45,7 @@ from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.package import Document, Schema
 
 from flows.utils import (
+    SlackNotify,
     get_labelled_passage_paths,
     iterate_batch,
     remove_translated_suffix,
@@ -1077,7 +1078,13 @@ async def updates_by_s3(
 
 
 # No timeout set since the caller of this has one.
-@flow(log_prints=True)
+@flow(
+    log_prints=True,
+    retries=2,
+    retry_delay_seconds=5,
+    on_failure=[SlackNotify.message],
+    on_crashed=[SlackNotify.message],
+)
 async def run_partial_updates_of_concepts_for_document_passages(
     document_importer: DocumentImporter,
     cache_bucket: str,

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -13,10 +13,20 @@ from datetime import timedelta
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Iterable, Protocol, TypeAlias, TypedDict, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Protocol,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 import boto3
 import httpx
+import tenacity
 import vespa.application
 import vespa.querybuilder as qb
 from cpr_sdk.models.search import Concept as VespaConcept
@@ -30,6 +40,7 @@ from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.deployments import run_deployment
 from prefect.logging import get_logger
 from pydantic import BaseModel, NonNegativeInt, PositiveInt
+from vespa.exceptions import VespaError
 from vespa.io import VespaQueryResponse, VespaResponse
 from vespa.package import Document, Schema
 
@@ -113,6 +124,24 @@ class Operation(Enum):
 
     INDEX = "index"
     DEINDEX = "deindex"
+
+
+def vespa_retry(
+    max_attempts: int = 3,
+    wait_seconds: int = 2,
+    exception_types: tuple[type[Exception], ...] = (QueryError, VespaError),
+) -> Callable:
+    """Template for retries, use as a decorator."""
+
+    return tenacity.retry(
+        retry=tenacity.retry_if_exception_type(exception_types),
+        stop=tenacity.stop_after_attempt(max_attempts),
+        wait=tenacity.wait_fixed(wait_seconds),
+        before_sleep=lambda retry_state: print(
+            f"Retrying after error. Attempt {retry_state.attempt_number} of {max_attempts}"
+        ),
+        reraise=True,
+    )
 
 
 def get_vespa_search_adapter_from_aws_secrets(
@@ -456,6 +485,7 @@ def convert_labelled_passage_to_concepts(
     return concepts
 
 
+@vespa_retry()
 def get_document_from_vespa(
     document_import_id: DocumentImportId,
     vespa_search_adapter: VespaSearchAdapter,
@@ -498,6 +528,7 @@ def get_document_from_vespa(
     return document_id, document
 
 
+@vespa_retry()
 def get_document_passage_from_vespa(
     text_block_id: str,
     document_import_id: DocumentImportId,
@@ -541,6 +572,7 @@ def get_document_passage_from_vespa(
     return passage_id, passage
 
 
+@vespa_retry()
 async def get_document_passages_from_vespa(
     document_import_id: DocumentImportId,
     text_blocks_ids: list[TextBlockId] | None,
@@ -1169,15 +1201,27 @@ async def run_partial_updates_of_concepts_for_document_passages(
             data_id,
         )
 
-    # The previously established connection pool isn't used since
-    # `feed_iterable` creates its own.
-    vespa_search_adapter.client.feed_iterable(  # pyright: ignore[reportOptionalMemberAccess]
-        iter=data,
-        schema="document_passage",
-        namespace="doc_search",
-        operation_type="update",
-        max_connections=DEFAULT_DOCUMENTS_BATCH_SIZE,  # How many tasks to have running at once
-        callback=_vespa_response_handler_cb_with_state,
+    @vespa_retry()
+    def _feed_updates(
+        vespa_search_adapter: VespaSearchAdapter,
+        data: Iterable[dict[str, Any]],
+        callback: Callable[[VespaResponse, VespaDataId], None],
+    ) -> None:
+        # The previously established connection pool isn't used since
+        # `feed_iterable` creates its own.
+        vespa_search_adapter.client.feed_iterable(  # pyright: ignore[reportOptionalMemberAccess]
+            iter=data,
+            schema="document_passage",
+            namespace="doc_search",
+            operation_type="update",
+            max_connections=DEFAULT_DOCUMENTS_BATCH_SIZE,  # How many tasks to have running at once
+            callback=callback,
+        )
+
+    _feed_updates(
+        vespa_search_adapter,
+        data,
+        _vespa_response_handler_cb_with_state,
     )
 
     # Write concepts counts to S3

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,8 +3222,11 @@ files = [
     {file = "lxml-5.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7ce1a171ec325192c6a636b64c94418e71a1964f56d002cc28122fceff0b6121"},
     {file = "lxml-5.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:795f61bcaf8770e1b37eec24edf9771b307df3af74d1d6f27d812e15a9ff3872"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29f451a4b614a7b5b6c2e043d7b64a15bd8304d7e767055e8ab68387a8cacf4e"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f7f991a68d20c75cb13c5c9142b2a3f9eb161f1f12a9489c82172d1f133c0"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4aa412a82e460571fad592d0f93ce9935a20090029ba08eca05c614f99b0cc92"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:ac7ba71f9561cd7d7b55e1ea5511543c0282e2b6450f122672a2694621d63b7e"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:c5d32f5284012deaccd37da1e2cd42f081feaa76981f0eaa474351b68df813c5"},
+    {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:ce31158630a6ac85bddd6b830cffd46085ff90498b397bd0a259f59d27a12188"},
     {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:31e63621e073e04697c1b2d23fcb89991790eef370ec37ce4d5d469f40924ed6"},
     {file = "lxml-5.4.0-cp37-cp37m-win32.whl", hash = "sha256:be2ba4c3c5b7900246a8f866580700ef0d538f2ca32535e991027bdaba944063"},
     {file = "lxml-5.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:09846782b1ef650b321484ad429217f5154da4d6e786636c38e434fa32e94e49"},
@@ -8384,4 +8387,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.11"
-content-hash = "468acd749a9abe78fbb9759f3aafae117c03abf4c45e130110e79f9e70a3ef95"
+content-hash = "baa0bedf2688c2f131b3c945f052b5868732e16e629228c7170f0c1dd80f0512"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ awscli = "^1.37.24"
 prefect = {extras = ["slack"], version = "^3.3.1"}
 pydantic-ai = "^0.0.53"
 httpx = "^0.28.1"
+tenacity = "^9.1.2"
 
 [tool.poetry.group.transformers]
 optional = true


### PR DESCRIPTION
Add two kinds of retries for our indexing flow:
1. Vespa interaction: When communicating with vespa for a total of 3 attempts, 2 second wait between each, and only on specific errors that are likely to be network related (QueryError, VespaError) — note this means not catching `ValueError`, which are less likely to be transient but could also be added in the future if that assumption proves wrong.
2. Prefect flow, document level: Retries the whole document if it meets a failure, currently only tries again two times, and will alert in slack each failure/crash to make sure the issue is surfaced