### PR TITLE
feat: Add progress reporting

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -10,16 +10,31 @@ from dataclasses import dataclass, field
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Callable, NewType, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Literal,
+    NewType,
+    ParamSpec,
+    TypeVar,
+    overload,
+)
+from uuid import UUID
 
 import boto3
 from botocore.exceptions import ClientError
+from prefect.artifacts import (
+    create_progress_artifact,
+    update_progress_artifact,
+)
 from prefect.client.schemas.objects import FlowRun, StateType
 from prefect.deployments import run_deployment
 from prefect.flows import Flow
 from prefect.settings import PREFECT_UI_URL
+from prefect.utilities.names import generate_slug
 from prefect_slack.credentials import SlackWebhook
-from pydantic import PositiveInt
+from pydantic import Field, PositiveInt, RootModel
 from typing_extensions import Self
 
 from scripts.cloud import (
@@ -451,21 +466,83 @@ async def return_with(
         return (accompaniment, e)
 
 
-def fn_is_async(fn: Callable[..., Any] | Flow) -> bool:
+# Match what Prefect uses for Flows:
+#
+# > .. we use the generic type variables `P` and `R` for "Parameters"
+# > and "Returns" respectively.
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def fn_is_async(fn: Callable[..., Any] | Flow[P, R]) -> bool:
     """Check if a function is async."""
     if isinstance(fn, Flow):
         return fn.isasync  # type: ignore[reportFunctionMemberAccess]
     return inspect.iscoroutinefunction(fn)
 
 
+class Percentage(
+    RootModel[
+        Annotated[
+            float,
+            Field(ge=0.0, le=100.0),
+        ]
+    ]
+):
+    """A percentage"""
+
+    def __str__(self) -> str:
+        """Return as string"""
+        return f"{self.root}%"
+
+    def __repr__(self) -> str:
+        """Return as string representation"""
+        return f"{self.__name__}({self.root})"
+
+    def __float__(self) -> float:
+        """Enable automatic conversion to float"""
+        return self.root
+
+    def to_float(self: Self) -> float:
+        """Return as a float"""
+        return float(self)
+
+    @staticmethod
+    def from_lists(r: Sequence[T], t: Sequence[U]) -> "Percentage":
+        """Relative size of 2 lists as a precentage."""
+        return Percentage((len(r) / len(t)) * 100.0)
+
+
+@overload
 async def map_as_sub_flow(
-    fn: Callable[..., Awaitable[U]],
+    fn: Flow[P, R],
+    aws_env: AwsEnv,
+    counter: PositiveInt,
+    batches: Generator[Sequence[T], None, None],
+    parameters: Callable[[Sequence[T]], dict[str, Any]],
+    unwrap_result: Literal[True],
+) -> tuple[Sequence[R], Sequence[BaseException | FlowRun]]: ...
+
+
+@overload
+async def map_as_sub_flow(
+    fn: Flow[P, R],
+    aws_env: AwsEnv,
+    counter: PositiveInt,
+    batches: Generator[Sequence[T], None, None],
+    parameters: Callable[[Sequence[T]], dict[str, Any]],
+    unwrap_result: Literal[False],
+) -> tuple[Sequence[FlowRun], Sequence[BaseException | FlowRun]]: ...
+
+
+async def map_as_sub_flow(
+    fn: Flow[P, R],
     aws_env: AwsEnv,
     counter: PositiveInt,
     batches: Generator[Sequence[T], None, None],
     parameters: Callable[[Sequence[T]], dict[str, Any]],
     unwrap_result: bool,
-) -> tuple[Sequence[U | FlowRun], Sequence[BaseException | FlowRun]]:
+) -> tuple[Sequence[R | FlowRun], Sequence[BaseException | FlowRun]]:
     """
     Map over an iterable, running the function as a sub-flow.
 
@@ -482,15 +559,16 @@ async def map_as_sub_flow(
 
     This assumes that the same parameters are used for each sub-flow run
     """
-    flow_name = function_to_flow_name(fn)
+    flow_name = function_to_flow_name(fn.fn)
     deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
+    qualified_name = f"{flow_name}/{deployment_name}"
     semaphore = asyncio.Semaphore(counter)
 
     tasks = [
         wait_for_semaphore(
             semaphore,
             run_deployment(
-                name=f"{flow_name}/{deployment_name}",
+                name=qualified_name,
                 parameters=parameters(batch),
                 # Rely on the flow's own timeout, if any, to make sure it
                 # eventually ends[1].
@@ -504,12 +582,18 @@ async def map_as_sub_flow(
         for batch in batches
     ]
 
-    results: Sequence[FlowRun | BaseException] = await asyncio.gather(
-        *tasks,
+    def desc_update_fn(tasks, results) -> str:
+        return f"Finished sub-flow for {qualified_name}, progressing to {len(results)}/{len(tasks)} finished"
+
+    results: Sequence[FlowRun | BaseException] = await gather_and_report(
+        tasks=tasks,
         return_exceptions=True,
+        key=f"progress-sub-flows-{generate_slug(2)}",
+        desc_create=f"Starting sub-flows for {qualified_name} for {len(tasks)} tasks",
+        desc_update_fn=desc_update_fn,
     )
 
-    successes: list[U] = []
+    successes: list[R | FlowRun] = []
     failures: list[BaseException | FlowRun] = []
     for result in results:
         if isinstance(result, BaseException):
@@ -527,7 +611,7 @@ async def map_as_sub_flow(
                             # the return.
                             raise_on_failure=True,
                         )
-                        flow_result: U = (
+                        flow_result: R = (
                             await result_fn() if fn_is_async(fn) else result_fn()
                         )
                         successes.append(flow_result)
@@ -555,3 +639,61 @@ class Fault(Exception):
         if self.metadata is None:
             return self.msg
         return f"{self.msg} | metadata: {json.dumps(self.metadata, default=str)}"
+
+
+def default_desc(tasks, results) -> str:
+    return f"Finished task {len(results)} of {len(tasks)}"
+
+
+@overload
+async def gather_and_report(
+    tasks: Sequence[Awaitable[T]],
+    return_exceptions: Literal[True],
+    key: str,
+    desc_create: str,
+    desc_update_fn: Callable[[Sequence[Any], list[Any]], str] = default_desc,
+) -> Sequence[T | Exception]: ...
+
+
+@overload
+async def gather_and_report(
+    tasks: Sequence[Awaitable[T]],
+    return_exceptions: Literal[False],
+    key: str,
+    desc_create: str,
+    desc_update_fn: Callable[[Sequence[Any], list[Any]], str] = default_desc,
+) -> Sequence[T]: ...
+
+
+async def gather_and_report(
+    tasks: Sequence[Awaitable[T]],
+    return_exceptions: bool,
+    key: str,
+    desc_create: str,
+    desc_update_fn: Callable[[Sequence[Any], list[Any]], str] = default_desc,
+) -> Sequence[T] | Sequence[T | Exception]:
+    progress_artifact_id: UUID = await create_progress_artifact(
+        progress=0.0,
+        key=key,
+        description=desc_create,
+    )
+
+    results = []
+
+    for future in asyncio.as_completed(tasks):
+        try:
+            result = await future
+            results.append(result)
+        except Exception as e:
+            if return_exceptions:
+                results.append(e)
+            else:
+                raise e
+        finally:
+            await update_progress_artifact(
+                artifact_id=progress_artifact_id,
+                progress=Percentage.from_lists(results, tasks).to_float(),
+                description=desc_update_fn(tasks, results),
+            )
+
+    return results

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -1,9 +1,11 @@
+import asyncio
 import os
 import re
 import time
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -16,6 +18,7 @@ from flows.utils import (
     file_name_from_path,
     filter_non_english_language_file_stems,
     fn_is_async,
+    gather_and_report,
     get_file_stems_for_document_id,
     get_labelled_passage_paths,
     iterate_batch,
@@ -292,3 +295,203 @@ def test_fn_is_async():
 
     assert fn_is_async(async_flow)
     assert not fn_is_async(sync_flow)
+
+
+@pytest.fixture
+def mock_progress_artifacts():
+    """Fixture to mock progress artifact functions and return their IDs."""
+    with (
+        patch(
+            "flows.utils.create_progress_artifact", new_callable=AsyncMock
+        ) as mock_create,
+        patch(
+            "flows.utils.update_progress_artifact", new_callable=AsyncMock
+        ) as mock_update,
+    ):
+        mock_artifact_id = uuid4()
+        mock_create.return_value = mock_artifact_id
+        yield {
+            "create": mock_create,
+            "update": mock_update,
+            "artifact_id": mock_artifact_id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_gather_and_report_calls_progress_artifacts(mock_progress_artifacts):
+    """Test that gather_and_report calls create_progress_artifact and update_progress_artifact."""
+    mock_create_progress_artifact = mock_progress_artifacts["create"]
+    mock_update_progress_artifact = mock_progress_artifacts["update"]
+    mock_artifact_id = mock_progress_artifacts["artifact_id"]
+
+    # Create some async tasks to gather
+    async def sample_task(value):
+        await asyncio.sleep(0.01)  # Small delay to simulate work
+        return value * 2
+
+    tasks = [sample_task(i) for i in range(3)]
+
+    # Call gather_and_report
+    results = await gather_and_report(
+        tasks=tasks,
+        return_exceptions=False,
+        key="test-progress-key",
+        desc_create="Starting test tasks",
+        desc_update_fn=lambda tasks,
+        results: f"Completed {len(results)}/{len(tasks)} tasks",
+    )
+
+    # Verify results (order may vary due to asyncio.as_completed)
+    assert sorted(results) == [0, 2, 4]
+
+    # Verify create_progress_artifact was called once
+    mock_create_progress_artifact.assert_called_once_with(
+        progress=0.0,
+        key="test-progress-key",
+        description="Starting test tasks",
+    )
+
+    # Verify update_progress_artifact was called for each completed task
+    assert mock_update_progress_artifact.call_count == 3
+
+    # Check that all calls to update_progress_artifact used the correct artifact_id
+    for call in mock_update_progress_artifact.call_args_list:
+        _args, kwargs = call
+        assert kwargs["artifact_id"] == mock_artifact_id
+
+
+@pytest.mark.asyncio
+async def test_gather_and_report_with_exceptions(mock_progress_artifacts):
+    """Test that gather_and_report calls progress artifacts even when tasks raise exceptions."""
+    mock_create_progress_artifact = mock_progress_artifacts["create"]
+    mock_update_progress_artifact = mock_progress_artifacts["update"]
+
+    # Create tasks that will raise exceptions
+    async def failing_task():
+        await asyncio.sleep(0.01)
+        raise ValueError("Test error")
+
+    async def success_task():
+        await asyncio.sleep(0.01)
+        return "success"
+
+    tasks = [failing_task(), success_task(), failing_task()]
+
+    # Call gather_and_report with return_exceptions=True
+    results = await gather_and_report(
+        tasks=tasks,
+        return_exceptions=True,
+        key="test-error-key",
+        desc_create="Starting tasks with errors",
+    )
+
+    # Verify results contain both exceptions and successful values
+    # (order may vary)
+    assert len(results) == 3
+    success_results = [r for r in results if r == "success"]
+    error_results = [r for r in results if isinstance(r, ValueError)]
+    assert len(success_results) == 1
+    assert len(error_results) == 2
+
+    # Verify create_progress_artifact was called once
+    mock_create_progress_artifact.assert_called_once_with(
+        progress=0.0,
+        key="test-error-key",
+        description="Starting tasks with errors",
+    )
+
+    # Verify update_progress_artifact was called for each task
+    # (including failed ones)
+    assert mock_update_progress_artifact.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_gather_and_report_matches_asyncio_gather(mock_progress_artifacts):
+    """Test that gather_and_report produces the same results as asyncio.gather."""
+
+    # Create test tasks with deterministic results
+    async def task_add(x, y):
+        await asyncio.sleep(0.001)  # Minimal delay
+        return x + y
+
+    async def task_multiply(x, y):
+        await asyncio.sleep(0.001)
+        return x * y
+
+    async def task_power(x, y):
+        await asyncio.sleep(0.001)
+        return x**y
+
+    tasks_for_gather = [task_add(2, 3), task_multiply(4, 5), task_power(2, 3)]
+    tasks_for_gather_and_report = [
+        task_add(2, 3),
+        task_multiply(4, 5),
+        task_power(2, 3),
+    ]
+
+    gather_results = await asyncio.gather(*tasks_for_gather, return_exceptions=False)
+    gather_and_report_results = await gather_and_report(
+        tasks=tasks_for_gather_and_report,
+        return_exceptions=False,
+        key="comparison-test",
+        desc_create="Comparing with asyncio.gather",
+    )
+
+    assert sorted(gather_results) == sorted(gather_and_report_results) == [5, 8, 20]
+
+
+@pytest.mark.asyncio
+async def test_gather_and_report_matches_asyncio_gather_with_exceptions(
+    mock_progress_artifacts,
+):
+    """Test that gather_and_report handles exceptions the same as asyncio.gather."""
+
+    async def success_task(value):
+        await asyncio.sleep(0.001)
+        return value * 2
+
+    async def failing_task(error_msg):
+        await asyncio.sleep(0.001)
+        raise ValueError(error_msg)
+
+    tasks_for_gather = [
+        success_task(10),
+        failing_task("error1"),
+        success_task(20),
+        failing_task("error2"),
+    ]
+    tasks_for_gather_and_report = [
+        success_task(10),
+        failing_task("error1"),
+        success_task(20),
+        failing_task("error2"),
+    ]
+
+    gather_results = await asyncio.gather(*tasks_for_gather, return_exceptions=True)
+    gather_and_report_results = await gather_and_report(
+        tasks=tasks_for_gather_and_report,
+        return_exceptions=True,
+        key="exception-comparison-test",
+        desc_create="Comparing exceptions with asyncio.gather",
+    )
+
+    assert len(gather_results) == len(gather_and_report_results) == 4
+
+    gather_successes = [r for r in gather_results if not isinstance(r, Exception)]
+    gather_exceptions = [r for r in gather_results if isinstance(r, Exception)]
+
+    report_successes = [
+        r for r in gather_and_report_results if not isinstance(r, Exception)
+    ]
+    report_exceptions = [
+        r for r in gather_and_report_results if isinstance(r, Exception)
+    ]
+
+    assert len(gather_successes) == len(report_successes) == 2
+    assert len(gather_exceptions) == len(report_exceptions) == 2
+
+    assert sorted(gather_successes) == sorted(report_successes) == [20, 40]
+
+    gather_error_messages = sorted([str(e) for e in gather_exceptions])
+    report_error_messages = sorted([str(e) for e in report_exceptions])
+    assert gather_error_messages == report_error_messages == ["error1", "error2"]


### PR DESCRIPTION
Use the Prefect [progress kind of artifact](https://docs.prefect.io/v3/how-to-guides/workflows/artifacts#create-progress-artifacts) for places where it either takes generally a while and/or there's a lot of things to enumerate through.

I've tried to make it as _for free_ as possible, so it's in the sub-flow mapping function, and I've created a gather equivalent.

More can be done as we go along in the repository.

**Demo**

Flow run: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/06881402-67a0-797b-8000-7ccc08a829e7
1. 0%
<img width="2173" height="1320" alt="CleanShot 2025-07-23 at 21 04 02" src="https://github.com/user-attachments/assets/ab3b472f-adb0-4f5f-9144-399d3504dc53" />

2. 50%

<img width="2173" height="1320" alt="CleanShot 2025-07-23 at 21 06 16" src="https://github.com/user-attachments/assets/09ca4ca6-ae55-4110-a51b-223c15bb8edb" />

3. 100%

<img width="2173" height="1320" alt="CleanShot 2025-07-23 at 21 07 21" src="https://github.com/user-attachments/assets/2fc02fec-2f2a-465d-933f-f27c22f64a42" />


FIXES PLA-610
