### PR TITLE
refactor: Explicitly control updating document passages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.2.2"
+version = "0.3.0"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
+++ b/tests/flows/fixtures/labelled_passages/Q218/v4/UNFCCC.party.309.0_translated_en.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7019dc052ff5704d61c88a13e0af7c3cd887babef53c8af0b15633a14adfe676
-size 80361513
+oid sha256:64c9d4b14f7f7575b208d70016df932057c68245daa730903d1a1a266c63a721
+size 7832105

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -23,6 +23,7 @@ from flows.boundary import (
     DocumentObjectUri,
     Operation,
     TextBlockId,
+    _update_text_block,
     convert_labelled_passage_to_concepts,
     get_continuation_tokens_from_query_response,
     get_data_id_from_vespa_hit_id,
@@ -34,10 +35,12 @@ from flows.boundary import (
     get_vespa_passages_from_query_response,
     get_vespa_search_adapter_from_aws_secrets,
     load_labelled_passages_by_uri,
+    remove_concepts_from_existing_vespa_concepts,
     s3_obj_generator,
     s3_obj_generator_from_s3_paths,
     s3_obj_generator_from_s3_prefixes,
     s3_paths_or_s3_prefixes,
+    update_concepts_on_existing_vespa_concepts,
     updates_by_s3,
 )
 from flows.index import Config
@@ -1171,3 +1174,79 @@ async def test_lower_max_hits_query_profile(
     assert error_info["summary"] == "Illegal query"
     assert f"{hits_beyond_limit} hits requested" in error_info["message"]
     assert "configured limit" in error_info["message"]
+
+
+@pytest.mark.vespa
+@pytest.mark.asyncio
+async def test__update_text_block__update(
+    vespa_app,
+    local_vespa_search_adapter: VespaSearchAdapter,
+    example_vespa_concepts,
+) -> None:
+    text_block_id = "1457"
+    document_import_id = "CCLW.executive.10014.4470"
+
+    document_passage_id, document_passage = get_document_passage_from_vespa(
+        text_block_id=text_block_id,
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        (
+            vespa_response,
+            text_block_id_response,
+            document_import_id_response,
+        ) = await _update_text_block(
+            text_block_id=text_block_id,
+            document_passage_id=document_passage_id,
+            document_passage=document_passage,
+            merge_serialise_concepts_cb=update_concepts_on_existing_vespa_concepts,
+            concepts=example_vespa_concepts,
+            vespa_connection_pool=vespa_connection_pool,
+        )
+
+        assert text_block_id == text_block_id_response
+        assert (
+            "id:doc_search:document_passage::CCLW.executive.10014.4470.1457"
+            == document_import_id_response
+        )
+        assert vespa_response.is_successful()
+
+
+@pytest.mark.vespa
+@pytest.mark.asyncio
+async def test__update_text_block__remove(
+    vespa_app,
+    local_vespa_search_adapter: VespaSearchAdapter,
+    example_vespa_concepts,
+) -> None:
+    text_block_id = "1457"
+    document_import_id = "CCLW.executive.10014.4470"
+
+    document_passage_id, document_passage = get_document_passage_from_vespa(
+        text_block_id=text_block_id,
+        document_import_id=document_import_id,
+        vespa_search_adapter=local_vespa_search_adapter,
+    )
+
+    async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
+        (
+            vespa_response,
+            text_block_id_response,
+            document_import_id_response,
+        ) = await _update_text_block(
+            text_block_id=text_block_id,
+            document_passage_id=document_passage_id,
+            document_passage=document_passage,
+            merge_serialise_concepts_cb=remove_concepts_from_existing_vespa_concepts,
+            concepts=example_vespa_concepts,
+            vespa_connection_pool=vespa_connection_pool,
+        )
+
+        assert text_block_id == text_block_id_response
+        assert (
+            "id:doc_search:document_passage::CCLW.executive.10014.4470.1457"
+            == document_import_id_response
+        )
+        assert vespa_response.is_successful()

--- a/tests/flows/test_deindex.py
+++ b/tests/flows/test_deindex.py
@@ -25,13 +25,12 @@ from flows.boundary import (
     DocumentObjectUri,
     Operation,
     TextBlockId,
-    VespaDataId,
     VespaHitId,
     get_data_id_from_vespa_hit_id,
     get_document_passage_from_vespa,
     op_to_fn,
     remove_concepts_from_existing_vespa_concepts,
-    remove_feed_result_callback,
+    remove_result_callback,
     run_partial_updates_of_concepts_for_document_passages,
     s3_paths_or_s3_prefixes,
     serialise_concepts_counts,
@@ -1411,8 +1410,7 @@ async def test_cleanups_by_s3(
     mock_s3_client.head_object(Bucket=mock_bucket, Key=key)
 
 
-def test_remove_feed_result_callback():
-    failures: list[VespaResponse] = []
+def test_remove_result_callback():
     concepts_counts: Counter[ConceptModel] = Counter()
     grouped_concepts: dict[TextBlockId, list[VespaConcept]] = {
         "18593": [
@@ -1437,15 +1435,14 @@ def test_remove_feed_result_callback():
         url="test-url",
         operation_type="update",
     )
-    data_id: VespaDataId = "UNFCCC.party.1062.0.18593"
+    text_block_id: TextBlockId = "18593"
 
     assert (
-        remove_feed_result_callback(
-            failures=failures,
+        remove_result_callback(
             concepts_counts=concepts_counts,
             grouped_concepts=grouped_concepts,
             response=response,
-            data_id=data_id,
+            text_block_id=text_block_id,
         )
         is None
     )
@@ -1453,11 +1450,9 @@ def test_remove_feed_result_callback():
     assert concepts_counts == Counter(
         {ConceptModel(wikibase_id=WikibaseID("Q100"), model_name="sectors_model"): 0}
     )
-    assert failures == []
 
 
-def test_remove_feed_result_callback_not_successful_response():
-    failures: list[VespaResponse] = []
+def test_remove_result_callback_not_successful_response():
     concepts_counts: Counter[ConceptModel] = Counter()
     grouped_concepts: dict[TextBlockId, list[VespaConcept]] = {
         "18593": [
@@ -1482,15 +1477,14 @@ def test_remove_feed_result_callback_not_successful_response():
         url="test-url",
         operation_type="update",
     )
-    data_id: VespaDataId = "UNFCCC.party.1062.0.18593"
+    text_block_id: TextBlockId = "18593"
 
     assert (
-        remove_feed_result_callback(
-            failures=failures,
+        remove_result_callback(
             concepts_counts=concepts_counts,
             grouped_concepts=grouped_concepts,
             response=response,
-            data_id=data_id,
+            text_block_id=text_block_id,
         )
         is None
     )
@@ -1498,4 +1492,3 @@ def test_remove_feed_result_callback_not_successful_response():
     assert concepts_counts == Counter(
         {ConceptModel(wikibase_id=WikibaseID("Q100"), model_name="sectors_model"): 1}
     )
-    assert failures == [response]

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -18,12 +18,11 @@ from flows.boundary import (
     ConceptModel,
     Operation,
     TextBlockId,
-    VespaDataId,
     get_document_passages_from_vespa,
     op_to_fn,
     run_partial_updates_of_concepts_for_document_passages,
     update_concepts_on_existing_vespa_concepts,
-    update_feed_result_callback,
+    update_result_callback,
     update_s3_with_update_concepts_counts,
 )
 from flows.index import (
@@ -609,8 +608,7 @@ def test_update_concepts_on_existing_vespa_concepts(
         assert concept.model_dump(mode="json") in updated_passage_concepts
 
 
-def test_update_feed_result_callback():
-    failures: list[VespaResponse] = []
+def test_update_result_callback():
     concepts_counts: Counter[ConceptModel] = Counter()
     grouped_concepts: dict[TextBlockId, list[VespaConcept]] = {
         "18593": [
@@ -635,15 +633,14 @@ def test_update_feed_result_callback():
         url="test-url",
         operation_type="update",
     )
-    data_id: VespaDataId = "UNFCCC.party.1062.0.18593"
+    text_block_id: TextBlockId = "18593"
 
     assert (
-        update_feed_result_callback(
-            failures=failures,
+        update_result_callback(
             concepts_counts=concepts_counts,
             grouped_concepts=grouped_concepts,
             response=response,
-            data_id=data_id,
+            text_block_id=text_block_id,
         )
         is None
     )
@@ -651,11 +648,9 @@ def test_update_feed_result_callback():
     assert concepts_counts == Counter(
         {ConceptModel(wikibase_id=WikibaseID("Q100"), model_name="sectors_model"): 1}
     )
-    assert failures == []
 
 
-def test_update_feed_result_callback_not_successful_response():
-    failures: list[VespaResponse] = []
+def test_update_result_callback_not_successful_response():
     concepts_counts: Counter[ConceptModel] = Counter()
     grouped_concepts: dict[TextBlockId, list[VespaConcept]] = {}
     response: VespaResponse = VespaResponse(
@@ -664,21 +659,19 @@ def test_update_feed_result_callback_not_successful_response():
         url="test-url",
         operation_type="update",
     )
-    data_id: VespaDataId = "UNFCCC.party.1062.0.18593"
+    text_block_id: TextBlockId = "18593"
 
     assert (
-        update_feed_result_callback(
-            failures=failures,
+        update_result_callback(
             concepts_counts=concepts_counts,
             grouped_concepts=grouped_concepts,
             response=response,
-            data_id=data_id,
+            text_block_id=text_block_id,
         )
         is None
     )
 
     assert concepts_counts == Counter()
-    assert failures == [response]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This takes us back to a time before we [tried to use](https://github.com/climatepolicyradar/knowledge-graph/pull/368) `pyvespa` for working through all our updates operations.

It was way too far to do a simple revert, so I've written this based on what was before that PR, and where we've gotten to.

Effectively, no tests were needed to be updated. This is a good thing! It indicates that the functionality/effects weren't changed.

FIXES PLA-603