### PR TITLE
refactor: run all io bound tasks async for aggregator

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -220,10 +220,12 @@ async def process_single_document(
                 f"{document_id}.json",
             ),
         )
-        s3_object_write_text(str(s3_uri), json.dumps(vespa_concepts))
+        await asyncio.to_thread(
+            s3_object_write_text, str(s3_uri), json.dumps(vespa_concepts)
+        )
 
         # Duplicate to latest
-        s3_copy_file(
+        await s3_copy_file(
             source=s3_uri,
             target=S3Uri(
                 bucket=config.cache_bucket,

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -222,7 +222,7 @@ def s3_object_write_text(s3_uri: str, text: str) -> None:
     s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
 
 
-def s3_copy_file(source: S3Uri, target: S3Uri) -> None:
+async def s3_copy_file(source: S3Uri, target: S3Uri) -> None:
     """Copy a file from one S3 location to another."""
     s3 = boto3.client("s3")
     s3.copy_object(


### PR DESCRIPTION
Note that s3_object_write_text is used in several other flows some of which are async, so I havent made a change to it and am using asyncio to run it async instead