### PR TITLE
test: Add very large test for indexing a document

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Install poetry
         shell: bash
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Install poetry
         shell: bash

--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ We've built our knowledge graph by running a set of classifiers over our giant c
 In the short-term, identifying where each concept is mentioned in our documents makes it easier for interested users of CPR's tools to jump straight to the relevant sections of our documents.
 
 In the longer term, we expect the graph to be a useful artefact in its own right. By analysing the structured web of relationships between climate policy concepts and the documents that mention them, we should be able to identify emerging topics and high-leverage areas for policy intervention.
+
+## Testing
+
+Make sure you have [Git LFS](https://git-lfs.com) installed if you want to run all the tests.

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1362,7 +1362,6 @@ async def run_partial_updates_of_concepts_for_document_passages(
         response: VespaResponse, data_id: VespaDataId
     ):
         try:
-            print("acquiring lock")
             acquired_lock = response_cb_lock.acquire(
                 blocking=True,
                 timeout=timedelta(minutes=2).total_seconds(),
@@ -1372,7 +1371,6 @@ async def run_partial_updates_of_concepts_for_document_passages(
                 print("failed to acquire lock")
                 return
 
-            print("handling response")
             vespa_response_handler_cb(
                 failures,
                 concepts_counts,
@@ -1382,7 +1380,6 @@ async def run_partial_updates_of_concepts_for_document_passages(
             )
         finally:
             locked = response_cb_lock.locked()
-            print(f"releasing lock? {locked}")
             if locked:
                 response_cb_lock.release()
 

--- a/justfile
+++ b/justfile
@@ -17,9 +17,13 @@ install +OPTS="":
 test +OPTS="":
     poetry run pytest --disable-pytest-warnings --color=yes {{OPTS}}
 
-# test the project, excluding tests that rely on a local vespa instance
+# test the project, excluding tests that rely on a local Vespa instance
 test-without-vespa +OPTS="":
     poetry run pytest --disable-pytest-warnings --color=yes {{OPTS}} -m 'not vespa'
+
+# test the project, excluding slow tests
+test-without-slow +OPTS="":
+    poetry run pytest --disable-pytest-warnings --color=yes {{OPTS}} -m 'not slow'
 
 # update the snapshots for the tests
 test-snapshot-update:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ env = [
   "WIKIBASE_PASSWORD=test_password",
   "WIKIBASE_URL=https://test.test.test"
 ]
-markers = ["vespa", "flaky_on_ci", "transformers"]
+markers = ["vespa", "flaky_on_ci", "transformers", "slow"]
 asyncio_default_fixture_loop_scope = "function"
 
 [build-system]

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -145,6 +145,35 @@ def vespa_app(
     )
 
 
+@pytest.fixture(scope="function")
+def vespa_large_app(
+    mock_vespa_credentials,
+):
+    # Connection
+    print("\nSetting up Vespa connection...")
+    app = Vespa(mock_vespa_credentials["VESPA_INSTANCE_URL"])
+
+    subprocess.run(
+        ["just", "vespa_feed_large_data"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=600,  # Seconds
+    )
+
+    yield app  # This is where the test function will be executed
+
+    # Teardown
+    print("\nTearing down Vespa connection...")
+    subprocess.run(
+        ["just", "vespa_delete_data"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,  # Seconds
+    )
+
+
 @pytest.fixture
 def local_vespa_search_adapter(
     create_vespa_params, mock_vespa_credentials, tmp_path

--- a/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
+++ b/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:116327fbb157ae7f2bd91d852461a120513594ef723fbac6e958842dea7d24b2
-size 80820686
+oid sha256:7019dc052ff5704d61c88a13e0af7c3cd887babef53c8af0b15633a14adfe676
+size 80361513

--- a/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
+++ b/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:116327fbb157ae7f2bd91d852461a120513594ef723fbac6e958842dea7d24b2
+size 80820686

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -1,6 +1,4 @@
 import json
-import subprocess
-import time
 from collections import Counter
 from datetime import datetime
 from functools import partial
@@ -331,6 +329,7 @@ async def test_run_partial_updates_of_concepts_for_document_passages(
 async def test_run_partial_updates_of_concepts_for_document_passages_for_large_document(
     local_vespa_search_adapter: VespaSearchAdapter,
     vespa_app,
+    vespa_large_app,
     mock_bucket,
     mock_s3_client,
 ) -> None:
@@ -345,39 +344,6 @@ async def test_run_partial_updates_of_concepts_for_document_passages_for_large_d
     key = "labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json"
     mock_s3_client.put_object(
         Bucket=mock_bucket, Key=key, Body=body, ContentType="application/json"
-    )
-
-    # Setup Vespa
-    start = time.perf_counter()
-    subprocess.run(
-        [
-            "vespa",
-            "feed",
-            "tests/local_vespa/test_documents/family_document_UNFCCC.party.309.0.json",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=600,  # Seconds
-    )
-    print(
-        f"finished feeding family document (seconds): {time.perf_counter() - start:.2f}"
-    )
-
-    start = time.perf_counter()
-    subprocess.run(
-        [
-            "vespa",
-            "feed",
-            "tests/local_vespa/test_documents/document_passage_UNFCCC.party.309.0.json",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=600,  # Seconds
-    )
-    print(
-        f"finished feeding document passages (seconds): {time.perf_counter() - start:.2f}"
     )
 
     # Make sure the expected document passages are in Vespa

--- a/tests/local_vespa/local_vespa.just
+++ b/tests/local_vespa/local_vespa.just
@@ -28,9 +28,15 @@ vespa_deploy_schema:
 # Feeds some test data into local Vespa instance
 vespa_feed_data:
 	vespa config set target local
-	vespa feed tests/local_vespa/test_documents/search_weights.json
-	vespa feed tests/local_vespa/test_documents/family_document.json
-	vespa feed tests/local_vespa/test_documents/document_passage.json
+	vespa feed --target local tests/local_vespa/test_documents/search_weights.json
+	vespa feed --target local tests/local_vespa/test_documents/family_document.json
+	vespa feed --target local tests/local_vespa/test_documents/document_passage.json
+
+# Feeds some large test data into local Vespa instance
+vespa_feed_large_data:
+	vespa config set target local
+	vespa feed --target local tests/local_vespa/test_documents/family_document_UNFCCC.party.309.0.json
+	vespa feed --target local tests/local_vespa/test_documents/document_passage_UNFCCC.party.309.0.json
 
 # Deletes some test data into local Vespa instance
 #

--- a/tests/local_vespa/test_documents/family_document_UNFCCC.party.309.0.json
+++ b/tests/local_vespa/test_documents/family_document_UNFCCC.party.309.0.json
@@ -1,0 +1,51 @@
+[
+      {
+        "id": "id:doc_search:family_document::UNFCCC.party.309.0",
+        "fields": {
+          "search_weights_ref": "id:doc_search:search_weights::default_weights",
+          "family_name": "Colombia National inventory report. NIR2",
+          "family_description": "<p>Colombia National inventory report submitted in 2019</p>",
+          "family_import_id": "UNFCCC.family.309.0",
+          "family_slug": "colombia-national-inventory-report-nir2_7da5",
+          "family_publication_ts": "2019-04-11T00:00:00+00:00",
+          "family_category": "UNFCCC",
+          "family_geography": "COL",
+          "family_geographies": [
+            "COL"
+          ],
+          "family_source": "UNFCCC",
+          "document_import_id": "UNFCCC.party.309.0",
+          "document_title": "Colombia National inventory report - Informe de Inventario Nacional de GEI de Colombia",
+          "document_slug": "colombia-national-inventory-report-informe-de-inventario-nacional-de-gei-de-colombia_3df3",
+          "document_languages": [
+            "Spanish"
+          ],
+          "document_md5_sum": "3e0c676eb6f59569063416112ba35cca",
+          "document_content_type": "application/pdf",
+          "document_cdn_object": "COL/1900/colombia-biennial-update-report-bur-bur-2-national-inventory-report_3e0c676eb6f59569063416112ba35cca.pdf",
+          "document_source_url": "https://unfccc.int/sites/default/files/resource/NIR_BUR2_Colombia.pdf",
+          "corpus_import_id": "UNFCCC.corpus.i00000001.n0000",
+          "corpus_type_name": "Intl. agreements",
+          "metadata": [
+            {
+              "name": "family.author",
+              "value": "Colombia"
+            },
+            {
+              "name": "family.author_type",
+              "value": "Party"
+            },
+            {
+              "name": "document.role",
+              "value": "MAIN"
+            },
+            {
+              "name": "document.type",
+              "value": "National Inventory Report"
+            }
+          ],
+          "family_name_index": "Colombia National inventory report. NIR2",
+          "family_description_index": "<p>Colombia National inventory report submitted in 2019</p>"
+        }
+      }
+    ]


### PR DESCRIPTION
Huge documents simply are a thing, and thus we should have better testing around them. This also can help with benchmarking. This test whilst not calling the function directly that uses continuation tokens, calls it as part of a higher function.

`tests/local_vespa/test_documents/document_passage_UNFCCC.party.309.0.json` has 50,024 document passages in it. We wanted at least > 50,000. This data was pulled from Vespa (staging).

Doing the document passages feed took 18s once. The test took 48s once. I think this is fine to have run by default on CI.

FIXES PLA-590
