### PR TITLE
Adding initial handling of passages with no fields.

### DIFF
--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -634,13 +634,24 @@ def get_vespa_passages_from_query_response(
         dig(passage_root, "children", 0, "children", 0)
         for passage_root in passages_root
     ]
-    vespa_passages: dict[TextBlockId, tuple[VespaHitId, VespaPassage]] = {
-        passage["fields"]["text_block_id"]: (
+
+    vespa_passages: dict[TextBlockId, tuple[VespaHitId, VespaPassage]] = {}
+    for passage in passage_hits:
+        fields = passage.get("fields")
+        if not fields:
+            print(f"Skipping passage with no 'fields': {passage}")
+            continue
+
+        text_block_id = fields.get("text_block_id")
+        if not text_block_id:
+            print(f"Skipping passage with no 'text_block_id': {fields}")
+            continue
+
+        text_block_id = TextBlockId(passage["fields"]["text_block_id"])
+        vespa_passages[text_block_id] = (
             passage["id"],
             VespaPassage.model_validate(passage["fields"]),
         )
-        for passage in passage_hits
-    }
 
     return vespa_passages
 

--- a/tests/flows/fixtures/query_responses/grouped_text_block_by_family_document_ref.json
+++ b/tests/flows/fixtures/query_responses/grouped_text_block_by_family_document_ref.json
@@ -117,6 +117,26 @@
                                         ]
                                     }
                                 ]
+                            },
+                            {
+                                "id": "group:string:986",
+                                "relevance": 0.0017429193899782135,
+                                "value": "986",
+                                "children": [
+                                    {
+                                        "id": "hitlist:hits",
+                                        "relevance": 1.0,
+                                        "label": "hits",
+                                        "children": [
+                                            {
+                                                "id": "id:doc_search:document_passage::CCLW.executive.10014.4470.985",
+                                                "relevance": 0.0017429193899782135,
+                                                "source": "family-document-passage",
+                                                "fields_malformed": {}
+                                            }
+                                        ]
+                                    }
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for a `KeyError` seen during a staging run of the passage indexing section of the data pipeline. 
- We add a hit with no fields key to and present a fix. 
- Printing out the passage with no fields key for debugging. When running in prefect this should be visible from the logs. 

> Encountered exception during execution: KeyError('fields')
> ...
>   File "/opt/prefect/knowledge-graph/flows/boundary.py", line 636, in get_vespa_passages_from_query_response
>     vespa_passages: dict[TextBlockId, tuple[VespaHitId, VespaPassage]] = {
>   File "/opt/prefect/knowledge-graph/flows/boundary.py", line 637, in <dictcomp>
>     passage["fields"]["text_block_id"]: (
> KeyError: 'fields'