### PR TITLE
ci: Remove deprecated `reviewers` field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,22 @@ updates:
       prefix: feat
       include: scope
     groups:
-       all:
-         applies-to: version-updates
-         patterns:
-           - "*"
+      all:
+        applies-to: version-updates
+        patterns:
+          - "*"
     directory: /
     schedule:
       interval: monthly
-    reviewers:
-      - climatepolicyradar/deng
   - package-ecosystem: github-actions
     commit-message:
       prefix: feat
       include: scope
     groups:
-       all:
-         applies-to: version-updates
-         patterns:
-           - "*"
+      all:
+        applies-to: version-updates
+        patterns:
+          - "*"
     directory: /
     schedule:
       interval: monthly
-    reviewers:
-      - climatepolicyradar/deng
-


### PR DESCRIPTION
GitHub is blasting warnings about this, so remove it. It also means that Data Science is able to merge these in.

I've formatted the file too.
