### PR TITLE
Don't run inference on html documents with invalid text 

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -446,12 +446,17 @@ async def run_classifier_inference_on_document(
     document = load_document(config, file_stem)
     print(f"Loaded document with file stem {file_stem}")
 
-    # Handle documents with no text and no language
-    if (
+    # Don't run inference on documents that have no text or languages as well as html
+    # documents with no valid text.
+    no_text_and_no_languages: bool = (
         not document.languages
         and document.pdf_data is None
         and document.html_data is None
-    ):
+    )
+    html_and_invalid_text: bool = (
+        document.html_data is not None and not document.html_data.has_valid_text
+    )
+    if no_text_and_no_languages or html_and_invalid_text:
         store_labels(
             config=config,
             labels=[],

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -446,7 +446,7 @@ async def run_classifier_inference_on_document(
     document = load_document(config, file_stem)
     print(f"Loaded document with file stem {file_stem}")
 
-    # Don't run inference on documents that have no text or languages as well as html
+    # Don't run inference on documents that have no text or languages as well as HTML
     # documents with no valid text.
     no_text_and_no_languages: bool = (
         not document.languages

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -304,7 +304,7 @@ async def test_run_classifier_inference_on_document(
 
     assert "Cannot run inference on" in str(exc_info.value)
 
-    # Run the function on a html document with has_valid_text=False
+    # Run the function on a HTML document with has_valid_text=False
     document_stem = "HTML.document.0.1"
     with patch("flows.inference.load_document") as mock_load_document:
         html_document_invalid_text = BaseParserOutput(
@@ -345,10 +345,8 @@ async def test_run_classifier_inference_on_document(
 
         assert result is None
 
-        # Assert that we did not store any labels
+        # Load the stored labels from s3
         expected_key = f"labelled_passages/{classifier_name}/{classifier_alias}/{document_stem}.json"
-
-        # Verify the content of the stored labels
         s3 = boto3.client("s3", region_name=test_config.bucket_region)
         response = s3.get_object(Bucket=test_config.cache_bucket, Key=expected_key)
         data = json.loads(response["Body"].read().decode("utf-8"))


### PR DESCRIPTION
This Pull Request: 
---
- Is an update to the KG inference pipeline to no longer run inference on html documents with no valid text as these aren't indexed into vespa so passages won't exist.
- We also won't see the benefit of this until we rerun inference so we will still see some `ValueErrors` until then. 

_Note: Lot's of explanation on the linked linear ticket._ 