### PR TITLE
Add mixins for high-level classifier attributes

### DIFF
--- a/src/classifier/bert_based.py
+++ b/src/classifier/bert_based.py
@@ -12,13 +12,16 @@ from transformers import (
     pipeline,
 )
 
-from src.classifier.classifier import Classifier
+from src.classifier.classifier import (
+    Classifier,
+    ClassifierForWhichInferenceNeedsToRunOnAGPU,
+)
 from src.concept import Concept
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
 
-class BertBasedClassifier(Classifier):
+class BertBasedClassifier(Classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
     """
     Classifier that uses a fine-tuned transformer model to identify concepts in text.
 

--- a/src/classifier/bert_based.py
+++ b/src/classifier/bert_based.py
@@ -12,16 +12,13 @@ from transformers import (
     pipeline,
 )
 
-from src.classifier.classifier import (
-    Classifier,
-    ClassifierForWhichInferenceNeedsToRunOnAGPU,
-)
+from src.classifier.classifier import Classifier, GPUBoundClassifier
 from src.concept import Concept
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
 
-class BertBasedClassifier(Classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
+class BertBasedClassifier(Classifier, GPUBoundClassifier):
     """
     Classifier that uses a fine-tuned transformer model to identify concepts in text.
 

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -140,3 +140,23 @@ class Classifier(ABC):
 
             classifier.pipeline.device = torch.device("cuda:0")  # type: ignore
         return classifier
+
+
+class ZeroShotClassifier:
+    """
+    A classifier which can make predictions without training.
+
+    In other words, zero-shot models can make predictions based only on the concept
+    object, without seeing any examples of the concept appearing in real passages of
+    text.
+
+    https://en.wikipedia.org/wiki/Zero-shot_learning
+    """
+
+    pass
+
+
+class ClassifierForWhichInferenceNeedsToRunOnAGPU:
+    """A classifier for which inference needs to run on a GPU."""
+
+    pass

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -131,17 +131,22 @@ class Classifier(ABC):
         return classifier
 
 
-class ZeroShotClassifier:
+class ZeroShotClassifier(ABC):
     """
-    A classifier which can make predictions without training.
+    A mixin which identifies classifiers that can make predictions without training.
 
-    In other words, zero-shot models can make predictions based only on the concept
-    object, without seeing any examples of the concept appearing in real passages of
-    text.
+    Zero-shot classifiers can make predictions based only on a concept object, without
+    seeing any examples of the concept appearing in real passages of text. Zero-shot
+    classifiers do not require calling .fit() before running .predict().
 
-    https://en.wikipedia.org/wiki/Zero-shot_learning
+    See: https://en.wikipedia.org/wiki/Zero-shot_learning
     """
 
 
-class ClassifierForWhichInferenceNeedsToRunOnAGPU:
-    """A classifier for which inference needs to run on a GPU."""
+class GPUBoundClassifier(ABC):
+    """
+    A mixin which identifies classifiers which should run on GPU hardware.
+
+    GPU-bound classifiers should ideally run on GPU hardware during both training and
+    inference.
+    """

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -153,10 +153,6 @@ class ZeroShotClassifier:
     https://en.wikipedia.org/wiki/Zero-shot_learning
     """
 
-    pass
-
 
 class ClassifierForWhichInferenceNeedsToRunOnAGPU:
     """A classifier for which inference needs to run on a GPU."""
-
-    pass

--- a/src/classifier/embedding.py
+++ b/src/classifier/embedding.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from typing import Optional
 
-from src.classifier.classifier import Classifier
+from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.concept import Concept
 from src.identifiers import deterministic_hash
 from src.span import Span
 
 
-class EmbeddingClassifier(Classifier):
+class EmbeddingClassifier(Classifier, ZeroShotClassifier):
     """
     A classifier that uses an embedding model to identify concepts in text.
 

--- a/src/classifier/keyword.py
+++ b/src/classifier/keyword.py
@@ -1,11 +1,12 @@
 import re
 from datetime import datetime
 
-from src.classifier.classifier import Classifier, Span
+from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.concept import Concept
+from src.span import Span
 
 
-class KeywordClassifier(Classifier):
+class KeywordClassifier(Classifier, ZeroShotClassifier):
     """
     Classifier uses keyword matching to find instances of a concept in text.
 

--- a/src/classifier/llm.py
+++ b/src/classifier/llm.py
@@ -7,7 +7,7 @@ from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.settings import ModelSettings
 
-from src.classifier.classifier import Classifier
+from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.concept import Concept
 from src.identifiers import deterministic_hash
 from src.labelled_passage import LabelledPassage
@@ -59,7 +59,7 @@ Instructions:
 """
 
 
-class LLMClassifier(Classifier):
+class LLMClassifier(Classifier, ZeroShotClassifier):
     """A classifier that uses an LLM to predict the presence of a concept in a text."""
 
     def __init__(

--- a/src/classifier/rules_based.py
+++ b/src/classifier/rules_based.py
@@ -1,10 +1,10 @@
-from src.classifier.classifier import Classifier
+from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.classifier.keyword import KeywordClassifier
 from src.concept import Concept
 from src.span import Span
 
 
-class RulesBasedClassifier(Classifier):
+class RulesBasedClassifier(Classifier, ZeroShotClassifier):
     """
     Classifier uses keyword matching to find instances of a concept in text.
 

--- a/src/classifier/targets.py
+++ b/src/classifier/targets.py
@@ -1,9 +1,12 @@
 import warnings
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from datetime import datetime
 from typing import Callable
 
-from src.classifier.classifier import Classifier
+from src.classifier.classifier import (
+    Classifier,
+    ClassifierForWhichInferenceNeedsToRunOnAGPU,
+)
 from src.concept import Concept
 from src.identifiers import WikibaseID
 from src.span import Span
@@ -13,7 +16,7 @@ from src.span import Span
 DEFAULT_THRESHOLD = 0.524
 
 
-class BaseTargetClassifier(Classifier, ABC):
+class BaseTargetClassifier(Classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
     """Base class for target classifiers."""
 
     allowed_concept_ids = [

--- a/src/classifier/targets.py
+++ b/src/classifier/targets.py
@@ -3,10 +3,7 @@ from abc import abstractmethod
 from datetime import datetime
 from typing import Callable
 
-from src.classifier.classifier import (
-    Classifier,
-    ClassifierForWhichInferenceNeedsToRunOnAGPU,
-)
+from src.classifier.classifier import Classifier, GPUBoundClassifier
 from src.concept import Concept
 from src.identifiers import WikibaseID
 from src.span import Span
@@ -16,7 +13,7 @@ from src.span import Span
 DEFAULT_THRESHOLD = 0.524
 
 
-class BaseTargetClassifier(Classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
+class BaseTargetClassifier(Classifier, GPUBoundClassifier):
     """Base class for target classifiers."""
 
     allowed_concept_ids = [

--- a/tests/test_classifier_mixins.py
+++ b/tests/test_classifier_mixins.py
@@ -1,0 +1,52 @@
+"""Tests for isinstance behaviour of classifier mixins."""
+
+from src.classifier.classifier import (
+    Classifier,
+    ClassifierForWhichInferenceNeedsToRunOnAGPU,
+    ZeroShotClassifier,
+)
+from src.concept import Concept
+from src.span import Span
+
+
+class DummyClassifier(Classifier):
+    """A dummy classifier for testing purposes."""
+
+    def predict(self, text: str) -> list[Span]:
+        """Predicts nothing."""
+        return []
+
+
+class DummyZeroShotClassifier(DummyClassifier, ZeroShotClassifier):
+    """A dummy zero-shot classifier."""
+
+
+class DummyGpuClassifier(DummyClassifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
+    """A dummy GPU classifier."""
+
+
+concept = Concept(wikibase_id="Q1", preferred_label="test")
+
+
+def test_isinstance_for_a_zero_shot_classifier():
+    """Test that a zero-shot classifier is an instance of ZeroShotClassifier."""
+    classifier = DummyZeroShotClassifier(concept)
+    assert isinstance(classifier, ZeroShotClassifier)
+
+
+def test_isinstance_for_a_non_zero_shot_classifier():
+    """Test that a non-zero-shot classifier is not an instance of ZeroShotClassifier."""
+    classifier = DummyClassifier(concept)
+    assert not isinstance(classifier, ZeroShotClassifier)
+
+
+def test_isinstance_for_a_gpu_classifier():
+    """Test that a GPU classifier is an instance of the GPU marker class."""
+    classifier = DummyGpuClassifier(concept)
+    assert isinstance(classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU)
+
+
+def test_isinstance_for_a_non_gpu_classifier():
+    """Test that a non-GPU classifier is not an instance of the GPU marker class."""
+    classifier = DummyClassifier(concept)
+    assert not isinstance(classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU)

--- a/tests/test_classifier_mixins.py
+++ b/tests/test_classifier_mixins.py
@@ -1,10 +1,6 @@
 """Tests for isinstance behaviour of classifier mixins."""
 
-from src.classifier.classifier import (
-    Classifier,
-    ClassifierForWhichInferenceNeedsToRunOnAGPU,
-    ZeroShotClassifier,
-)
+from src.classifier.classifier import Classifier, GPUBoundClassifier, ZeroShotClassifier
 from src.concept import Concept
 from src.span import Span
 
@@ -21,7 +17,7 @@ class DummyZeroShotClassifier(DummyClassifier, ZeroShotClassifier):
     """A dummy zero-shot classifier."""
 
 
-class DummyGpuClassifier(DummyClassifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
+class DummyGpuClassifier(DummyClassifier, GPUBoundClassifier):
     """A dummy GPU classifier."""
 
 
@@ -43,10 +39,10 @@ def test_isinstance_for_a_non_zero_shot_classifier():
 def test_isinstance_for_a_gpu_classifier():
     """Test that a GPU classifier is an instance of the GPU marker class."""
     classifier = DummyGpuClassifier(concept)
-    assert isinstance(classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU)
+    assert isinstance(classifier, GPUBoundClassifier)
 
 
 def test_isinstance_for_a_non_gpu_classifier():
     """Test that a non-GPU classifier is not an instance of the GPU marker class."""
     classifier = DummyClassifier(concept)
-    assert not isinstance(classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU)
+    assert not isinstance(classifier, GPUBoundClassifier)


### PR DESCRIPTION
Kicked off by [this conversation](https://github.com/climatepolicyradar/architecture-hub/pull/31#discussion_r2168576236)

> I'd like to be able to mark some classifiers as having a particular characteristic, eg an `LLMClassifier` and a KeywordClassifier and a `RulesBasedClassifier` should all be instances of a `ZeroShotClassifier`, and a `TargetsClassifier` and a `BertBasedClassifier` should be instances of a `ClassifierWhichNeedsToRunInferenceOnAGPU`. Maybe that's set via a mixin, or through some other sort of superclass magic 🤔

Turns out that implementing this via a couple of mixins was very easy! We can now run simple checks like

```py
concept = wikibase.get_concept("Q123")
classifier = ClassifierFactory.create(concept)

if not isinstance(classifier, ZeroShotClassifier):
    classifier.train()

if isinstance(classifier, ClassifierForWhichInferenceNeedsToRunOnAGPU):
    # edit the config/spec to specify that this one needs to spin up a gpu
```


I'm not especially tied to the `ClassifierForWhichInferenceNeedsToRunOnAGPU` name here, and very happy to change it in the future. But for the time being, this feels like a nice demonstration of the principle, and a structure that we can continue to work with as our needs develop.