### PR TITLE
Filtering out sabin documents from inference.

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -234,7 +234,7 @@ def remove_sabin_file_stems(file_stems: list[DocumentStem]) -> list[DocumentStem
     File stems of the Sabin source follow the below naming convention:
     - "Sabin.document.16944.17490"
     """
-    return [stem for stem in file_stems if not stem.startswith(("Sabin", "sabin"))]
+    return [stem for stem in file_stems if not stem.startswith(("Sabin", "sabin", "SABIN"))]
 
 
 def download_classifier_from_wandb_to_local(

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -234,7 +234,7 @@ def remove_sabin_file_stems(file_stems: list[DocumentStem]) -> list[DocumentStem
     File stems of the Sabin source follow the below naming convention:
     - "Sabin.document.16944.17490"
     """
-    return [stem for stem in file_stems if stem.split(".")[0].lower() != "sabin"]
+    return [stem for stem in file_stems if not stem.startswith(("Sabin", "sabin"))]
 
 
 def download_classifier_from_wandb_to_local(

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -234,7 +234,9 @@ def remove_sabin_file_stems(file_stems: list[DocumentStem]) -> list[DocumentStem
     File stems of the Sabin source follow the below naming convention:
     - "Sabin.document.16944.17490"
     """
-    return [stem for stem in file_stems if not stem.startswith(("Sabin", "sabin", "SABIN"))]
+    return [
+        stem for stem in file_stems if not stem.startswith(("Sabin", "sabin", "SABIN"))
+    ]
 
 
 def download_classifier_from_wandb_to_local(

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 import boto3
 import prefect.artifacts as artifacts
+import wandb
 from cpr_sdk.parser_models import BaseParserOutput, BlockType
 from cpr_sdk.ssm import get_aws_ssm_param
 from prefect import flow
@@ -21,8 +22,8 @@ from prefect.deployments import run_deployment
 from prefect.logging import get_run_logger
 from prefect.task_runners import ConcurrentTaskRunner
 from pydantic import SecretStr
+from wandb.sdk.wandb_run import Run
 
-import wandb
 from flows.utils import (
     SlackNotify,
     filter_non_english_language_file_stems,
@@ -40,7 +41,6 @@ from scripts.update_classifier_spec import parse_spec_file
 from src.classifier import Classifier
 from src.labelled_passage import LabelledPassage
 from src.span import Span
-from wandb.sdk.wandb_run import Run
 
 # The "parent" AKA the higher level flows that do multiple things
 PARENT_TIMEOUT_S: int = int(timedelta(hours=12).total_seconds())

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -10,6 +10,7 @@ from prefect.testing.utilities import prefect_test_harness
 
 from flows.inference import (
     ClassifierSpec,
+    DocumentStem,
     _stringify,
     classifier_inference,
     determine_file_stems,
@@ -20,6 +21,7 @@ from flows.inference import (
     list_bucket_file_stems,
     load_classifier,
     load_document,
+    remove_sabin_file_stems,
     run_classifier_inference_on_document,
     store_labels,
     text_block_inference,
@@ -374,3 +376,35 @@ async def test_run_classifier_inference_on_document_missing(
 def test_iterate_batch(data, expected_lengths):
     for batch, expected in zip(list(iterate_batch(data)), expected_lengths):
         assert len(batch) == expected
+
+
+@pytest.mark.parametrize(
+    "input_stems,expected_output",
+    [
+        ([], []),
+        (
+            ["CCLW.executive.12345.6789", "UNFCCC.document.1234.5678"],
+            ["CCLW.executive.12345.6789", "UNFCCC.document.1234.5678"],
+        ),
+        (["Sabin.document.16944.17490", "Sabin.document.16945.17491"], []),
+        (
+            [
+                "CCLW.executive.12345.6789",
+                "Sabin.document.16944.17490",
+                "UNFCCC.document.1234.5678",
+                "Sabin.document.16945.17491",
+            ],
+            ["CCLW.executive.12345.6789", "UNFCCC.document.1234.5678"],
+        ),
+        (["sabin.document.16944.17490", "SABIN.document.16945.17491"], []),
+        (
+            ["SabinIndustries.document.1234.5678", "DocumentSabin.12345.6789"],
+            ["SabinIndustries.document.1234.5678", "DocumentSabin.12345.6789"],
+        ),
+    ],
+)
+def test_remove_sabin_file_stems(
+    input_stems: list[DocumentStem], expected_output: list[DocumentStem]
+):
+    result = remove_sabin_file_stems(input_stems)
+    assert result == expected_output

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -399,7 +399,7 @@ def test_iterate_batch(data, expected_lengths):
         (["sabin.document.16944.17490", "SABIN.document.16945.17491"], []),
         (
             ["SabinIndustries.document.1234.5678", "DocumentSabin.12345.6789"],
-            ["SabinIndustries.document.1234.5678", "DocumentSabin.12345.6789"],
+            ["DocumentSabin.12345.6789"],
         ),
     ],
 )


### PR DESCRIPTION
This Pull Request: 
---
- Filters out sabin documents from inference only (if they aren't in inference outputs they won't be presented to indexing). 
- Using the file stem to filter out the documents and ensuring we aren't case sensitive so we're resilient to minor upstream naming changes. 
- The alternative option I could see to using the file stem was to use the `source` field in the `document_metadata` of the parser outputs. However this would require reading the file from s3 and the document metadata field is just typed as a dict so this method was not deemed ideal. See example below: 

![image](https://github.com/user-attachments/assets/866ea424-5261-4858-b214-3ed632ae18a7)
 

