### PR TITLE
refactor: Add concurrency for indexing document passages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.5.1"
+version = "0.6.0"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"


### PR DESCRIPTION
As per our usual patterns. For the sake of small code changes and concurrent safety, I wrapped the I/O call as the one thing that waits on the semaphore.

FIXES PLA-639
