### PR TITLE
fix: Use correct `Fault` metadata field and make them printable too

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -60,6 +60,10 @@ class AggregationFailure(Exception):
         self.exception = exception
         self.context = context
 
+    def __str__(self) -> str:
+        """Return a string representation"""
+        return f"{self.document_id} | exception: {str(self.exception)} | context: {self.context}"
+
 
 @dataclass()
 class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "knowledge_graph"
-version = "0.6.4"
+version = "0.6.5"
 description = ""
 authors = ["CPR Data Science <dsci@climatepolicyradar.org>"]
 license = "Apache 2.0"


### PR DESCRIPTION
This is a regression from my recent refactoring.

The lack of `__str__` meant that Prefect had `"message": "Task run encountered an exception Fault: ",`, which is unhelpful. I had seen this before for `AggregationFailure`s, so I've fixed that too.

**Test**

[Flow run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/0685abf6-4890-7132-8000-91e173780f61?g_range=%7B%22type%22%3A%22span%22%2C%22seconds%22%3A-604800%7D&entity_id=0685abfe-3dc4-7fe4-8000-6dc0ac480db8&state=failed&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts)
```
 "message": "Task run encountered an exception Fault: Unexpected exception during document indexing | metadata: {\"document_stem\": \"CPR.document.i00000327.n0000\", \"exception\": \"Failed to index document passages or family document | metadata: {\\\"document_stem\\\": \\\"CPR.document.i00000327.n0000\\\", \\\"errors\\\": [\\\"Error(msg='text block not found in Vespa', metadata={'text_block_id': '0'})\\\", \\\"Error(msg='text block not found in Vespa', metadata={'text_block_id': '1'})\\\", \\\"Erro ...
```
The artifact also had failures correctly reported.


TOWARDS PLA-658
