### PR TITLE
fix: Make task hashable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.6.0"
+version = "0.6.1"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/test_aggregate_inference_results.py
+++ b/tests/flows/test_aggregate_inference_results.py
@@ -21,6 +21,7 @@ from flows.aggregate_inference_results import (
     process_single_document,
     validate_passages_are_same_except_concepts,
 )
+from flows.utils import DocumentImportId
 from scripts.cloud import ClassifierSpec
 from scripts.update_classifier_spec import write_spec_file
 from src.labelled_passage import LabelledPassage
@@ -268,7 +269,7 @@ async def test_process_single_document__value_error(
     keys, bucket, s3_async_client = mock_bucket_labelled_passages_large
     _, classifier_specs = mock_classifier_specs
 
-    document_id = "CCLW.executive.10061.4515"
+    document_id = DocumentImportId("CCLW.executive.10061.4515")
 
     # Replace the doc with a broken  one
     new_data = [
@@ -284,7 +285,7 @@ async def test_process_single_document__value_error(
 
     session = aioboto3.Session(region_name=test_aggregate_config.bucket_region)
     result = await asyncio.gather(
-        process_single_document(
+        process_single_document.fn(
             session,
             document_id,
             classifier_specs,


### PR DESCRIPTION
I saw this a lot[^1][^2] and it created a lot of noise, and may also cause  actual problems. I don't think the latter would be true though, as we don't use cached results, explicitly at least.

The session was successfully passed to the task, and used within it. E.g. you can see the 404s for objects not existing. It doesn't show up in the args though in Prefect's webapp.

**Test**

- https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068500ad-4c45-7734-8000-d58eb360ffef?entity_id=068500b4-27b2-723d-8000-0b5cb49b3953 — Ran went okay without the cache function error.

TOWARDS PLA-658

[^1]:
```
Error encountered when computing cache key - result will not be persisted.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/prefect/cache_policies.py", line 374, in compute_key
    return hash_objects(hashed_inputs, raise_on_failure=True)
  File "/usr/local/lib/python3.10/site-packages/prefect/utilities/hashing.py", line 89, in hash_objects
    raise HashError(msg)
prefect.exceptions.HashError: Unable to create hash - objects could not be serialized.
  JSON error: Unable to serialize unknown type: <class 'aioboto3.session.Session'>
  Pickle error: cannot pickle '_asyncio.Task' object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/prefect/task_engine.py", line 169, in compute_transaction_key
    key = self.task.cache_policy.compute_key(
  File "/usr/local/lib/python3.10/site-packages/prefect/cache_policies.py", line 214, in compute_key
    policy_key = policy.compute_key(
  File "/usr/local/lib/python3.10/site-packages/prefect/cache_policies.py", line 384, in compute_key
    raise ValueError(msg) from exc
ValueError: Unable to create hash - objects could not be serialized.
  JSON error: Unable to serialize unknown type: <class 'aioboto3.session.Session'>
  Pickle error: cannot pickle '_asyncio.Task' object

This often occurs when task inputs contain objects that cannot be cached like locks, file handles, or other system resources.

To resolve this, you can:
  1. Exclude these arguments by defining a custom `cache_key_fn`
  2. Disable caching by passing `cache_policy=NO_CACHE`
```
[^2]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/0684fda2-449e-7cdb-8000-732e3b78df1a?entity_id=0684fdc6-8809-7f22-8000-928b99be820a
