### PR TITLE
Automatically update the vibe checker every night

### DIFF
--- a/flows/deploy_static_sites.py
+++ b/flows/deploy_static_sites.py
@@ -64,6 +64,7 @@ def deploy_static_sites():
     names = {
         "concept_librarian": "cpr-knowledge-graph-concept-librarian",
         "labelling_librarian": "cpr-knowledge-graph-labelling-librarian",
+        "vibe_check": "cpr-knowledge-graph-vibe-check",
     }
     for app_name, bucket_name in names.items():
         generate_static_site(app_name)

--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -476,7 +476,7 @@ class WikibaseSession:
                         preferred_label=preferred_label,
                         alternative_labels=alternative_labels,
                         description=description,
-                        wikibase_id=wikibase_id,
+                        wikibase_id=WikibaseID(wikibase_id),
                     )
 
                     if "claims" in entity and entity["claims"] != []:

--- a/static_sites/vibe_check/__main__.py
+++ b/static_sites/vibe_check/__main__.py
@@ -1,16 +1,23 @@
+import io
 import shutil
 from pathlib import Path
 
+import boto3
+import pandas as pd
 import typer
+import yaml
+from dotenv import load_dotenv
 from jinja2 import Environment, FileSystemLoader
 from rich.console import Console
 
-from scripts.config import classifier_dir, processed_data_dir
-from src.classifier import Classifier
+from scripts.config import processed_data_dir, root_dir
+from src.classifier import Classifier, ClassifierFactory
+from src.concept import Concept
 from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 from src.wikibase import WikibaseSession
 
+load_dotenv()
 app = typer.Typer()
 
 console = Console(stderr=True)
@@ -21,49 +28,20 @@ templates = Environment(loader=FileSystemLoader(base_dir / "templates"))
 
 # Set up the input and output directories
 predictions_dir = processed_data_dir / "predictions"
+predictions_dir.mkdir(parents=True, exist_ok=True)
 dist_dir = base_dir / "dist"
 if dist_dir.exists():
     shutil.rmtree(dist_dir)
 dist_dir.mkdir(parents=True)
 
-
-def load_predictions(
-    wikibase_id: WikibaseID, classifier_id: str
-) -> list[LabelledPassage]:
-    """Read a JSONL file and return a list of predictions."""
-    file_path = predictions_dir / wikibase_id / f"{classifier_id}.jsonl"
-    if not file_path.exists():
-        console.log(
-            f"Warning: No predictions file found for {wikibase_id}/{classifier_id}",
-            style="yellow",
-        )
-        return []
-
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            predictions = [LabelledPassage.model_validate_json(line) for line in f]
-        return predictions
-    except Exception as e:
-        console.log(
-            f"Error loading predictions for {wikibase_id}/{classifier_id}: {str(e)}",
-            style="yellow",
-        )
-        return []
-
-
-def get_available_classifiers(wikibase_id: WikibaseID) -> dict[str, str]:
-    """Get list of available classifiers for a concept."""
-    concept_classifier_dir = classifier_dir / wikibase_id
-    if not concept_classifier_dir.exists():
-        return {}
-
-    classifiers = {}
-    for path in concept_classifier_dir.glob("*.pickle"):
-        classifier_id = path.stem
-        classifier_name = str(Classifier.load(path))
-        classifiers[classifier_id] = classifier_name
-
-    return classifiers
+# Load sample passages from S3
+s3 = boto3.client("s3", region_name="eu-west-1")
+with console.status("🚚 Loading the sample dataset"):
+    bytes_from_s3 = s3.get_object(
+        Bucket="cpr-knowledge-graph-vibe-check", Key="passages_dataset.feather"
+    )["Body"].read()
+    sample_passages = pd.read_feather(io.BytesIO(bytes_from_s3))
+console.log(f"📚 Loaded {len(sample_passages)} passages from the sample dataset")
 
 
 def get_available_regions(predictions: list[LabelledPassage]) -> list[str]:
@@ -113,98 +91,104 @@ def main():
 
     # Get all concepts with classifiers
     wikibase = WikibaseSession()
-    concepts = []
 
-    # Only look for concepts that have predictions
-    for concept_dir in predictions_dir.iterdir():
-        if not concept_dir.is_dir():
-            continue
+    with open(root_dir / "flows" / "classifier_specs" / "prod.yaml", "r") as f:
+        classifier_specs = yaml.safe_load(f)
 
-        wikibase_id = WikibaseID(concept_dir.name)
-        try:
-            concept = wikibase.get_concept(wikibase_id)
-            classifiers = get_available_classifiers(wikibase_id)
-            concepts.append(
-                {
-                    "id": wikibase_id,
-                    "label": concept.preferred_label,
-                    "str": str(concept),
-                    "description": concept.description,
-                    "url": concept.wikibase_url,
-                    "classifiers": classifiers,
-                    "n_classifiers": len(classifiers),
-                }
-            )
-            console.log(
-                f'Found concept "{concept}" with {len(classifiers)} classifiers'
-            )
+    concept_ids = list(
+        set([classifier_spec.split(":")[0] for classifier_spec in classifier_specs])
+    )
+    concepts: dict[WikibaseID, Concept] = dict(
+        zip(concept_ids, wikibase.get_concepts(wikibase_ids=concept_ids))
+    )
 
-        except Exception as e:
-            console.log(
-                f"Skipping concept {wikibase_id} due to error: {str(e)}",
-                style="yellow",
-            )
-            continue
+    # ignore targets concepts
+    concepts = {
+        WikibaseID(concept_id): concept
+        for concept_id, concept in concepts.items()
+        if concept_id
+        not in [
+            "Q1651",
+            "Q1652",
+            "Q1653",
+        ]
+    }
+    classifiers: dict[WikibaseID, Classifier] = {}
+    for concept_id, concept in concepts.items():
+        classifier = ClassifierFactory.create(concept)
+        classifiers[concept_id] = classifier
+        console.log(f"🤖 Created a {classifier} for {concept_id}")
 
     # Generate index page
     index_template = templates.get_template("index.html")
-    index_html = index_template.render(concepts=concepts, total_count=len(concepts))
+    index_html = index_template.render(
+        concepts=list(concepts.values()), total_count=len(concepts)
+    )
     (dist_dir / "index.html").write_text(index_html)
-    console.log(f"Generated index page with {len(concepts)} concepts")
+    console.log(f"📄 Generated index page with {len(concepts)} concepts")
 
     # Generate concept pages
-    for concept_data in concepts:
-        wikibase_id = concept_data["id"]
+    for i, (concept_id, classifier) in enumerate(classifiers.items()):
+        console.log(f"🤔 Processing concept {i + 1}/{len(classifiers)}: {classifier}")
+        concept = concepts[concept_id]
         concept_template = templates.get_template("concept.html")
         concept_html = concept_template.render(
-            wikibase_id=wikibase_id,
-            concept_str=concept_data["str"],
-            wikibase_url=concept_data["url"],
-            classifiers=concept_data["classifiers"],
+            wikibase_id=concept.wikibase_id,
+            concept_str=str(concept),
+            wikibase_url=concept.wikibase_url,
+            classifiers={classifier.id: classifier.name},
         )
 
-        concept_dir = dist_dir / str(wikibase_id)
+        concept_dir = dist_dir / str(concept.wikibase_id)
         concept_dir.mkdir(exist_ok=True)
         (concept_dir / "index.html").write_text(concept_html)
-        console.log(f"Generated concept page for {wikibase_id}")
+        console.log(f'📄 Generated concept page for "{concept}"')
 
-        # Generate predictions pages for each classifier
-        for classifier_id in concept_data["classifiers"]:
-            try:
-                predictions = load_predictions(wikibase_id, classifier_id)
-                predictions_template = templates.get_template("predictions.html")
-                predictions_html = predictions_template.render(
-                    predictions=predictions,
-                    wikibase_id=wikibase_id,
-                    wikibase_url=concept_data["url"],
-                    classifier_id=classifier_id,
-                    classifier_name=concept_data["classifiers"][classifier_id],
-                    concept_str=concept_data["str"],
-                    regions=get_available_regions(predictions),
-                    translated_statuses=get_available_translated_statuses(predictions),
-                    corpora=get_available_corpora(predictions),
-                    classifiers=concept_data["classifiers"],
+        # Generate predictions using the classifier
+        predictions: list[LabelledPassage] = []
+        for _, row in sample_passages.iterrows():
+            text = row["text_block.text"] or ""
+            predicted_spans = classifier.predict(text)
+            if predicted_spans:
+                predictions.append(
+                    LabelledPassage(
+                        text=text,
+                        spans=predicted_spans,
+                        metadata=row.to_dict(),
+                    )
                 )
+        console.log(
+            f'🔍 Found {len(predictions)} instances of "{concept}" in the sample dataset'
+        )
 
-                # Write the HTML version
-                (concept_dir / f"{classifier_id}.html").write_text(predictions_html)
+        # Generate the predictions page HTML
+        predictions_template = templates.get_template("predictions.html")
+        predictions_html = predictions_template.render(
+            predictions=predictions,
+            wikibase_id=concept.wikibase_id,
+            wikibase_url=concept.wikibase_url,
+            classifier_id=classifier.id,
+            classifier_name=classifier.name,
+            concept_str=str(concept),
+            regions=get_available_regions(predictions),
+            translated_statuses=get_available_translated_statuses(predictions),
+            corpora=get_available_corpora(predictions),
+            classifiers={classifier.id: classifier.name},
+            total_count=len(predictions),
+        )
 
-                # Write the JSONL version
-                json_content = "\n".join([p.model_dump_json() for p in predictions])
-                (concept_dir / f"{classifier_id}.json").write_text(json_content)
+        # Write the HTML version
+        (concept_dir / f"{classifier.id}.html").write_text(predictions_html)
 
-                console.log(
-                    f"Generated predictions page for {wikibase_id}/{classifier_id} (HTML and JSONL)"
-                )
-            except Exception as e:
-                console.log(
-                    f"Failed to generate predictions for {wikibase_id}/{classifier_id}: {str(e)}",
-                    style="yellow",
-                )
+        # Write the JSONL version
+        json_content = "\n".join([p.model_dump_json() for p in predictions])
+        (concept_dir / f"{classifier.id}.json").write_text(json_content)
 
-    console.log(f"Successfully generated static site in {dist_dir}", style="green")
+        console.log(f'📄 Generated predictions page for "{concept}"')
+
+    console.log(f"✅ Successfully generated static site in {dist_dir}", style="green")
     console.log(
-        "You can now run the site locally using `just serve-static-site vibe_check`",
+        "🚀 You can now run the site locally using `just serve-static-site vibe_check`",
         style="green",
     )
 

--- a/static_sites/vibe_check/templates/index.html
+++ b/static_sites/vibe_check/templates/index.html
@@ -81,28 +81,19 @@
                   Description
                 </p>
               </th>
-              <th
-                class="p-4 border-b border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-gray-700 w-32"
-              >
-                <p
-                  class="block text-sm font-normal leading-none text-slate-500 dark:text-slate-400"
-                >
-                  Classifier{{ 's' if total_count != 1 }}
-                </p>
-              </th>
             </tr>
           </thead>
           <tbody class="text-sm">
-            {% for concept in concepts|sort(attribute='id') %}
+            {% for concept in concepts|sort(attribute='wikibase_id') %}
             <tr
               class="hover:bg-slate-50 dark:hover:bg-gray-700 cursor-pointer"
-              onclick="window.location='{{ concept.id }}/index.html'"
+              onclick="window.location='{{ concept.wikibase_id }}/index.html'"
             >
               <td
                 class="p-4 border-b border-slate-200 dark:border-slate-600 py-5"
               >
                 <p class="text-slate-800 dark:text-slate-200 break-words">
-                  {{ concept.str }}
+                  {{ concept.preferred_label }}
                 </p>
               </td>
               <td
@@ -110,14 +101,6 @@
               >
                 <p class="text-slate-500 dark:text-slate-400 break-words">
                   {{ concept.description }}
-                </p>
-              </td>
-              <td
-                class="p-4 border-b border-slate-200 dark:border-slate-600 py-5"
-              >
-                <p class="text-slate-500 dark:text-slate-400">
-                  {{ concept.n_classifiers }} classifier{{ 's' if
-                  concept.n_classifiers != 1 }}
                 </p>
               </td>
             </tr>


### PR DESCRIPTION
at the request of the policy team! This PR:

- makes some small tweaks to the vibe checker build itself 
  - list of concepts to include comes from the `prod.yaml`
  - only shows a single classifier per concept, from the `ClassifierFactory` (NB might update this to use a few more variants in the future, if useful)
  - now running `.predict()` with each classifier in the script itself, on a sample of 250k passages
- adds add the vibe checker to the list of auto nightly rebuilt/deployed static sites

the whole process (including all predictions and the sync to s3) only takes a couple of mins to run on my laptop, so this shouldn't be too difficult for prefect to handle 🤞