### PR TITLE
ci: Check if the `workflow_run` completion was a success

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,10 @@ jobs:
         run: poetry run mkdocs gh-deploy --force
 
   deploy_prefect_sandbox:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: |
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: sandbox


### PR DESCRIPTION
Deploying should either be automatic (via the CI work flow completing) or via a manual trigger. For the former, we had the trigger, but we weren't checking if the completed workflow was a success completion, as opposed to something else like a failure completion.
