### PR TITLE
refactor: Run inference aggregation as multi-host

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -18,7 +18,10 @@ from prefect.flows import Flow
 
 import flows.boundary as boundary
 import flows.deindex as deindex
-from flows.aggregate_inference_results import aggregate_inference_results
+from flows.aggregate_inference_results import (
+    aggregate_inference_results,
+    aggregate_inference_results_batch,
+)
 from flows.data_backup import data_backup
 from flows.deploy_static_sites import deploy_static_sites
 from flows.index_from_aggregate_results import (
@@ -114,12 +117,17 @@ create_deployment(
 # Aggregate inference results
 
 create_deployment(
-    flow=aggregate_inference_results,
-    description="Aggregate inference results",
+    flow=aggregate_inference_results_batch,
+    description="Aggregate inference results for a batch of documents",
     flow_variables={
         "cpu": MEGABYTES_PER_GIGABYTE * 16,
         "memory": MEGABYTES_PER_GIGABYTE * 64,
     },
+)
+
+create_deployment(
+    flow=aggregate_inference_results,
+    description="Aggregate inference results, through coordinating batches of documents",
 )
 
 # Boundary
@@ -138,12 +146,12 @@ create_deployment(
 
 create_deployment(
     flow=index_aggregate_results_for_batch_of_documents,
-    description="Run passage indexing for a batch of documents from s3 to Vespa",
+    description="Run passage indexing for a batch of documents from S3 to Vespa",
 )
 
 create_deployment(
     flow=run_indexing_from_aggregate_results,
-    description="Run passage indexing for documents from s3 to Vespa",
+    description="Run passage indexing for documents from S3 to Vespa",
 )
 
 # De-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.6.6"
+version = "0.6.7"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -70,7 +70,7 @@ def test_wikibase_to_s3_config():
 @pytest.fixture
 def test_aggregate_config():
     yield AggregateInferenceResultsConfig(
-        _cache_bucket="test_bucket",
+        cache_bucket="test_bucket",
         aws_env=AwsEnv.sandbox,
     )
 


### PR DESCRIPTION
Similar to other pipelines, run inference aggregation multi-host.

I've taken this opportunity to find the re-usable pattern here. It is in effect, a faux Prefect task runner. This gives a single function to call that behind-the-scenes, uses our `run_deployment` + semaphore + results handling (separate successes and failures) pattern.

**Test**

I did a [flow run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068654e3-7283-74d9-8000-103eb5bfd237?entity_id=068654ea-7470-75f4-8000-43d606a19ffc&state=failed&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts), the made sure that it would only 2 run some batches first, to the max of the semaphore counter, and of the parameterised batch size of documents, of 10.

![CleanShot 2025-07-02 at 16 24 42](https://github.com/user-attachments/assets/ad8736f1-4061-4b9b-a098-ac68ff8c423f)

![CleanShot 2025-07-02 at 16 29 28](https://github.com/user-attachments/assets/03fca609-91d2-4179-8419-346982a7ca19)

![CleanShot 2025-07-02 at 16 30 37](https://github.com/user-attachments/assets/b39309f1-3886-4724-ba51-8099b7cb16cc)

FIXES PLA-668
