### PR TITLE
Make check specific for actual issues

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -1296,8 +1296,11 @@ async def run_partial_updates_of_concepts_for_document_passages(
             f"Memory size (Mb): {text_blocks_size_in_mb}. "
         )
 
-        if grouped_concepts_n != text_blocks_n:
-            logger.warning(
+        # It's normal for there to be less text blocks from inference than vespa
+        # because inference filters out more types. However it should never be
+        # The other way around
+        if grouped_concepts_n > text_blocks_n:
+            raise ValueError(
                 f"There were {grouped_concepts_n} text block ids from the labelled "
                 f"passages but {text_blocks_n} document passages were read from "
                 f"Vespa for {document_import_id}"


### PR DESCRIPTION
We found examples of our query returning too few passages. After some investigation it turned out to be normal for inference to have less, but the other way around is a genuine problem that we want to surface right away