### PR TITLE
refactor: Allow flexible async coroutines

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -75,7 +75,7 @@ T = TypeVar("T")
 CONCEPT_COUNT_SEPARATOR: Final[str] = ":"
 CONCEPTS_COUNTS_PREFIX_DEFAULT: Final[str] = "concepts_counts"
 DEFAULT_DOCUMENTS_BATCH_SIZE: Final[PositiveInt] = 50
-DEFAULT_TEXT_BLOCKS_BATCH_SIZE: Final[PositiveInt] = 50
+DEFAULT_TEXT_BLOCKS_BATCH_SIZE: Final[PositiveInt] = 20
 DEFAULT_UPDATES_TASK_BATCH_SIZE: Final[PositiveInt] = 5
 
 # Get more logs
@@ -1383,7 +1383,7 @@ async def run_partial_updates_of_concepts_for_document_passages(
             printer=print,
             name="partial updates",
         ):
-            semaphore = asyncio.Semaphore(DEFAULT_DOCUMENTS_BATCH_SIZE)
+            semaphore = asyncio.Semaphore(DEFAULT_TEXT_BLOCKS_BATCH_SIZE)
 
             tasks = []
             for text_block_id, concepts in grouped_concepts.items():

--- a/flows/index.py
+++ b/flows/index.py
@@ -9,6 +9,7 @@ from prefect.logging import get_run_logger
 from flows.boundary import (
     CONCEPTS_COUNTS_PREFIX_DEFAULT,
     DEFAULT_DOCUMENTS_BATCH_SIZE,
+    DEFAULT_TEXT_BLOCKS_BATCH_SIZE,
     DEFAULT_UPDATES_TASK_BATCH_SIZE,
     Operation,
     s3_paths_or_s3_prefixes,
@@ -80,6 +81,7 @@ async def index_labelled_passages_from_s3_to_vespa(
     config: Config | None = None,
     batch_size: int = DEFAULT_DOCUMENTS_BATCH_SIZE,
     indexing_task_batch_size: int = DEFAULT_UPDATES_TASK_BATCH_SIZE,
+    text_update_task_batch_size: int = DEFAULT_TEXT_BLOCKS_BATCH_SIZE,
 ) -> None:
     """
     Asynchronously index concepts from S3 into Vespa.
@@ -123,6 +125,7 @@ async def index_labelled_passages_from_s3_to_vespa(
         s3_paths=s3_accessor.paths,
         batch_size=batch_size,
         updates_task_batch_size=indexing_task_batch_size,
+        text_update_task_batch_size=text_update_task_batch_size,
         as_deployment=config.as_deployment,
         cache_bucket=config.cache_bucket,
         concepts_counts_prefix=config.concepts_counts_prefix,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.4.0"
+version = "0.4.1"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import json
 import os
@@ -17,9 +18,11 @@ from vespa.package import Document, Schema
 
 from flows.boundary import (
     CONCEPTS_COUNTS_PREFIX_DEFAULT,
+    DEFAULT_DOCUMENTS_BATCH_SIZE,
     VESPA_MAX_EQUIV_ELEMENTS_IN_QUERY,
     VESPA_MAX_LIMIT,
     DocumentImporter,
+    DocumentImportId,
     DocumentObjectUri,
     Operation,
     TextBlockId,
@@ -1183,8 +1186,8 @@ async def test__update_text_block__update(
     local_vespa_search_adapter: VespaSearchAdapter,
     example_vespa_concepts,
 ) -> None:
-    text_block_id = "1457"
-    document_import_id = "CCLW.executive.10014.4470"
+    text_block_id = TextBlockId("1457")
+    document_import_id = DocumentImportId("CCLW.executive.10014.4470")
 
     document_passage_id, document_passage = get_document_passage_from_vespa(
         text_block_id=text_block_id,
@@ -1192,12 +1195,15 @@ async def test__update_text_block__update(
         vespa_search_adapter=local_vespa_search_adapter,
     )
 
+    semaphore = asyncio.Semaphore(DEFAULT_DOCUMENTS_BATCH_SIZE)
+
     async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
         (
             vespa_response,
             text_block_id_response,
             document_import_id_response,
         ) = await _update_text_block(
+            semaphore=semaphore,
             text_block_id=text_block_id,
             document_passage_id=document_passage_id,
             document_passage=document_passage,
@@ -1221,8 +1227,8 @@ async def test__update_text_block__remove(
     local_vespa_search_adapter: VespaSearchAdapter,
     example_vespa_concepts,
 ) -> None:
-    text_block_id = "1457"
-    document_import_id = "CCLW.executive.10014.4470"
+    text_block_id = TextBlockId("1457")
+    document_import_id = DocumentImportId("CCLW.executive.10014.4470")
 
     document_passage_id, document_passage = get_document_passage_from_vespa(
         text_block_id=text_block_id,
@@ -1230,12 +1236,15 @@ async def test__update_text_block__remove(
         vespa_search_adapter=local_vespa_search_adapter,
     )
 
+    semaphore = asyncio.Semaphore(DEFAULT_DOCUMENTS_BATCH_SIZE)
+
     async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
         (
             vespa_response,
             text_block_id_response,
             document_import_id_response,
         ) = await _update_text_block(
+            semaphore=semaphore,
             text_block_id=text_block_id,
             document_passage_id=document_passage_id,
             document_passage=document_passage,


### PR DESCRIPTION
A batch of tasks means that the batch has to wait until all tasks finish, before starting the next batch. That means the coroutines are _inflexible_.

Instead, use a queue AKA lock AKA semaphore, so that the concurrency is managed by there being _space_ in the semaphore. E.g. a semaphore of 8 means that there's 8 concurrent tasks. A task blocks until it acquires a lock, from the semaphore.

TOWARDS PLA-615