### PR TITLE
refactor: Add reporting for inference batches

### DIFF
--- a/flows/index_from_aggregate_results.py
+++ b/flows/index_from_aggregate_results.py
@@ -5,7 +5,7 @@ import tempfile
 from collections import Counter
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from typing import Any, Final, TypeVar
+from typing import Any, Final
 
 import boto3
 import httpx
@@ -47,6 +47,7 @@ from flows.utils import (
     collect_unique_file_stems_under_prefix,
     iterate_batch,
     remove_translated_suffix,
+    return_with_id,
     wait_for_semaphore,
 )
 from scripts.cloud import AwsEnv
@@ -57,9 +58,6 @@ DEFAULT_VESPA_MAX_CONNECTIONS_AGG_INDEXER: Final[PositiveInt] = 50
 DEFAULT_INDEXER_CONCURRENCY_LIMIT: Final[PositiveInt] = 10
 # How many document passages to index concurrently per document
 INDEXER_DOCUMENT_PASSAGES_CONCURRENCY_LIMIT: Final[PositiveInt] = 5
-
-T = TypeVar("T")
-U = TypeVar("U")
 
 
 def load_json_data_from_s3(bucket: str, key: str) -> dict[str, Any]:
@@ -496,17 +494,6 @@ async def index_aggregate_results_for_batch_of_documents(
         raise ValueError(
             f"Failed to process {len(errors_per_document)}/{len(document_stems)} documents"
         )
-
-
-async def return_with_id(
-    id: U,
-    fn: Awaitable[T | Exception],
-) -> tuple[U, T | Exception]:
-    try:
-        result = await fn
-        return (id, result)
-    except Exception as e:
-        return (id, e)
 
 
 @flow(

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -16,8 +16,10 @@ from prefect import flow
 from prefect.artifacts import create_table_artifact
 from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.concurrency.asyncio import concurrency
+from prefect.context import get_run_context
 from prefect.deployments import run_deployment
 from prefect.logging import get_run_logger
+from prefect.utilities.names import generate_slug
 from pydantic import PositiveInt, SecretStr
 from wandb.sdk.wandb_run import Run
 
@@ -29,6 +31,7 @@ from flows.utils import (
     filter_non_english_language_file_stems,
     get_file_stems_for_document_id,
     iterate_batch,
+    return_with_id,
     wait_for_semaphore,
 )
 from scripts.cloud import (
@@ -492,6 +495,66 @@ async def run_classifier_inference_on_document(
     return None
 
 
+async def create_inference_on_batch_summary_artifact(
+    successes: list[DocumentStem],
+    failures: list[tuple[DocumentStem, Exception]],
+    unknown_failures: list[BaseException],
+    flow_run_name: str | None,
+):
+    """Create an artifact with a summary about a batch inference run."""
+
+    total_documents = len(successes) + len(failures) + len(unknown_failures)
+    successful_documents = len(successes)
+    failed_documents = len(failures)
+    unknown_failures_count = len(unknown_failures)
+
+    overview_description = f"""# Batch Inference Summary
+
+## Overview
+- **Flow Run**: {flow_run_name or "Unknown"}
+- **Total documents processed**: {total_documents}
+- **Successful documents**: {successful_documents}
+- **Failed documents**: {failed_documents}
+- **Unknown failures**: {unknown_failures_count}
+"""
+
+    document_details = (
+        [
+            {
+                "Document stem": document_stem,
+                "Status": "✓",
+                "Exception": "N/A",
+            }
+            for document_stem in successes
+        ]
+        + [
+            {
+                "Document stem": document_stem,
+                "Status": "✗",
+                "Exception": str(exc),
+            }
+            for document_stem, exc in failures
+        ]
+        + [
+            {
+                "Document stem": "Unknown",
+                "Status": "✗",
+                "Exception": str(exc),
+            }
+            for exc in unknown_failures
+        ]
+    )
+
+    if not flow_run_name:
+        flow_run_name = f"unknown-{generate_slug(2)}"
+
+    await create_table_artifact(
+        key=f"batch-inference-{flow_run_name}",
+        table=document_details,
+        description=overview_description,
+    )
+
+
 @flow(log_prints=True)
 async def run_classifier_inference_on_batch_of_documents(
     batch: list[DocumentStem],
@@ -535,33 +598,60 @@ async def run_classifier_inference_on_batch_of_documents(
     )
 
     tasks = [
-        run_classifier_inference_on_document(
-            config=config,
-            file_stem=file_stem,
-            classifier_name=classifier_name,
-            classifier_alias=classifier_alias,
-            classifier=classifier,
+        return_with_id(
+            file_stem,
+            run_classifier_inference_on_document(
+                config=config,
+                file_stem=file_stem,
+                classifier_name=classifier_name,
+                classifier_alias=classifier_alias,
+                classifier=classifier,
+            ),
         )
         for file_stem in batch
     ]
 
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    results: list[
+        tuple[DocumentStem, Exception | None] | BaseException
+    ] = await asyncio.gather(*tasks, return_exceptions=True)
 
-    failures: list[Exception] = []
+    successes: list[DocumentStem] = []
+    failures: list[tuple[DocumentStem, Exception]] = []
+    # We really don't expect these, since there's a try/catch handler
+    # in `return_with_id`. It is technically possible though, for
+    # there to be what I'm calling here an _unknown_ failure.
+    unknown_failures: list[BaseException] = []
 
     for result in results:
-        if isinstance(result, Exception):
-            logger.exception(f"Failed to process document: {result}")
-            failures.append(result)
-        elif result is None:
-            continue
+        if isinstance(result, BaseException):
+            unknown_failures.append(result)
         else:
-            raise ValueError(
-                f"Unexpected type of result. Type: `{type(result)}`, value: `{result}`"
-            )
+            document_stem, value = result
+            if isinstance(value, Exception):
+                logger.exception(f"Failed to process document {document_stem}: {value}")
+                failures.append((document_stem, value))
+            else:
+                successes.append(document_stem)
+
+    # https://docs.prefect.io/v3/concepts/runtime-context#access-the-run-context-directly
+    run_context = get_run_context()
+    flow_run_name: str | None
+    if run_context:
+        flow_run_name = str(run_context.flow_run.name)
+    else:
+        flow_run_name = None
+
+    await create_inference_on_batch_summary_artifact(
+        successes,
+        failures,
+        unknown_failures,
+        flow_run_name,
+    )
 
     if len(failures) > 0:
-        raise ValueError(f"Failed to process {len(failures)}/{len(results)} documents")
+        raise ValueError(
+            f"Failed to process {len(failures) + len(unknown_failures)}/{len(results)} documents"
+        )
 
     return None
 
@@ -730,7 +820,7 @@ async def create_inference_summary_artifact(
     successes: dict[ClassifierSpec, FlowRun],
     failures_classifier_specs: set[ClassifierSpec],
 ) -> None:
-    """Create a table artifact with summary information about the inference run."""
+    """Create an artifact with a summary about the inference run."""
 
     # Prepare summary data for the artifact
     total_documents = len(filtered_file_stems)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.6.2"
+version = "0.6.3"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/__snapshots__/test_inference.ambr
+++ b/tests/flows/__snapshots__/test_inference.ambr
@@ -13,3 +13,12 @@
     }),
   )
 # ---
+# name: test_run_classifier_inference_on_batch_of_documents
+  '[{"Document stem": "PDF.document.0.1", "Status": "\\u2713", "Exception": "N/A"}]'
+# ---
+# name: test_run_classifier_inference_on_batch_of_documents_empty_batch
+  '[]'
+# ---
+# name: test_run_classifier_inference_on_batch_of_documents_with_failures
+  '[{"Document stem": "NonExistent.doc.1", "Status": "\\u2717", "Exception": "An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist."}, {"Document stem": "AnotherMissing.doc.2", "Status": "\\u2717", "Exception": "An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist."}]'
+# ---


### PR DESCRIPTION
It's hard to debug otherwise.

**Tests**

I did a Prefect [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/0685438f-9d78-7b7c-8000-d5a63dfe6dba?g_range=%7B%22type%22%3A%22span%22%2C%22seconds%22%3A-604800%7D&entity_id=7faa08bb-9e58-4be8-b7de-1837cdeb6fdf&state=cancelled&state=cancelling&state=completed&state=crashed&state=failed&state=paused&state=pending&state=running&state=scheduled&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts) and got a top-level artifact and also a batch-level artifact!

TOWARDS PLA-658
