### PR TITLE
Refactor DocumentId to DocumentStem in aggregate inference results pipeline

### DIFF
--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -138,10 +138,6 @@ async def get_all_labelled_passages_for_one_document(
                 config.document_source_prefix,
                 spec.name,
                 spec.alias,
-                # TODO: This is a document stem.
-                #   The labelled_passages s3 prefix contains files with a _translated
-                #   suffix. Inference also identifies stems and persists this when
-                #   saving inference results.
                 f"{document_stem}.json",
             ),
         )
@@ -324,7 +320,7 @@ async def create_aggregate_inference_summary_artifact(
 
     details = [
         {
-            "Failed document ID": failure.document_stem,
+            "Failed document Stem": failure.document_stem,
             "Exception": str(failure.exception),
             "Context": failure.context,
         }

--- a/flows/aggregate_inference_results.py
+++ b/flows/aggregate_inference_results.py
@@ -25,7 +25,7 @@ from flows.boundary import (
 )
 from flows.inference import DOCUMENT_TARGET_PREFIX_DEFAULT
 from flows.utils import (
-    DocumentImportId,
+    DocumentStem,
     S3Uri,
     SlackNotify,
     collect_unique_file_stems_under_prefix,
@@ -61,16 +61,14 @@ SerialisedVespaConcept: TypeAlias = list[dict[str, str]]
 class AggregationFailure(Exception):
     """A document failure."""
 
-    def __init__(
-        self, document_id: DocumentImportId, exception: Exception, context: str
-    ):
-        self.document_id = document_id
+    def __init__(self, document_stem: DocumentStem, exception: Exception, context: str):
+        self.document_stem = document_stem
         self.exception = exception
         self.context = context
 
     def __str__(self) -> str:
         """Return a string representation"""
-        return f"{self.document_id} | exception: {str(self.exception)} | context: {self.context}"
+        return f"{self.document_stem} | exception: {str(self.exception)} | context: {self.context}"
 
 
 class Config(BaseModel):
@@ -127,7 +125,7 @@ def build_run_output_identifier() -> RunOutputIdentifier:
 
 async def get_all_labelled_passages_for_one_document(
     s3: S3Client,
-    document_id: DocumentImportId,
+    document_stem: DocumentStem,
     classifier_specs: Sequence[ClassifierSpec],
     config: Config,
 ) -> AsyncGenerator[tuple[ClassifierSpec, list[LabelledPassage]], None]:
@@ -140,7 +138,11 @@ async def get_all_labelled_passages_for_one_document(
                 config.document_source_prefix,
                 spec.name,
                 spec.alias,
-                f"{document_id}.json",
+                # TODO: This is a document stem.
+                #   The labelled_passages s3 prefix contains files with a _translated
+                #   suffix. Inference also identifies stems and persists this when
+                #   saving inference results.
+                f"{document_stem}.json",
             ),
         )
         response = await s3.get_object(Bucket=s3_uri.bucket, Key=s3_uri.key)
@@ -202,23 +204,23 @@ def task_run_name(parameters: dict[str, Any]) -> str:
     persist_result=False,
 )
 async def process_document(
-    document_id: DocumentImportId,
+    document_stem: DocumentStem,
     session: aioboto3.Session,
     classifier_specs: list[ClassifierSpec],
     config: Config,
     run_output_identifier: RunOutputIdentifier,
-) -> DocumentImportId:
+) -> DocumentStem:
     """Process a single document and return its status."""
     try:
         async with session.client("s3") as s3:
-            print("Fetching labelled passages for", document_id)
+            print("Fetching labelled passages for", document_stem)
 
             concepts_for_vespa: dict[TextBlockId, SerialisedVespaConcept] = {}
             async for (
                 spec,
                 labelled_passages,
             ) in get_all_labelled_passages_for_one_document(
-                s3, document_id, classifier_specs, config
+                s3, document_stem, classifier_specs, config
             ):
                 # `concepts_for_vespa`` starts empty so Validation not needed initially
                 if not concepts_for_vespa:
@@ -232,7 +234,7 @@ async def process_document(
                 if len(labelled_passages) != len(concepts_for_vespa.keys()):
                     raise ValueError(
                         f"The number of passages diverge when appending {spec}: "
-                        f"{len(labelled_passages)=} != {len(concepts_for_vespa)=}"
+                        + f"{len(labelled_passages)=} != {len(concepts_for_vespa)=}"
                     )
 
                 for passage, text_block_id in zip(
@@ -240,8 +242,9 @@ async def process_document(
                 ):
                     if passage.id != text_block_id:
                         raise ValueError(
-                            f"The text_block id diverges for {spec} when compared with what has been collected so far:"
-                            f"{passage.id=} != {text_block_id=}"
+                            f"The text_block id diverges for {spec} when compared with"
+                            + "what has been collected so far:"
+                            + f"{passage.id=} != {text_block_id=}"
                         )
                     serialised_concepts = [
                         vc.model_dump(mode="json")
@@ -257,7 +260,7 @@ async def process_document(
                 key=os.path.join(
                     config.aggregate_inference_results_prefix,
                     run_output_identifier,
-                    f"{document_id}.json",
+                    f"{document_stem}.json",
                 ),
             )
             await s3_object_write_text_async(s3, s3_uri, json.dumps(concepts_for_vespa))
@@ -271,40 +274,42 @@ async def process_document(
                     key=os.path.join(
                         config.aggregate_inference_results_prefix,
                         "latest",
-                        f"{document_id}.json",
+                        f"{document_stem}.json",
                     ),
                 ),
             )
-            return document_id
+            return document_stem
     except ClientError as e:
         print(f"ClientError: {e.response}")
         raise AggregationFailure(
-            document_id=document_id, exception=e, context=e.response
+            document_stem=document_stem, exception=e, context=e.response
         )
     except Exception as e:
-        raise AggregationFailure(document_id=document_id, exception=e, context=repr(e))
+        raise AggregationFailure(
+            document_stem=document_stem, exception=e, context=repr(e)
+        )
 
 
 def handle_results(
-    results: Sequence[DocumentImportId | AggregationFailure],
-) -> tuple[list[DocumentImportId], list[AggregationFailure]]:
-    success_ids: list[DocumentImportId] = []
+    results: Sequence[DocumentStem | AggregationFailure],
+) -> tuple[list[DocumentStem], list[AggregationFailure]]:
+    success_stems: list[DocumentStem] = []
     failures: list[AggregationFailure] = []
 
     for result in results:
         if isinstance(result, AggregationFailure):
             failures.append(result)
         elif isinstance(result, str):
-            success_ids.append(DocumentImportId(result))
+            success_stems.append(DocumentStem(result))
         else:
             raise ValueError(f"Unknown result type: {type(result)}")
 
-    return success_ids, failures
+    return success_stems, failures
 
 
 async def create_aggregate_inference_summary_artifact(
     config: Config,
-    success_ids: list[DocumentImportId],
+    success_stems: list[DocumentStem],
     failures: list[AggregationFailure],
 ) -> None:
     """Create a summary artifact of the aggregated inference results."""
@@ -313,13 +318,13 @@ async def create_aggregate_inference_summary_artifact(
 
 ## Overview
 - **Environment**: {config.aws_env.value}
-- **Documents processed**: {len(success_ids)}
-- **Failed documents**: {len(failures)}/{len(success_ids)}
+- **Documents processed**: {len(success_stems)}
+- **Failed documents**: {len(failures)}/{len(success_stems)}
 """
 
     details = [
         {
-            "Failed document ID": failure.document_id,
+            "Failed document ID": failure.document_stem,
             "Exception": str(failure.exception),
             "Context": failure.context,
         }
@@ -335,7 +340,7 @@ async def create_aggregate_inference_summary_artifact(
 
 async def create_aggregate_inference_overall_summary_artifact(
     aws_env: AwsEnv,
-    document_ids: list[DocumentImportId],
+    document_stems: list[DocumentStem],
     classifier_specs: list[ClassifierSpec],
     run_output_identifier: RunOutputIdentifier,
     successes: Sequence[RunOutputIdentifier],
@@ -348,7 +353,7 @@ async def create_aggregate_inference_overall_summary_artifact(
 - **Environment**: {aws_env.value}
 - **Run Output Identifier**: `{run_output_identifier}`
 - **Total classifier specs.**: {len(classifier_specs)}
-- **Total documents**: {len(document_ids)}
+- **Total documents**: {len(document_stems)}
 - **Successful batches**: {len(successes)}
 - **Failed batches**: {len(failures)}
 """
@@ -359,20 +364,20 @@ async def create_aggregate_inference_overall_summary_artifact(
     )
 
 
-def collect_stems_by_specs(config: Config) -> list[DocumentImportId]:
+def collect_stems_by_specs(config: Config) -> list[DocumentStem]:
     """Collect the stems for the given specs."""
-    document_ids = []
+    document_stems = []
     specs = parse_spec_file(config.aws_env)
     for spec in specs:
         prefix = os.path.join(config.document_source_prefix, spec.name, spec.alias)
-        document_ids.extend(
+        document_stems.extend(
             collect_unique_file_stems_under_prefix(
                 bucket_name=config.cache_bucket_str,
                 prefix=prefix,
             )
         )
 
-    return list(set(document_ids))
+    return list(set(document_stems))
 
 
 @flow(
@@ -381,7 +386,7 @@ def collect_stems_by_specs(config: Config) -> list[DocumentImportId]:
     task_runner=ThreadPoolTaskRunner(max_workers=DEFAULT_N_DOCUMENTS_IN_BATCH),
 )
 async def aggregate_inference_results_batch(
-    document_ids: Sequence[DocumentImportId],
+    document_stems: Sequence[DocumentStem],
     config_json: dict[str, Any],
     classifier_specs: Sequence[ClassifierSpec],
     run_output_identifier: RunOutputIdentifier,
@@ -392,7 +397,7 @@ async def aggregate_inference_results_batch(
     session = aioboto3.Session(region_name=config.bucket_region)
 
     futures = process_document.map(  # pyright: ignore[reportFunctionMemberAccess]
-        document_ids,
+        document_stems,
         session=unmapped(session),
         classifier_specs=unmapped(classifier_specs),
         config=unmapped(config),
@@ -403,12 +408,12 @@ async def aggregate_inference_results_batch(
     results = futures.result(raise_on_failure=False)
 
     print("handling results")
-    success_ids, failures = handle_results(results)
+    success_stems, failures = handle_results(results)
 
     print("creating summary artifact")
     await create_aggregate_inference_summary_artifact(
         config=config,
-        success_ids=success_ids,
+        success_stems=success_stems,
         failures=failures,
     )
 
@@ -427,7 +432,7 @@ async def aggregate_inference_results_batch(
     log_prints=True,
 )
 async def aggregate_inference_results(
-    document_ids: None | list[DocumentImportId] = None,
+    document_stems: None | list[DocumentStem] = None,
     config: Config | None = None,
     n_documents_in_batch: PositiveInt = DEFAULT_N_DOCUMENTS_IN_BATCH,
     n_batches: PositiveInt = 5,
@@ -437,29 +442,29 @@ async def aggregate_inference_results(
         print("no config provided, creating one")
         config = await Config.create()
 
-    if not document_ids:
+    if not document_stems:
         print(
-            "no document ids provided, collecting all available from s3 under prefix: "
-            f"{config.document_source_prefix}"
+            "no document stems provided, collecting all available from s3 under prefix: "
+            + f"{config.document_source_prefix}"
         )
-        document_ids = collect_stems_by_specs(config)
+        document_stems = collect_stems_by_specs(config)
 
     run_output_identifier = build_run_output_identifier()
     classifier_specs = parse_spec_file(config.aws_env)
 
     print(
-        f"Aggregating inference results for {len(document_ids)} documents, using "
-        f"{len(classifier_specs)} classifiers, outputting to {run_output_identifier}"
+        f"Aggregating inference results for {len(document_stems)} documents, using "
+        + f"{len(classifier_specs)} classifiers, outputting to {run_output_identifier}"
     )
 
     batches = iterate_batch(
-        document_ids,
+        document_stems,
         n_documents_in_batch,
     )
 
-    def parameters(batch: Sequence[DocumentImportId]) -> dict[str, Any]:
+    def parameters(batch: Sequence[DocumentStem]) -> dict[str, Any]:
         return {
-            "document_ids": batch,
+            "document_stems": batch,
             "config_json": config.model_dump(),
             "classifier_specs": classifier_specs,
             "run_output_identifier": run_output_identifier,
@@ -475,7 +480,7 @@ async def aggregate_inference_results(
 
     await create_aggregate_inference_overall_summary_artifact(
         aws_env=config.aws_env,
-        document_ids=document_ids,
+        document_stems=document_stems,
         classifier_specs=classifier_specs,
         run_output_identifier=run_output_identifier,
         successes=successes,

--- a/flows/index_from_aggregate_results.py
+++ b/flows/index_from_aggregate_results.py
@@ -600,7 +600,7 @@ async def run_indexing_from_aggregate_results(
             f"Running on all documents under run_output_identifier: {run_output_identifier}"
         )
         collected_document_stems: list[DocumentStem] = (
-            collect_unique_file_stems_under_prefix(  #  type: ignore[call-arg]
+            collect_unique_file_stems_under_prefix(
                 bucket_name=config.cache_bucket_str,
                 prefix=os.path.join(
                     config.aggregate_inference_results_prefix, run_output_identifier

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -211,7 +211,7 @@ def get_file_stems_for_document_id(
 def collect_unique_file_stems_under_prefix(
     bucket_name: str,
     prefix: str,
-) -> list[DocumentImportId]:
+) -> list[DocumentStem]:
     """Collect all unique file stems under a prefix."""
     s3 = boto3.client("s3")
     paginator = s3.get_paginator("list_objects_v2")
@@ -219,7 +219,7 @@ def collect_unique_file_stems_under_prefix(
     for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
         for obj in page.get("Contents", []):
             if obj["Key"].endswith(".json"):
-                file_stems.append(Path(obj["Key"]).stem)
+                file_stems.append(DocumentStem(Path(obj["Key"]).stem))
     return list(set(file_stems))
 
 

--- a/tests/flows/test_aggregate_inference_results.py
+++ b/tests/flows/test_aggregate_inference_results.py
@@ -21,7 +21,7 @@ from flows.aggregate_inference_results import (
     process_document,
     validate_passages_are_same_except_concepts,
 )
-from flows.utils import DocumentImportId
+from flows.utils import DocumentStem
 from scripts.cloud import ClassifierSpec
 from scripts.update_classifier_spec import write_spec_file
 from src.labelled_passage import LabelledPassage
@@ -54,15 +54,15 @@ async def test_aggregate_inference_results_batch(
     _, bucket, s3_async_client = mock_bucket_labelled_passages_large
     _, classifier_specs = mock_classifier_specs
 
-    document_ids = [
-        "CCLW.executive.10061.4515",
-        "CPR.document.i00000549.n0000",
-        "UNFCCC.non-party.467.0",
-        "UNFCCC.party.492.0",
+    document_stems = [
+        DocumentStem("CCLW.executive.10061.4515"),
+        DocumentStem("CPR.document.i00000549.n0000"),
+        DocumentStem("UNFCCC.non-party.467.0"),
+        DocumentStem("UNFCCC.party.492.0"),
     ]
 
     run_reference = await aggregate_inference_results_batch(
-        document_ids=document_ids,
+        document_stems=document_stems,
         config_json=test_aggregate_config.model_dump(),
         classifier_specs=classifier_specs,
         run_output_identifier="test-run",
@@ -71,11 +71,11 @@ async def test_aggregate_inference_results_batch(
     all_collected_ids = []
     collected_ids_for_document = []
 
-    for document_id in document_ids:
+    for document_stem in document_stems:
         s3_path = os.path.join(
             test_aggregate_config.aggregate_inference_results_prefix,
             run_reference,
-            f"{document_id}.json",
+            f"{document_stem}.json",
         )
         try:
             response = await s3_async_client.get_object(Bucket=bucket, Key=s3_path)
@@ -84,7 +84,7 @@ async def test_aggregate_inference_results_batch(
         except s3_async_client.exceptions.NoSuchKey:
             pytest.fail(f"Unable to find output file: {s3_path}")
         except json.JSONDecodeError:
-            pytest.fail(f"Unable to deserialise output for: {document_id}")
+            pytest.fail(f"Unable to deserialise output for: {document_stem}")
         except Exception as e:
             pytest.fail(f"Unexpected error: {e}")
 
@@ -102,7 +102,7 @@ async def test_aggregate_inference_results_batch(
                     )
 
         assert len(collected_ids_for_document) > 0, (
-            f"No concepts found for document: {document_id}"
+            f"No concepts found for document: {document_stem}"
         )
         all_collected_ids.extend(collected_ids_for_document)
 
@@ -124,12 +124,15 @@ async def test_aggregate_inference_results_batch__with_failures(
     mock_bucket_labelled_passages_large, mock_classifier_specs, test_aggregate_config
 ):
     _, classifier_specs = mock_classifier_specs
-    expect_failure_ids = ["Some.Made.Up.Document.ID", "Another.One.That.Should.Fail"]
-    document_ids = ["CCLW.executive.10061.4515"] + expect_failure_ids
+    expect_failure_stems = [
+        DocumentStem("Some.Made.Up.Document.ID"),
+        DocumentStem("Another.One.That.Should.Fail"),
+    ]
+    document_stems = [DocumentStem("CCLW.executive.10061.4515")] + expect_failure_stems
 
     with pytest.raises(ValueError):
         await aggregate_inference_results_batch(
-            document_ids=document_ids,
+            document_stems=document_stems,
             config_json=test_aggregate_config.model_dump(),
             classifier_specs=classifier_specs,
             run_output_identifier="test-run",
@@ -138,8 +141,8 @@ async def test_aggregate_inference_results_batch__with_failures(
     summary_artifact = await Artifact.get("aggregate-inference-sandbox")
     assert summary_artifact and summary_artifact.description
     artifact_data = json.loads(summary_artifact.data)
-    failured_ids = [f["Failed document ID"] for f in artifact_data]
-    assert set(failured_ids) == set(expect_failure_ids)
+    failure_stems = [f["Failed document Stem"] for f in artifact_data]
+    assert set(failure_stems) == set(expect_failure_stems)
     assert artifact_data[0]["Context"]["Error"]["Code"] == "NoSuchKey"
     assert artifact_data[1]["Context"]["Error"]["Code"] == "NoSuchKey"
 
@@ -164,7 +167,7 @@ async def test_get_all_labelled_passages_for_one_document(
     mock_bucket_labelled_passages_large, test_aggregate_config
 ):
     _, _, s3_async_client = mock_bucket_labelled_passages_large
-    document_id = "CCLW.executive.10061.4515"
+    document_stem = DocumentStem("CCLW.executive.10061.4515")
     classifier_specs = [
         ClassifierSpec(name="Q218", alias="v5"),
         ClassifierSpec(name="Q767", alias="v3"),
@@ -172,7 +175,7 @@ async def test_get_all_labelled_passages_for_one_document(
     ]
     all_labelled_passages = []
     async for spec, labelled_passages in get_all_labelled_passages_for_one_document(
-        s3_async_client, document_id, classifier_specs, test_aggregate_config
+        s3_async_client, document_stem, classifier_specs, test_aggregate_config
     ):
         all_labelled_passages.append(labelled_passages)
     assert len(all_labelled_passages) == len(classifier_specs)
@@ -209,11 +212,11 @@ async def test_process_single_document__success(
 ):
     _, bucket, s3_async_client = mock_bucket_labelled_passages_large
     _, classifier_specs = mock_classifier_specs
-    document_id = "CCLW.executive.10061.4515"
+    document_stem = DocumentStem("CCLW.executive.10061.4515")
 
     session = aioboto3.Session(region_name=test_aggregate_config.bucket_region)
-    assert document_id == await process_document.fn(
-        document_id,
+    assert document_stem == await process_document.fn(
+        document_stem,
         session,
         classifier_specs,
         test_aggregate_config,
@@ -226,7 +229,7 @@ async def test_process_single_document__success(
         Key=os.path.join(
             test_aggregate_config.aggregate_inference_results_prefix,
             "run_output_identifier",
-            f"{document_id}.json",
+            f"{document_stem}.json",
         ),
     )
     assert response["ContentLength"] > 0
@@ -237,7 +240,7 @@ async def test_process_single_document__success(
         Key=os.path.join(
             test_aggregate_config.aggregate_inference_results_prefix,
             "latest",
-            f"{document_id}.json",
+            f"{document_stem}.json",
         ),
     )
     assert response["ContentLength"] > 0
@@ -247,7 +250,7 @@ async def test_process_single_document__success(
 async def test_process_single_document__client_error(
     mock_bucket_labelled_passages_large, mock_classifier_specs, test_aggregate_config
 ):
-    document_id = "CCLW.executive.10061.4515"
+    document_stem = DocumentStem("CCLW.executive.10061.4515")
     spec_file_path, classifier_specs = mock_classifier_specs
     classifier_specs.append(ClassifierSpec(name="Q9999999999", alias="v99"))
     write_spec_file(spec_file_path, classifier_specs)
@@ -255,7 +258,7 @@ async def test_process_single_document__client_error(
     session = aioboto3.Session(region_name=test_aggregate_config.bucket_region)
     result = await asyncio.gather(
         process_document.fn(
-            document_id,
+            document_stem,
             session,
             classifier_specs,
             test_aggregate_config,
@@ -278,7 +281,7 @@ async def test_process_single_document__value_error(
     keys, bucket, s3_async_client = mock_bucket_labelled_passages_large
     _, classifier_specs = mock_classifier_specs
 
-    document_id = DocumentImportId("CCLW.executive.10061.4515")
+    document_stem = DocumentStem("CCLW.executive.10061.4515")
 
     # Replace the doc with a broken  one
     new_data = [
@@ -295,7 +298,7 @@ async def test_process_single_document__value_error(
     session = aioboto3.Session(region_name=test_aggregate_config.bucket_region)
     result = await asyncio.gather(
         process_document.fn(
-            document_id,
+            document_stem,
             session,
             classifier_specs,
             test_aggregate_config,

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -9,6 +9,7 @@ import boto3
 import pytest
 
 from flows.utils import (
+    DocumentStem,
     SlackNotify,
     collect_unique_file_stems_under_prefix,
     file_name_from_path,
@@ -168,10 +169,10 @@ def test_collect_file_stems_under_prefix(test_config, mock_bucket) -> None:
 
     assert set(file_stems) == set(
         [
-            "CCLW.executive.1.1",
-            "CCLW.executive.2.2",
-            "CCLW.executive.2.2_translated_en",
-            "CCLW.executive.3.3",
+            DocumentStem("CCLW.executive.1.1"),
+            DocumentStem("CCLW.executive.2.2"),
+            DocumentStem("CCLW.executive.2.2_translated_en"),
+            DocumentStem("CCLW.executive.3.3"),
         ]
     )
 


### PR DESCRIPTION
This Pull Request: 
---
- Refactors the use of `DocumentId` to `DocumentStem` in aggregate inference results KG pipeline. 
- This is required as in the labelled passages pipeline we read in document stems and persist this to the output.
- This means that we have labelled passages with the translated suffix and thus cannot be read via document id. 
- Discussion on any splash damage of the misuse of document ids has been listed on the ticket. 