### PR TITLE
fix: Remove unused import

### DIFF
--- a/flows/index.py
+++ b/flows/index.py
@@ -14,7 +14,6 @@ from cpr_sdk.models.search import Passage as VespaPassage
 from prefect import flow, task, unmapped
 from prefect.artifacts import create_markdown_artifact, create_table_artifact
 from prefect.client.schemas.objects import FlowRun
-from prefect.deployments import run_deployment  # noqa: F401
 from prefect.logging import get_run_logger
 from prefect.task_runners import ThreadPoolTaskRunner
 from prefect.utilities.names import generate_slug


### PR DESCRIPTION
This wasn't being warned about via linting since it had the ignore directive.

FIXES PLA-737
