### PR TITLE
Fix logging issues in indexing

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -111,6 +111,16 @@ class S3Accessor(BaseModel):
     paths: list[str] | None = None
     prefixes: list[str] | None = None
 
+    def __str__(self) -> str:
+        """String representation of the S3Accessor for logging"""
+        prefix_count = len(self.prefixes) if self.prefixes else 0
+        path_count = len(self.paths) if self.paths else 0
+        return f"(prefixes={prefix_count}, paths={path_count})"
+
+    def __repr__(self) -> str:
+        """String representation of the S3Accessor for logging"""
+        return self.__str__()
+
 
 # AKA LabelledPassage
 # Example: 18593

--- a/flows/index.py
+++ b/flows/index.py
@@ -114,7 +114,7 @@ async def index_labelled_passages_from_s3_to_vespa(
         config.document_source_prefix,
     )
 
-    print(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
+    print(f"Running on: {s3_accessor}")
 
     await updates_by_s3(
         aws_env=config.aws_env,

--- a/flows/index.py
+++ b/flows/index.py
@@ -72,6 +72,7 @@ class Config:
     on_failure=[SlackNotify.message],
     on_crashed=[SlackNotify.message],
     timeout_seconds=None,
+    log_prints=True,
 )
 async def index_labelled_passages_from_s3_to_vespa(
     classifier_specs: list[ClassifierSpec] | None = None,
@@ -88,25 +89,23 @@ async def index_labelled_passages_from_s3_to_vespa(
     file in the specified S3 path is expected to represent the
     document's import ID.
     """
-    logger = get_run_logger()
-
     if not config:
-        logger.info("no config provided, creating one")
+        print("no config provided, creating one")
 
         config = await Config.create()
     else:
-        logger.info("config provided")
+        print("config provided")
     assert config.cache_bucket
 
-    logger.info(f"running with config: {config}")
+    print(f"running with config: {config}")
 
     if classifier_specs is None:
-        logger.info("no classifier specs. passed in, loading from file")
+        print("no classifier specs. passed in, loading from file")
         classifier_specs = parse_spec_file(config.aws_env)
 
     disallow_latest_alias(classifier_specs)
 
-    logger.info(f"running with classifier specs: {classifier_specs}")
+    print(f"running with classifier specs: {classifier_specs}")
 
     s3_accessor = s3_paths_or_s3_prefixes(
         classifier_specs,
@@ -115,7 +114,7 @@ async def index_labelled_passages_from_s3_to_vespa(
         config.document_source_prefix,
     )
 
-    logger.info(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
+    print(f"s3_prefixes: {s3_accessor.prefixes}, s3_paths: {s3_accessor.paths}")
 
     await updates_by_s3(
         aws_env=config.aws_env,


### PR DESCRIPTION
See individual commits about the ways this resolves logging issues. One of which led to an actual failure:

- Fix logging around the `s3_accessor`
    
    I was curious why "s3_prefixes" didnt appear in the logs, and after
    taking a closer look at what that log line was doing realised theres a
    very good chance its failing to log out a gigantic log object. This
    would also make sense of why the open telemetry failure occured here as
    well as the underlying state update error due to request size
    
    I also moved the logic for what to log out of the main function for
    neatness reasons

- Log print statements
    
    Prefect was missing log statements that where found in ecs. This is due
    to the function `s3_paths_or_s3_prefixes` having print statements rather
    then use logging. Elsewhere we have adopted print statements for prefect
    flows because they are cleaner and seem to behave better with concurrency
    so I have switched the main flow here to do the same. This will then
    allow the s3 functions print statements to be logged