### PR TITLE
fix: Representing indexing all as appropriate Prefect state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"


### PR DESCRIPTION
# Solution 2

From the discussion in Slack (see: issue), we're reducing the number of Prefect calls via removing flow/task approaches.

This is to reduce the number of Prefect API calls so we're less likely to be rate-limited. The downside being that we lose observability.

# Solution 1

Based on Prefect[^1], this is always being shown as a success state. This is misleading to us when evaluating the run. It should appropriately be a failed state too.

This begs the question of, are straying too far from the light of Prefect, and shouldn't be passing data in a failed flow run state?

FIXES PLA-640

[^1]: https://docs.prefect.io/v3/develop/manage-states#manage-states
