### PR TITLE
resolve warning raised by the targets classifier

### DIFF
--- a/src/classifier/targets.py
+++ b/src/classifier/targets.py
@@ -89,7 +89,7 @@ class BaseTargetClassifier(Classifier, ABC):
         """Predict whether the supplied texts contain targets."""
 
         predictions: list[list[dict]] = self.pipeline(
-            texts, padding=True, truncation=True, return_all_scores=True
+            texts, padding=True, truncation=True, top_k=None
         )
 
         results = []


### PR DESCRIPTION
I've been seeing these warnings when running the targets classifier recently:

```
UserWarning: `return_all_scores` is now deprecated,  if want a similar functionality use `top_k=None` instead of `return_all_scores=True` or `top_k=1` instead of `return_all_scores=False`.
```

This PR switches the deprecated `return_all_scores=True` for `top_k=None`, which resolves the warning