### PR TITLE
refactor: revise defaults aggregate params after runs

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -342,8 +342,8 @@ def collect_stems_by_specs(config: Config) -> list[DocumentImportId]:
 async def aggregate_inference_results(
     document_ids: None | list[DocumentImportId] = None,
     config: Config | None = None,
-    max_concurrent_tasks: int = 10,
-    batch_size: int = 10,
+    max_concurrent_tasks: int = 20,
+    batch_size: int = 5,
 ) -> RunOutputIdentifier:
     """Aggregate the inference results for the given document ids."""
     if not config:


### PR DESCRIPTION
The result of having ran in production a few times trying out various configurations. These lower batch size is nice ones to work with as it reports back faster now we're actually running async. And the concurrent tasks don't seem to make the overall run faster over this amount.