### PR TITLE
include recursive `has_subconcept` relationships in training, not `subconcept_of`

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -245,7 +245,7 @@ def main(
     # Fetch all of its subconcepts recursively
     concept = wikibase.get_concept(
         wikibase_id,
-        include_recursive_subconcept_of=True,
+        include_recursive_has_subconcept=True,
         include_labels_from_subconcepts=True,
     )
 


### PR DESCRIPTION
When fetching the concepts from the concept store for training, we included a line which fetched the IDs for recursively connected concepts to those which we're interested in. Including those IDs is intended to allow us to fetch instances of all parent concepts when filtering for a particular concept.

```py
    concept = wikibase.get_concept(
        wikibase_id,
        include_recursive_subconcept_of=True,
        include_labels_from_subconcepts=True,
    )
```

However, we seem to have included the relationships which run in the wrong direction - we should be including the IDs for all recursive _children_ of the target concept, but we were including all of its recursive _parents_.

```py
    concept = wikibase.get_concept(
        wikibase_id,
        include_recursive_has_subconcept=True,
        include_labels_from_subconcepts=True,
    )
```

In combination with the way that we index concepts, this seems to have had a widespread effect of tagging all instances of a concept with all of their siblings 🤦 

With any luck, switching the direction of the recursively fetched relationships should result in many fewer erroneous tags.

I'll retrain and promote new versions of all models alongside this small code change.