### PR TITLE
Support both incremental and historical runs

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -285,7 +285,7 @@ async def create_aggregate_inference_summary_artifact(
     task_runner=ConcurrentTaskRunner(),
 )
 async def aggregate_inference_results(
-    document_ids: list[DocumentImportId],
+    document_ids: None | list[DocumentImportId] = None,
     config: Config | None = None,
     max_concurrent_tasks: int = 5,
 ) -> RunOutputIdentifier:

--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -223,6 +223,9 @@ async def process_single_document(
         all_labelled_passages = get_all_labelled_passages_for_one_document(
             document_id, classifier_specs, config
         )
+        print(
+            f"Combining {len(all_labelled_passages)} labelled passages for {document_id}"
+        )
         vespa_concepts = combine_labelled_passages(all_labelled_passages)
 
         # Write to s3
@@ -237,6 +240,7 @@ async def process_single_document(
         s3_object_write_text(str(s3_uri), json.dumps(vespa_concepts))
         return document_id
     except ClientError as e:
+        print(e.response)
         raise AggregationFailure(
             document_id=document_id, exception=e, context=e.response
         )

--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -3,7 +3,6 @@ import json
 import os
 from collections import defaultdict
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import Any, TypeAlias
 
 import boto3
@@ -23,6 +22,7 @@ from flows.boundary import (
 )
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
 from flows.utils import (
+    S3Uri,
     SlackNotify,
     collect_unique_file_stems_under_prefix,
     wait_for_semaphore,
@@ -46,29 +46,6 @@ SpecStr: TypeAlias = str
 
 # A serialised vespa concept, see cpr_sdk.models.search.Concept
 SerialisedVespaConcept: TypeAlias = list[dict[str, str]]
-
-
-class S3Uri:
-    """A URI for an S3 object."""
-
-    def __init__(self, bucket: str, key: str, protocol: str = "s3"):
-        self.protocol = protocol
-        self.bucket = bucket
-        self.key = key
-
-    def __str__(self) -> str:
-        """Return the string representation of the S3 URI."""
-        return f"{self.protocol}://{self.bucket}/{self.key}"
-
-    @property
-    def uri(self) -> str:
-        """Return the string representation of the S3 URI."""
-        return os.path.join(self.bucket, self.key)
-
-    @property
-    def stem(self) -> str:
-        """Return the stem of the S3 URI (the key without the extension)."""
-        return Path(self.key).stem
 
 
 class AggregationFailure(Exception):

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -56,6 +56,7 @@ from flows.utils import (
     DocumentObjectUri,
     DocumentStem,
     Profiler,
+    S3Uri,
     SlackNotify,
     get_labelled_passage_paths,
     iterate_batch,
@@ -221,7 +222,7 @@ def s3_object_write_text(s3_uri: str, text: str) -> None:
     s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
 
 
-def s3_copy_file(source, target) -> None:
+def s3_copy_file(source: S3Uri, target: S3Uri) -> None:
     """Copy a file from one S3 location to another."""
     s3 = boto3.client("s3")
     s3.copy_object(

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -221,6 +221,16 @@ def s3_object_write_text(s3_uri: str, text: str) -> None:
     s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
 
 
+def s3_copy_file(source, target) -> None:
+    """Copy a file from one S3 location to another."""
+    s3 = boto3.client("s3")
+    s3.copy_object(
+        Bucket=source.bucket,
+        CopySource=source.uri,
+        Key=target.key,
+    )
+
+
 def s3_obj_generator_from_s3_prefixes(
     s3_prefixes: Sequence[str],
 ) -> Generator[

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -93,6 +93,29 @@ class SlackNotify:
         return None
 
 
+class S3Uri:
+    """A URI for an S3 object."""
+
+    def __init__(self, bucket: str, key: str, protocol: str = "s3"):
+        self.protocol = protocol
+        self.bucket = bucket
+        self.key = key
+
+    def __str__(self) -> str:
+        """Return the string representation of the S3 URI."""
+        return f"{self.protocol}://{self.bucket}/{self.key}"
+
+    @property
+    def uri(self) -> str:
+        """Return the string representation of the S3 URI."""
+        return os.path.join(self.bucket, self.key)
+
+    @property
+    def stem(self) -> str:
+        """Return the stem of the S3 URI (the key without the extension)."""
+        return Path(self.key).stem
+
+
 def remove_translated_suffix(file_name: DocumentStem) -> DocumentImportId:
     """
     Remove the suffix from a file name that indicates it has been translated.

--- a/tests/flows/test_aggregate_inference_results.py
+++ b/tests/flows/test_aggregate_inference_results.py
@@ -200,6 +200,7 @@ def test_validate_passages_are_same_except_concepts():
 async def test_process_single_document__success(
     mock_bucket_labelled_passages_large, test_aggregate_config
 ):
+    _, bucket, s3_client = mock_bucket_labelled_passages_large
     document_id = "CCLW.executive.10061.4515"
     classifier_specs = [
         ClassifierSpec(name="Q218", alias="v5"),
@@ -218,6 +219,26 @@ async def test_process_single_document__success(
                 test_aggregate_config,
                 "run_output_identifier",
             )
+
+        # Check that the file is in the run_output_identifier prefix with head object
+        response = s3_client.head_object(
+            Bucket=bucket,
+            Key=os.path.join(
+                test_aggregate_config.aggregate_inference_results_prefix,
+                "run_output_identifier",
+                f"{document_id}.json",
+            ),
+        )
+        # Check that the file is in the latest prefix with head object
+        response = s3_client.head_object(
+            Bucket=bucket,
+            Key=os.path.join(
+                test_aggregate_config.aggregate_inference_results_prefix,
+                "latest",
+                f"{document_id}.json",
+            ),
+        )
+        assert response["ContentLength"] > 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This adds a prefix alongside the run identifiers that holds all of the latest  aggregated results.

The idea here is to have all the latest ran aggregations compiled in a single place. Previously, all the documents to be drawn on for indexing would need to be within a single run identifier. Most of the time this is really useful and lets us only run on what has just been completed. But there are also times when we need to rerun on everything, or when we want to review what the current state should be. In this case it helps to also maintain all of the last aggregated documents. Another key benefit is for analytics, we can review all aggregations in one go, now in s3, later also in the data lake.

We previously had some bad experiences with using `latest` with models, but I do think this is different enough from that situation that its worth having.

---
Bonuses:
- Adds a little bit more logging
- Moves s3_uri to utils