### PR TITLE
Add a new dedicated Identifier class

### DIFF
--- a/scripts/build_dataset/02_download_litigation.py
+++ b/scripts/build_dataset/02_download_litigation.py
@@ -26,7 +26,7 @@ from rich.console import Console
 from rich.progress import track
 
 from scripts.config import raw_data_dir
-from src.identifiers import generate_identifier
+from src.identifiers import Identifier
 
 console = Console()
 
@@ -80,7 +80,7 @@ console.print(
 
 # Add an identifier to each document
 sampled_litigation_df["id"] = sampled_litigation_df.apply(
-    lambda x: generate_identifier(x["Title"], x["Document file"]), axis=1
+    lambda x: Identifier.generate(x["Title"], x["Document file"]), axis=1
 )
 
 # Save the litigation documents as a json file

--- a/scripts/build_dataset/05_add_geography.py
+++ b/scripts/build_dataset/05_add_geography.py
@@ -17,7 +17,7 @@ from rich.progress import track
 
 from scripts.config import interim_data_dir, processed_data_dir, raw_data_dir
 from src.geography import geography_string_to_iso
-from src.identifiers import generate_identifier
+from src.identifiers import Identifier
 
 console = Console()
 
@@ -33,7 +33,7 @@ litigation_df["Jurisdictions"] = litigation_df["Jurisdictions"].str.split(">").s
 
 # Add an identifier to each document
 litigation_df["id"] = litigation_df.apply(
-    lambda x: generate_identifier(x["Title"], x["Document file"]),
+    lambda x: Identifier.generate(x["Title"], x["Document file"]),
     axis=1,
 )
 litigation_df.set_index("id", inplace=True)

--- a/scripts/push_to_argilla.py
+++ b/scripts/push_to_argilla.py
@@ -11,7 +11,7 @@ from tqdm.auto import tqdm  # type: ignore
 from scripts.config import concept_dir, processed_data_dir
 from src.argilla_v2 import ArgillaSession
 from src.concept import Concept
-from src.identifiers import WikibaseID, generate_identifier
+from src.identifiers import Identifier, WikibaseID
 from src.labelled_passage import LabelledPassage
 
 tqdm.pandas()
@@ -90,7 +90,7 @@ def main(
 
     for username in usernames:
         try:
-            password = generate_identifier(username)
+            password = Identifier.generate(username)
             user = rg.User(
                 id=uuid.uuid4(),
                 username=username,

--- a/scripts/upload_targets_data.py
+++ b/scripts/upload_targets_data.py
@@ -121,7 +121,7 @@ def main():
 
     # for username in usernames:
     #     try:
-    #         password = generate_identifier(username)
+    #         password = Identifier.generate(username)
     #         _ = rg_v1.User.create(
     #             username=username,
     #             password=password,

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional, Sequence, Union
 
 from src.concept import Concept
-from src.identifiers import WikibaseID, deterministic_hash, generate_identifier
+from src.identifiers import Identifier, WikibaseID
 from src.span import Span
 from src.version import Version
 
@@ -88,31 +88,20 @@ class Classifier(ABC):
         """Return the name of the classifier."""
         return self.__class__.__name__
 
-    def __hash__(self):
-        """
-        Return a deterministic hash of the classifier using SHA-256.
-
-        The hash is based on:
-        1. The classifier's class name
-        2. The concept's core data in a deterministically ordered format
-        3. The version if it exists
-        """
-        return deterministic_hash(
-            [
-                self.name,
-                self.concept.__hash__(),
-                self.version if self.version else None,
-            ]
-        )
-
     def __eq__(self, other):
         """Return whether two classifiers are equal."""
-        return self.__hash__() == other.__hash__()
+        if not isinstance(other, Classifier):
+            return False
+        return self.id == other.id
 
     @property
-    def id(self):
+    def id(self) -> Identifier:
         """Return a neat human-readable identifier for the classifier."""
-        return generate_identifier(self.__hash__())
+        return Identifier.generate(self.name, self.concept)
+
+    def __hash__(self) -> int:
+        """Return a hash for the classifier."""
+        return hash(self.id)
 
     def save(self, path: Union[str, Path]):
         """

--- a/src/classifier/embedding.py
+++ b/src/classifier/embedding.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from src.classifier.classifier import Classifier
 from src.concept import Concept
-from src.identifiers import deterministic_hash
+from src.identifiers import Identifier
 from src.span import Span
 
 
@@ -46,17 +46,19 @@ class EmbeddingClassifier(Classifier):
             f'{self.name}("{self.concept.preferred_label}", threshold={self.threshold})'
         )
 
-    def __hash__(self):
+    @property
+    def id(self) -> Identifier:
         """Return a hash of the classifier."""
-        return deterministic_hash(
-            [
-                self.name,
-                self.concept.__hash__(),
-                str(self.embedding_model),
-                self.threshold,
-                self.version if self.version else None,
-            ]
+        return Identifier.generate(
+            self.name,
+            self.concept,
+            self.embedding_model,
+            self.threshold,
         )
+
+    def __hash__(self) -> int:
+        """Return a hash of the classifier."""
+        return hash(self.id)
 
     def predict(self, text: str, threshold: Optional[float] = None) -> list[Span]:
         """

--- a/src/classifier/llm.py
+++ b/src/classifier/llm.py
@@ -9,7 +9,7 @@ from pydantic_ai.settings import ModelSettings
 
 from src.classifier.classifier import Classifier
 from src.concept import Concept
-from src.identifiers import deterministic_hash
+from src.identifiers import Identifier
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
@@ -74,7 +74,7 @@ class LLMClassifier(Classifier):
                     "variables needed to run each."
                 ),
             ),
-        ] = "gemini-1.5-flash-002",
+        ] = "gemini-2.0-flash",
         system_prompt_template: Annotated[
             str,
             Field(
@@ -117,18 +117,21 @@ class LLMClassifier(Classifier):
 
         self.random_seed = random_seed
 
-    def __hash__(self) -> int:
+    @property
+    def id(self) -> Identifier:
         """Overrides the default hash function, to enrich the hash with metadata"""
-        return deterministic_hash(
-            [
-                self.name,
-                self.concept.__hash__(),
-                self.version if self.version else None,
-                self.model_name,
-                self.system_prompt_template,
-                self.random_seed,
-            ]
+        return Identifier.generate(
+            self.name,
+            self.concept.__hash__(),
+            self.version if self.version else None,
+            self.model_name,
+            self.system_prompt_template,
+            self.random_seed,
         )
+
+    def __hash__(self) -> int:
+        """Return a hash of the classifier."""
+        return hash(self.id)
 
     def __repr__(self):
         """Return a string representation of the classifier."""

--- a/src/concept.py
+++ b/src/concept.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from src.identifiers import WikibaseID, deterministic_hash
+from src.identifiers import Identifier, WikibaseID
 from src.labelled_passage import LabelledPassage
 
 if TYPE_CHECKING:
@@ -128,18 +128,21 @@ class Concept(BaseModel):
         """Return a short string representation of the concept"""
         return self.__repr__()
 
+    @property
+    def id(self) -> Identifier:
+        """Return a unique ID for the concept"""
+        return Identifier.generate(
+            self.wikibase_id,
+            self.preferred_label,
+            self.description,
+            self.definition,
+            *sorted(self.alternative_labels),  # Sort for deterministic ordering
+            *sorted(self.negative_labels),  # Sort for deterministic ordering
+        )
+
     def __hash__(self) -> int:
         """Return a hash for the concept"""
-        return deterministic_hash(
-            [
-                str(self.wikibase_id),
-                self.preferred_label,
-                self.description,
-                self.definition,
-                *sorted(self.alternative_labels),  # Sort for deterministic ordering
-                *sorted(self.negative_labels),  # Sort for deterministic ordering
-            ]
-        )
+        return hash(self.id)
 
     @property
     def wikibase_url(self) -> str:

--- a/src/labelled_passage.py
+++ b/src/labelled_passage.py
@@ -4,7 +4,7 @@ import re
 from argilla import Argilla, Record, Response
 from pydantic import BaseModel, Field, model_validator
 
-from src.identifiers import generate_identifier
+from src.identifiers import Identifier
 from src.span import Span, merge_overlapping_spans
 
 
@@ -27,7 +27,7 @@ class LabelledPassage(BaseModel):
     )
 
     def __init__(self, text: str, spans: list[Span], **kwargs):
-        id = kwargs.pop("id", generate_identifier(text))
+        id = kwargs.pop("id", Identifier.generate(text))
         super().__init__(text=text, spans=spans, id=id, **kwargs)
 
     @model_validator(mode="after")

--- a/src/span.py
+++ b/src/span.py
@@ -2,9 +2,9 @@ import re
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, computed_field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
-from src.identifiers import WikibaseID, deterministic_hash, generate_identifier
+from src.identifiers import Identifier, WikibaseID
 
 
 class Span(BaseModel):
@@ -49,10 +49,10 @@ class Span(BaseModel):
 
         json_encoders = {datetime: lambda dt: dt.isoformat()}
 
-    @computed_field
-    def id(self) -> str:
+    @property
+    def id(self) -> Identifier:
         """Return the unique identifier for the span."""
-        return generate_identifier(
+        return Identifier.generate(
             self.text,
             self.start_index,
             self.end_index,
@@ -84,7 +84,7 @@ class Span(BaseModel):
                 )
         return self
 
-    @computed_field
+    @property
     def labelled_text(self) -> str:
         """The span's labelled substring"""
         return self.text[self.start_index : self.end_index]
@@ -94,15 +94,8 @@ class Span(BaseModel):
         return self.end_index - self.start_index
 
     def __hash__(self) -> int:
-        """Return a unique hash for the span."""
-        return deterministic_hash(
-            [
-                self.text,
-                self.start_index,
-                self.end_index,
-                self.concept_id,
-            ]
-        )
+        """Return a hash for the span."""
+        return hash(self.id)
 
     def __eq__(self, other: object) -> bool:
         """Check whether two spans are equal."""

--- a/src/span.py
+++ b/src/span.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from src.identifiers import Identifier, WikibaseID
 
@@ -49,6 +49,7 @@ class Span(BaseModel):
 
         json_encoders = {datetime: lambda dt: dt.isoformat()}
 
+    @computed_field
     @property
     def id(self) -> Identifier:
         """Return the unique identifier for the span."""
@@ -84,6 +85,7 @@ class Span(BaseModel):
                 )
         return self
 
+    @computed_field
     @property
     def labelled_text(self) -> str:
         """The span's labelled substring"""

--- a/src/version.py
+++ b/src/version.py
@@ -12,6 +12,10 @@ class Version:
         """Create a new instance of Version after validation."""
         self.value = self._validate(value)
 
+    def __hash__(self):
+        """Return a hash of the Version."""
+        return hash(self.value)
+
     @classmethod
     def _validate(cls, value: str) -> int:
         if value == "latest":

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,5 @@
 import re
 
-from src.identifiers import deterministic_hash
-
 
 class Version:
     """A version as mandated by W&B."""
@@ -54,10 +52,6 @@ class Version:
         if isinstance(other, Version):
             return self.value < other.value
         return str(self) < other
-
-    def __hash__(self):
-        """Return a hash value for the Version."""
-        return deterministic_hash(self.value)
 
     def increment(self) -> "Version":
         """Increment the version number by 1."""

--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -14,14 +14,13 @@ from src.exceptions import ConceptNotFoundError, RevisionNotFoundError
 from src.identifiers import WikibaseID
 
 logger = getLogger(__name__)
-
 dotenv.load_dotenv()
 
 
 class WikibaseSession:
     """A session for interacting with Wikibase"""
 
-    session = httpx.Client()
+    session = httpx.Client(timeout=30)
 
     has_subconcept_property_id = os.getenv("WIKIBASE_HAS_SUBCONCEPT_PROPERTY_ID", "P1")
     subconcept_of_property_id = os.getenv("WIKIBASE_SUBCONCEPT_OF_PROPERTY_ID", "P2")

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -9,7 +9,7 @@ from src.classifier.keyword import KeywordClassifier
 from src.classifier.rules_based import RulesBasedClassifier
 from src.classifier.stemmed_keyword import StemmedKeywordClassifier
 from src.concept import Concept
-from src.identifiers import WikibaseID, generate_identifier
+from src.identifiers import Identifier, WikibaseID
 from src.span import Span
 from tests.common_strategies import concept_label_strategy, concept_strategy
 
@@ -265,7 +265,7 @@ def test_whether_classifier_hashes_are_generated_correctly(
     classifier_class: Type[Classifier], concept: Concept
 ):
     classifier = classifier_class(concept)
-    assert classifier.id == generate_identifier(classifier.__hash__())
+    assert classifier.id == Identifier.generate(classifier.name, classifier.concept)
     assert classifier == classifier_class(concept)
 
 


### PR DESCRIPTION
Adding this PR to kick things off, with the intention to hand over the rest of the work on [PLA-557](https://linear.app/climate-policy-radar/issue/PLA-557/overhaul-of-model-id-to-add-lineage-tracking) to @climatepolicyradar/deng, who will do a much better job than me at the rest of the implementation.

This PR adds a new `Identifier` class, whose `Identifier.generate()` supersedes the `generate_identifier` function with much nicer structures for validation and testing etc. There's still more work to do here (broken down in the top-level ticket) but I hope sets some sort of direction/intent for the subsequent bits of work 🙇‍♂️ 