### PR TITLE
fix: add missing await from gathering passages

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -115,7 +115,7 @@ def build_run_output_identifier() -> RunOutputIdentifier:
     return f"{start_time}-{run_name}"
 
 
-def get_all_labelled_passages_for_one_document(
+async def get_all_labelled_passages_for_one_document(
     document_id: DocumentImportId,
     classifier_specs: list[ClassifierSpec],
     config: Config,
@@ -203,7 +203,7 @@ async def process_single_document(
 ) -> DocumentImportId | AggregationFailure:
     """Process a single document and return its status."""
     try:
-        all_labelled_passages = get_all_labelled_passages_for_one_document(
+        all_labelled_passages = await get_all_labelled_passages_for_one_document(
             document_id, classifier_specs, config
         )
         print(

--- a/tests/flows/test_aggregate_inference_results.py
+++ b/tests/flows/test_aggregate_inference_results.py
@@ -156,7 +156,8 @@ def test_build_run_output_prefix():
     assert "None" not in prefix
 
 
-def test_get_all_labelled_passages_for_one_document(
+@pytest.mark.asyncio
+async def test_get_all_labelled_passages_for_one_document(
     mock_bucket_labelled_passages_large, test_aggregate_config
 ):
     document_id = "CCLW.executive.10061.4515"
@@ -165,7 +166,7 @@ def test_get_all_labelled_passages_for_one_document(
         ClassifierSpec(name="Q767", alias="v3"),
         ClassifierSpec(name="Q1286", alias="v3"),
     ]
-    labelled_passages = get_all_labelled_passages_for_one_document(
+    labelled_passages = await get_all_labelled_passages_for_one_document(
         document_id, classifier_specs, test_aggregate_config
     )
     assert len(labelled_passages) == len(classifier_specs)


### PR DESCRIPTION
We didn't have any async functions in the task meaning without this we were basically running these tasks sequentially 🙀 An obvious next step would be to also apply this to the object write out, and I'd like to follow up on that after seeing this in action, but have held off right now as its shared by other functions, its also a much smaller part of the length of these tasks.

Playing around with this locally and having some tasks async and others not really showed up in the length of cold starts, so theres also an opportunity to review if we have any code running elsewhere that could be made async