### PR TITLE
Feature/handle query returning all passages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   pull_request:
-    # TEMP
-    # branches:
-    #   - main
+    branches:
+      - main
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
+    # TEMP
+    # branches:
+    #   - main
   push:
     branches:
       - main

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1271,9 +1271,9 @@ async def run_partial_updates_of_concepts_for_document_passages(
         text_blocks_n = len(text_blocks)
         if grouped_concepts_n != text_blocks_n:
             logger.warning(
-                f"There were {grouped_concepts_n} labelled passages and only "
-                f"{text_blocks_n} document passages were read from Vespa for "
-                f"{document_import_id}"
+                f"There were {grouped_concepts_n} text block ids from the labelled "
+                f"passages and only {text_blocks_n} document passages were read from "
+                f"Vespa for {document_import_id}"
             )
 
     # Batch updates (writes)

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1272,7 +1272,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
         if grouped_concepts_n != text_blocks_n:
             logger.warning(
                 f"There were {grouped_concepts_n} text block ids from the labelled "
-                f"passages and only {text_blocks_n} document passages were read from "
+                f"passages but {text_blocks_n} document passages were read from "
                 f"Vespa for {document_import_id}"
             )
 

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1270,9 +1270,10 @@ async def run_partial_updates_of_concepts_for_document_passages(
         grouped_concepts_n = len(grouped_concepts)
         text_blocks_n = len(text_blocks)
         if grouped_concepts_n != text_blocks_n:
-            raise ValueError(
-                f"there were {grouped_concepts_n} labelled passages and only "
-                f"{text_blocks_n} document passages were read from Vespa"
+            logger.warning(
+                f"There were {grouped_concepts_n} labelled passages and only "
+                f"{text_blocks_n} document passages were read from Vespa for "
+                f"{document_import_id}"
             )
 
     # Batch updates (writes)
@@ -1290,7 +1291,15 @@ async def run_partial_updates_of_concepts_for_document_passages(
         id: VespaDataId
         fields: dict[str, Any]
 
-    def _to_data(text_block_id: TextBlockId, concepts: list[VespaConcept]) -> DataPoint:
+    def _to_data(
+        text_block_id: TextBlockId, concepts: list[VespaConcept]
+    ) -> DataPoint | None:
+        if text_block_id not in text_blocks:
+            logger.error(
+                f"document passage `{text_block_id}` not found in Vespa for document `{document_import_id}`"
+            )
+            return None
+
         document_passage_id = text_blocks[text_block_id][0]
         document_passage = text_blocks[text_block_id][1]
 
@@ -1304,9 +1313,11 @@ async def run_partial_updates_of_concepts_for_document_passages(
         return {"id": data_id, "fields": {"concepts": serialised_concepts}}
 
     logger.info("Beginning creation of DataPoints.")
-    data: Iterable[dict[str, Any]] = list(
-        map(lambda x: dict(_to_data(*x)), grouped_concepts.items())
-    )
+    data: Iterable[dict[str, Any]] = []
+    for text_block_id, concepts in grouped_concepts.items():
+        data_point = _to_data(text_block_id, concepts)
+        if data_point:
+            data.append(dict(data_point))
     logger.info("Finished creation of DataPoints.")
 
     response_cb_lock: threading.Lock = threading.Lock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.1.8"
+version = "0.2.0"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"


### PR DESCRIPTION
This Pull Request: 
---
- Currently the indexing pipeline on main looks to only yield passages from vespa that exist in the labelled passages data from s3 by explicitly passing in text block ids into the query before using the `equiv` operator. 
- Now with continuation tokens we look to yield all passages for a document import id from vespa and thus this conditional check no longer applies.
- We do however still log a warning as we would really hope they match (as we create labelled passages from parser outputs in the pipeline cache). 
- We then update the `_to_data` function to handle the scenario where we have a text block from the labelled passages but not in the vespa passage query results. 
