### PR TITLE
feat: spec reader interface for specs with more data

### DIFF
--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+from scripts.cloud import AwsEnv
+from src.identifiers import WikibaseID
+
+SPEC_DIR = Path("flows") / "classifier_specs" / "v2"
+
+
+class ClassifierSpec(BaseModel):
+    """Details for a classifier to run."""
+
+    wikibase_id: WikibaseID = Field(
+        description=(
+            "The wikibase id for the underlying concept being classified. e.g. 'Q992'"
+        ),
+    )
+    classifier_id: str = Field(
+        description=(
+            "The unique identifier for the classifier, built from its internals."
+        ),
+    )
+    wandb_registry_version: int = Field(
+        description=("The version of the classifier in wandb registry. e.g. 1"),
+    )
+    gpu: bool = Field(
+        description=("Whether the classifier should be run on a GPU."),
+        default=False,
+    )
+    only_run_on: list[str] = Field(
+        description=(
+            "The source of documents to classify. If not provided, the classifier will"
+            "be run on all sources. Sources are the first part of a document id, e.g. "
+            "'sabin' in 'sabin.document.1.1', or 'UNFCCC' in 'UNFCCC.document.1.1'"
+        ),
+        default=None,
+    )
+
+    def __hash__(self):
+        """Make ClassifierSpec hashable for use in sets and as dict keys."""
+        return hash((self.wikibase_id, self.classifier_id))
+
+    def __str__(self):
+        """Return a string representation of the classifier spec."""
+        return f"{self.wikibase_id}:{self.classifier_id}"
+
+
+def determine_spec_file_path(aws_env: AwsEnv, spec_dir: Path = SPEC_DIR) -> Path:
+    """Determine the path to the spec file for a given AWS environment."""
+    return spec_dir / f"{aws_env}.yaml"
+
+
+def load_classifier_specs(
+    aws_env: AwsEnv, spec_dir: Path = SPEC_DIR
+) -> list[ClassifierSpec]:
+    """Load classifier specs into python for a given environment."""
+    file_path = determine_spec_file_path(aws_env, spec_dir)
+
+    with open(file_path, "r") as file:
+        contents = yaml.load(file, Loader=yaml.FullLoader)
+
+    classifier_specs = []
+    for spec in contents:
+        classifier_specs.append(ClassifierSpec.model_validate(spec))
+
+    return classifier_specs
+
+
+if __name__ == "__main__":
+    classifier_specs = load_classifier_specs(AwsEnv("sandbox"))
+    print(classifier_specs)

--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -4,7 +4,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 from scripts.cloud import AwsEnv
-from src.identifiers import WikibaseID
+from src.identifiers import Identifier, WikibaseID
 
 SPEC_DIR = Path("flows") / "classifier_specs" / "v2"
 
@@ -17,7 +17,7 @@ class ClassifierSpec(BaseModel):
             "The wikibase id for the underlying concept being classified. e.g. 'Q992'"
         ),
     )
-    classifier_id: str = Field(
+    classifier_id: Identifier = Field(
         description=(
             "The unique identifier for the classifier, built from its internals."
         ),

--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 import yaml
 from pydantic import BaseModel, Field
@@ -11,6 +12,14 @@ SPEC_DIR = Path("flows") / "classifier_specs" / "v2"
 
 class ClassifierSpec(BaseModel):
     """Details for a classifier to run."""
+
+    class ComputeEnvironment(BaseModel):
+        """Details about the compute environment the classifier should on."""
+
+        gpu: bool = Field(
+            description=("Whether the classifier should be run on a GPU."),
+            default=False,
+        )
 
     wikibase_id: WikibaseID = Field(
         description=(
@@ -26,9 +35,9 @@ class ClassifierSpec(BaseModel):
         description=("The version of the classifier in wandb registry. e.g. v1"),
         pattern=r"^v\d+$",
     )
-    gpu: bool = Field(
-        description=("Whether the classifier should be run on a GPU."),
-        default=False,
+    compute_environment: Optional[ComputeEnvironment] = Field(
+        description=ComputeEnvironment.__doc__,
+        default=None,
     )
 
     def __hash__(self):

--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -29,14 +29,6 @@ class ClassifierSpec(BaseModel):
         description=("Whether the classifier should be run on a GPU."),
         default=False,
     )
-    only_run_on: list[str] = Field(
-        description=(
-            "The source of documents to classify. If not provided, the classifier will"
-            "be run on all sources. Sources are the first part of a document id, e.g. "
-            "'sabin' in 'sabin.document.1.1', or 'UNFCCC' in 'UNFCCC.document.1.1'"
-        ),
-        default=None,
-    )
 
     def __hash__(self):
         """Make ClassifierSpec hashable for use in sets and as dict keys."""

--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -22,8 +22,9 @@ class ClassifierSpec(BaseModel):
             "The unique identifier for the classifier, built from its internals."
         ),
     )
-    wandb_registry_version: int = Field(
-        description=("The version of the classifier in wandb registry. e.g. 1"),
+    wandb_registry_version: str = Field(
+        description=("The version of the classifier in wandb registry. e.g. v1"),
+        pattern=r"^v\d+$",
     )
     gpu: bool = Field(
         description=("Whether the classifier should be run on a GPU."),

--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -32,7 +32,7 @@ class ClassifierSpec(BaseModel):
 
     def __hash__(self):
         """Make ClassifierSpec hashable for use in sets and as dict keys."""
-        return hash((self.wikibase_id, self.classifier_id))
+        return hash(self.classifier_id)
 
     def __str__(self):
         """Return a string representation of the classifier spec."""

--- a/flows/classifier_specs/v2/sandbox.yaml
+++ b/flows/classifier_specs/v2/sandbox.yaml
@@ -1,0 +1,16 @@
+---
+- wikibase_id: Q368
+  classifier_id: ju9239oi
+  wandb_registry_version: 3
+  gpu: True
+- wikibase_id: Q123
+  classifier_id: x438f30k
+  wandb_registry_version: 1
+  extra_info:
+    - key: "extra_info"
+      value: "extra_value"
+- wikibase_id: Q999
+  classifier_id: ju3f93jf
+  wandb_registry_version: 2
+  only_run_on:
+    - sabin

--- a/flows/classifier_specs/v2/sandbox.yaml
+++ b/flows/classifier_specs/v2/sandbox.yaml
@@ -12,5 +12,3 @@
 - wikibase_id: Q999
   classifier_id: ju3f93jf
   wandb_registry_version: 2
-  only_run_on:
-    - sabin

--- a/flows/classifier_specs/v2/sandbox.yaml
+++ b/flows/classifier_specs/v2/sandbox.yaml
@@ -2,7 +2,8 @@
 - wikibase_id: Q368
   classifier_id: ju9239oi
   wandb_registry_version: v3
-  gpu: True
+  compute_environment:
+    gpu: true
 - wikibase_id: Q123
   classifier_id: x438f30k
   wandb_registry_version: v1

--- a/flows/classifier_specs/v2/sandbox.yaml
+++ b/flows/classifier_specs/v2/sandbox.yaml
@@ -1,14 +1,14 @@
 ---
 - wikibase_id: Q368
   classifier_id: ju9239oi
-  wandb_registry_version: 3
+  wandb_registry_version: v3
   gpu: True
 - wikibase_id: Q123
   classifier_id: x438f30k
-  wandb_registry_version: 1
+  wandb_registry_version: v1
   extra_info:
     - key: "extra_info"
       value: "extra_value"
 - wikibase_id: Q999
   classifier_id: ju3f93jf
-  wandb_registry_version: 2
+  wandb_registry_version: v2

--- a/src/identifiers.py
+++ b/src/identifiers.py
@@ -131,7 +131,7 @@ class Identifier(str):
         return cls(identifier)
 
     @classmethod
-    def _validate(cls, value: str) -> str:
+    def _validate(cls, value: str, field=None) -> str:
         """Validate that the Identifier string is in the correct format"""
         if not isinstance(value, str):
             raise TypeError(

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -42,7 +42,6 @@ from src.identifiers import WikibaseID
                 "classifier_id": "test_classifier",
                 "wandb_registry_version": 1,
                 "gpu": True,
-                "only_run_on": ["UNFCCC", "Sabin"],
             },
             does_not_raise(),
         ),
@@ -70,9 +69,6 @@ def test_load_classifier_specs():
         - wikibase_id: Q999
           classifier_id: ju3f93jf
           wandb_registry_version: 2
-          only_run_on:
-            - sabin
-            - unfccc
     """).lstrip()
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -1,0 +1,87 @@
+import tempfile
+import textwrap
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from flows.classifier_specs.spec_interface import ClassifierSpec, load_classifier_specs
+from scripts.cloud import AwsEnv
+from src.identifiers import WikibaseID
+
+
+@pytest.mark.parametrize(
+    ("spec_dict", "expectation"),
+    [
+        (  # missing required fields - bad
+            {},
+            pytest.raises(ValidationError),
+        ),
+        (
+            {  # missing optional fields - fine
+                "wikibase_id": WikibaseID("Q123"),
+                "classifier_id": "test_classifier",
+                "wandb_registry_version": 1,
+            },
+            does_not_raise(),
+        ),
+        (
+            {  # extra fields - fine
+                "wikibase_id": WikibaseID("Q123"),
+                "classifier_id": "test_classifier",
+                "wandb_registry_version": 1,
+                "extra_info": "will be ignored",
+            },
+            does_not_raise(),
+        ),
+        (
+            {  # all fields - fine
+                "wikibase_id": WikibaseID("Q123"),
+                "classifier_id": "test_classifier",
+                "wandb_registry_version": 1,
+                "gpu": True,
+                "only_run_on": ["UNFCCC", "Sabin"],
+            },
+            does_not_raise(),
+        ),
+    ],
+)
+def test_classifier_spec_creation(spec_dict, expectation):
+    """Test creating a ClassifierSpec with the new fields."""
+    # missing required fields
+    with expectation:
+        ClassifierSpec(**spec_dict)
+
+
+def test_load_classifier_specs():
+    """Test loading classifier specs from a YAML file."""
+    sample_data = textwrap.dedent("""
+        ---
+        - wikibase_id: Q368
+          classifier_id: ju9239oi
+          wandb_registry_version: 3
+          gpu: True
+        - wikibase_id: Q123
+          classifier_id: x438f30k
+          wandb_registry_version: 1
+          extra_info: will be ignored
+        - wikibase_id: Q999
+          classifier_id: ju3f93jf
+          wandb_registry_version: 2
+          only_run_on:
+            - sabin
+            - unfccc
+    """).lstrip()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_spec_dir = Path(temp_dir)
+        spec_file = temp_spec_dir / "sandbox.yaml"
+        with open(spec_file, "w") as f:
+            f.write(sample_data)
+
+        with patch("flows.classifier_specs.spec_interface.SPEC_DIR", temp_spec_dir):
+            specs = load_classifier_specs(AwsEnv("sandbox"))
+
+        assert len(specs) == 3

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -48,7 +48,9 @@ from src.identifiers import Identifier, WikibaseID
                 "wikibase_id": WikibaseID("Q123"),
                 "classifier_id": Identifier("abcd2345"),
                 "wandb_registry_version": "v1",
-                "gpu": True,
+                "compute_environment": {
+                    "gpu": True,
+                },
             },
             does_not_raise(),
         ),
@@ -68,7 +70,8 @@ def test_load_classifier_specs():
         - wikibase_id: Q368
           classifier_id: abcd2345
           wandb_registry_version: v3
-          gpu: True
+          compute_environment:
+            gpu: true
         - wikibase_id: Q123
           classifier_id: abcd2345
           wandb_registry_version: v1
@@ -87,3 +90,5 @@ def test_load_classifier_specs():
         specs = load_classifier_specs(AwsEnv("sandbox"), spec_dir=temp_spec_dir)
 
         assert len(specs) == 3
+        assert specs[0].compute_environment.gpu
+        assert not specs[1].compute_environment

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from flows.classifier_specs.spec_interface import ClassifierSpec, load_classifier_specs
 from scripts.cloud import AwsEnv
-from src.identifiers import WikibaseID
+from src.identifiers import Identifier, WikibaseID
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ from src.identifiers import WikibaseID
         (
             {  # Bad registry version - bad
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": "test_classifier",
+                "classifier_id": Identifier("abcd2345"),
                 "wandb_registry_version": "latest",
             },
             pytest.raises(ValidationError),
@@ -29,7 +29,7 @@ from src.identifiers import WikibaseID
         (
             {  # missing optional fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": "test_classifier",
+                "classifier_id": Identifier("abcd2345"),
                 "wandb_registry_version": "v1",
             },
             does_not_raise(),
@@ -37,7 +37,7 @@ from src.identifiers import WikibaseID
         (
             {  # extra fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": "test_classifier",
+                "classifier_id": Identifier("abcd2345"),
                 "wandb_registry_version": "v1",
                 "extra_info": "will be ignored",
             },
@@ -46,7 +46,7 @@ from src.identifiers import WikibaseID
         (
             {  # all fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": "test_classifier",
+                "classifier_id": Identifier("abcd2345"),
                 "wandb_registry_version": "v1",
                 "gpu": True,
             },
@@ -66,15 +66,15 @@ def test_load_classifier_specs():
     sample_data = textwrap.dedent("""
         ---
         - wikibase_id: Q368
-          classifier_id: ju9239oi
+          classifier_id: abcd2345
           wandb_registry_version: v3
           gpu: True
         - wikibase_id: Q123
-          classifier_id: x438f30k
+          classifier_id: abcd2345
           wandb_registry_version: v1
           extra_info: will be ignored
         - wikibase_id: Q999
-          classifier_id: ju3f93jf
+          classifier_id: abcd2345
           wandb_registry_version: v2
     """).lstrip()
 


### PR DESCRIPTION
We are moving to having specs with more data included in them. This starts an interface for working with these new file structures. There was plenty of code existing spread out that interfaces with the old files, this begins to consolidate that for the new files.

More work will be needed to update before and after this point in the lifecycle (i.e. training, inference, etc). The basic reading of these files seemed like a good place to start as these tie everything else together.