### PR TITLE
fix: Don't load ~80 docs into memory at a once

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -1,9 +1,8 @@
 import asyncio
 import json
 import os
-from collections import defaultdict
 from dataclasses import asdict, dataclass
-from typing import Any, Sequence, TypeAlias
+from typing import Any, AsyncGenerator, Sequence, TypeAlias
 
 import aioboto3
 from botocore.exceptions import ClientError
@@ -122,9 +121,8 @@ async def get_all_labelled_passages_for_one_document(
     document_id: DocumentImportId,
     classifier_specs: list[ClassifierSpec],
     config: Config,
-) -> dict[SpecStr, list[LabelledPassage]]:
+) -> AsyncGenerator[tuple[ClassifierSpec, list[LabelledPassage]], None]:
     """Get the labelled passages from s3."""
-    labelled_passages = defaultdict(list)
 
     for spec in classifier_specs:
         s3_uri = S3Uri(
@@ -138,13 +136,11 @@ async def get_all_labelled_passages_for_one_document(
         )
         response = await s3.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
         body = await response["Body"].read()
-        spec_doc = [
+        labelled_passages = [
             LabelledPassage.model_validate_json(passage)
             for passage in json.loads(body.decode("utf-8"))
         ]
-        labelled_passages[str(spec)].extend(spec_doc)
-
-    return labelled_passages
+        yield spec, labelled_passages
 
 
 def check_all_values_are_the_same(values: list[Any]) -> bool:
@@ -167,35 +163,6 @@ def validate_passages_are_same_except_concepts(passages: list[LabelledPassage]) 
             )
 
 
-def combine_labelled_passages(
-    labelled_passages: dict[SpecStr, list[LabelledPassage]],
-) -> dict[TextBlockId, SerialisedVespaConcept]:
-    """Combine the labelled passages across the different classifier specs."""
-    labelled_passages_lists = list(labelled_passages.values())
-    if not check_all_values_are_the_same([len(lpl) for lpl in labelled_passages_lists]):
-        raise ValueError(
-            f"The length of the labelled passages are not the same across classifier "
-            f"outputs: {labelled_passages.keys()}"
-        )
-
-    combined_passages = {}
-    for passages in zip(*labelled_passages_lists):
-        validate_passages_are_same_except_concepts(passages)
-        passage_id = passages[0].id
-
-        all_vespa_concepts = []
-        for passage in passages:
-            vespa_concepts = convert_labelled_passage_to_concepts(passage)
-            serialised_vespa_concepts = [
-                vc.model_dump(mode="json") for vc in vespa_concepts
-            ]
-            all_vespa_concepts.extend(serialised_vespa_concepts)
-
-        combined_passages[passage_id] = all_vespa_concepts
-
-    return combined_passages
-
-
 @task()
 async def process_single_document(
     document_id: DocumentImportId,
@@ -207,13 +174,45 @@ async def process_single_document(
     try:
         session = aioboto3.Session(region_name="eu-west-1")
         async with session.client("s3") as s3:
-            all_labelled_passages = await get_all_labelled_passages_for_one_document(
+            print("Fetching labelled passages for", document_id)
+
+            concepts_for_vespa: dict[TextBlockId, SerialisedVespaConcept] = {}
+            async for (
+                spec,
+                labelled_passages,
+            ) in get_all_labelled_passages_for_one_document(
                 s3, document_id, classifier_specs, config
-            )
-            print(
-                f"Combining {len(all_labelled_passages)} labelled passages for {document_id}"
-            )
-            vespa_concepts = combine_labelled_passages(all_labelled_passages)
+            ):
+                # `concepts_for_vespa`` starts empty so Validation not needed initially
+                if not concepts_for_vespa:
+                    for passage in labelled_passages:
+                        concepts_for_vespa[TextBlockId(passage.id)] = [
+                            vc.model_dump(mode="json")
+                            for vc in convert_labelled_passage_to_concepts(passage)
+                        ]
+                    continue
+
+                if len(labelled_passages) != len(concepts_for_vespa.keys()):
+                    raise ValueError(
+                        f"The number of passages diverge when appending {spec}: "
+                        f"{len(labelled_passages)=} != {len(concepts_for_vespa)=}"
+                    )
+
+                for passage, text_block_id in zip(
+                    labelled_passages, concepts_for_vespa.keys()
+                ):
+                    if passage.id != text_block_id:
+                        raise ValueError(
+                            f"The text_block id diverges for {spec} when compared with what has been collected so far:"
+                            f"{passage.id=} != {text_block_id=}"
+                        )
+                    serialised_concepts = [
+                        vc.model_dump(mode="json")
+                        for vc in convert_labelled_passage_to_concepts(passage)
+                    ]
+                    concepts_for_vespa[TextBlockId(passage.id)].extend(
+                        serialised_concepts
+                    )
 
             # Write to s3
             s3_uri = S3Uri(
@@ -224,7 +223,7 @@ async def process_single_document(
                     f"{document_id}.json",
                 ),
             )
-            await s3_object_write_text_async(s3, s3_uri, json.dumps(vespa_concepts))
+            await s3_object_write_text_async(s3, s3_uri, json.dumps(concepts_for_vespa))
 
             # Duplicate to latest
             await s3_copy_file(
@@ -246,9 +245,7 @@ async def process_single_document(
             document_id=document_id, exception=e, context=e.response
         )
     except Exception as e:
-        raise AggregationFailure(
-            document_id=document_id, exception=e, context="Unknown error"
-        )
+        raise AggregationFailure(document_id=document_id, exception=e, context=repr(e))
 
 
 @task()

--- a/tests/flows/test_aggregate_inference_results.py
+++ b/tests/flows/test_aggregate_inference_results.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import json
 import os
 import tempfile
@@ -17,7 +16,6 @@ from flows.aggregate_inference_results import (
     aggregate_inference_results,
     build_run_output_identifier,
     collect_stems_by_specs,
-    combine_labelled_passages,
     get_all_labelled_passages_for_one_document,
     process_single_document,
     validate_passages_are_same_except_concepts,
@@ -161,10 +159,12 @@ async def test_get_all_labelled_passages_for_one_document(
         ClassifierSpec(name="Q767", alias="v3"),
         ClassifierSpec(name="Q1286", alias="v3"),
     ]
-    labelled_passages = await get_all_labelled_passages_for_one_document(
+    all_labelled_passages = []
+    async for spec, labelled_passages in get_all_labelled_passages_for_one_document(
         s3_async_client, document_id, classifier_specs, test_aggregate_config
-    )
-    assert len(labelled_passages) == len(classifier_specs)
+    ):
+        all_labelled_passages.append(labelled_passages)
+    assert len(all_labelled_passages) == len(classifier_specs)
 
 
 def test_validate_passages_are_same_except_concepts():
@@ -231,7 +231,7 @@ async def test_process_single_document__success(
 
 
 @pytest.mark.asyncio
-async def test_process_single_document__failure(
+async def test_process_single_document__client_error(
     mock_bucket_labelled_passages_large, mock_classifier_specs, test_aggregate_config
 ):
     document_id = "CCLW.executive.10061.4515"
@@ -248,6 +248,7 @@ async def test_process_single_document__failure(
         ),
         return_exceptions=True,
     )
+    assert len(result) == 1
     assert isinstance(result[0], AggregationFailure)
     code = result[0].exception.response["Error"]["Code"]
     assert code == "NoSuchKey"
@@ -255,99 +256,49 @@ async def test_process_single_document__failure(
     assert key == "labelled_passages/Q9999999999/v99/CCLW.executive.10061.4515.json"
 
 
-def test_combine_labelled_passages(concept):
-    base_span = Span(
-        text="The",
-        start_index=0,
-        end_index=3,
-        concept_id=None,
-        labellers=['KeywordClassifier("greenhouse gas")'],
-        timestamps=[datetime.datetime(2025, 2, 24, 18, 42, 12, 677997)],
+@pytest.mark.asyncio
+async def test_process_single_document__value_error(
+    mock_bucket_labelled_passages_large, mock_classifier_specs, test_aggregate_config
+):
+    keys, bucket, s3_async_client = mock_bucket_labelled_passages_large
+    _, classifier_specs = mock_classifier_specs
+
+    document_id = "CCLW.executive.10061.4515"
+
+    # Replace the doc with a broken  one
+    new_data = [
+        '{"id":"b1","text":"Some words","spans":[],"metadata":{}}',
+        '{"id":"b2","text":"But not enough words","spans":[],"metadata":{}}',
+    ]
+    key = [k for k in keys if "CCLW.executive.10061.4515" in k][0]
+    await s3_async_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(new_data),
     )
 
-    Q218_concept = concept.model_copy(update={"id": "Q218"})
-    Q218_span = base_span.model_copy(update={"concept_id": "Q218"})
-
-    Q767_concept = concept.model_copy(update={"id": "Q767"})
-    Q767_span = base_span.model_copy(update={"concept_id": "Q767"})
-
-    Q1286_concept = concept.model_copy(update={"id": "Q1286"})
-    Q1286_span = base_span.model_copy(update={"concept_id": "Q1286"})
-
-    labelled_passages = {
-        "Q218:v5": [
-            LabelledPassage(
-                id="b0",
-                text="The",
-                spans=[Q218_span, Q218_span],
-                metadata={"concept": Q218_concept},
-            ),
-            LabelledPassage(
-                id="b1", text="The", spans=[], metadata={"concept": Q218_concept}
-            ),
-            LabelledPassage(
-                id="b2", text="The", spans=[], metadata={"concept": Q218_concept}
-            ),
-        ],
-        "Q767:v3": [
-            LabelledPassage(
-                id="b0",
-                text="The",
-                spans=[Q767_span],
-                metadata={"concept": Q767_concept},
-            ),
-            LabelledPassage(
-                id="b1",
-                text="The",
-                spans=[Q767_span],
-                metadata={"concept": Q767_concept},
-            ),
-            LabelledPassage(
-                id="b2", text="The", spans=[], metadata={"concept": Q767_concept}
-            ),
-        ],
-        "Q1286:v3": [
-            LabelledPassage(
-                id="b0",
-                text="The",
-                spans=[Q1286_span],
-                metadata={"concept": Q1286_concept},
-            ),
-            LabelledPassage(
-                id="b1",
-                text="The",
-                spans=[Q1286_span],
-                metadata={"concept": Q1286_concept},
-            ),
-            LabelledPassage(
-                id="b2",
-                text="The",
-                spans=[Q1286_span, Q1286_span, Q1286_span],
-                metadata={"concept": Q1286_concept},
-            ),
-        ],
-    }
-
-    # Happy case
-    combined_labelled_passages = combine_labelled_passages(labelled_passages)
-    assert len(combined_labelled_passages) == 3
-    assert len(combined_labelled_passages["b0"]) == 4
-    assert len(combined_labelled_passages["b1"]) == 2
-    assert len(combined_labelled_passages["b2"]) == 3
-
-    # different length lists
-    labelled_passages["Q218:v5"].append(
-        LabelledPassage(
-            id="b3", text="The", spans=[Q218_span], metadata={"concept": Q218_concept}
-        )
+    result = await asyncio.gather(
+        process_single_document(
+            document_id,
+            classifier_specs,
+            test_aggregate_config,
+            "run_output_identifier",
+        ),
+        return_exceptions=True,
     )
-    with pytest.raises(ValueError):
-        combine_labelled_passages(labelled_passages)
-
-    # passage mismatch
-    labelled_passages["Q218:v5"][0].text = "Different text"
-    with pytest.raises(ValueError):
-        combine_labelled_passages(labelled_passages)
+    assert len(result) == 1
+    assert isinstance(result[0], AggregationFailure)
+    assert isinstance(result[0].exception, ValueError)
+    assert (
+        result[0]
+        .exception.args[0]
+        .startswith("The number of passages diverge when appending")
+    )
+    assert (
+        result[0]
+        .exception.args[0]
+        .endswith("len(labelled_passages)=2 != len(concepts_for_vespa)=27")
+    )
 
 
 def test_collect_stems_by_specs(


### PR DESCRIPTION
The control flow for this was loading into memory each labelled_passage file for all inference outputs. Meaning we had doc_size * num_classifiers worth of memory being utilised.

This refactors the way the combining happens to combine one document at a time to the full list. The goal being to only have the current document and the full document open at once, fixing the memory usage regardless of classifier count.