### PR TITLE
fix: apply valid memory to correct deployment

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -122,6 +122,10 @@ create_deployment(
 create_deployment(
     flow=aggregate_inference_results,
     description="Aggregate inference results",
+    flow_variables={
+        "cpu": MEGABYTES_PER_GIGABYTE * 16,
+        "memory": MEGABYTES_PER_GIGABYTE * 64,
+    },
 )
 
 # Boundary
@@ -146,7 +150,6 @@ create_deployment(
 create_deployment(
     flow=run_indexing_from_aggregate_results,
     description="Index aggregated inference results from S3 into Vespa",
-    flow_variables={"memory": MEGABYTES_PER_GIGABYTE * 64},
 )
 
 # De-index


### PR DESCRIPTION
Think I was rushing a bit and had confused the names of the deployment, I also managed to specify an invalid config as the cpus are supposed to scale with the memory. Based on the aws documentation this should work: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

Ironically the aggregator did work when I ran it after this change, I suppose there must be some transcience dependant on which documents are run in parrelel