### PR TITLE
Feature/pla 760 remove state return types in inference pipeline

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -1046,7 +1046,7 @@ async def inference(
     )
 
     if inference_result.failed:
-        return Fault(
+        raise Fault(
             msg="Some inference batches had failures!",
             metadata={},
             data=inference_result,

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -21,7 +21,6 @@ from prefect.client.schemas.objects import FlowRun
 from prefect.concurrency.asyncio import concurrency
 from prefect.context import get_run_context
 from prefect.logging import get_run_logger
-from prefect.states import Completed, Failed, State
 from prefect.utilities.names import generate_slug
 from pydantic import BaseModel, ConfigDict, PositiveInt, SecretStr
 from types_aiobotocore_s3.type_defs import PutObjectOutputTypeDef
@@ -794,7 +793,7 @@ async def inference_batch_of_documents(
     config_json: dict,
     classifier_name: str,
     classifier_alias: str,
-) -> State:
+) -> BatchInferenceResult | Fault:
     """
     Run classifier inference on a batch of documents.
 
@@ -911,18 +910,12 @@ async def inference_batch_of_documents(
             f"Failed to run inference on {len(inferences_failures) + len(inferences_unknown_failures)}/"
             f"{len(results)} documents."
         )
-        return Failed(
-            message=message,
-            data=Fault(
-                msg=message,
-                metadata={},
-                data=batch_inference_result.model_dump(),
-            ),
+        raise Fault(
+            msg=message,
+            metadata={},
+            data=batch_inference_result,
         )
-    return Completed(
-        message=f"Successfully ran inference on all ({len(results)}) documents in batch.",
-        data=batch_inference_result.model_dump(),
-    )
+    return batch_inference_result
 
 
 @Profiler(
@@ -961,7 +954,7 @@ async def inference(
     config: Config | None = None,
     batch_size: int = INFERENCE_BATCH_SIZE_DEFAULT,
     classifier_concurrency_limit: PositiveInt = CLASSIFIER_CONCURRENCY_LIMIT,
-) -> State:
+) -> InferenceResult | Fault:
     """
     Flow to run inference on documents within a bucket prefix.
 
@@ -1053,19 +1046,12 @@ async def inference(
     )
 
     if inference_result.failed:
-        message = "Some inference batches had failures!"
-        return Failed(
-            message=message,
-            data=Fault(
-                msg=message,
-                metadata={},
-                data=inference_result.model_dump(),
-            ),
+        return Fault(
+            msg="Some inference batches had failures!",
+            metadata={},
+            data=inference_result,
         )
-    return Completed(
-        message="Successfully ran inference on all batches!",
-        data=inference_result.model_dump(),
-    )
+    return inference_result
 
 
 async def create_inference_summary_artifact(

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -632,7 +632,7 @@ class Fault(Exception):
 
     msg: str
     metadata: dict[str, Any] | None
-    data: dict[str, Any] | None = None
+    data: Any | None = None
 
     def __str__(self) -> str:
         """Return a string representation"""

--- a/tests/flows/test_full_pipeline.py
+++ b/tests/flows/test_full_pipeline.py
@@ -172,7 +172,7 @@ async def test_full_pipeline_no_config_provided(
                     ),
                 ],
                 unexpected_failures=[],
-            ).model_dump(),
+            ),
         )
         mock_aggregate.return_value = State(
             type=StateType.COMPLETED,
@@ -253,7 +253,7 @@ async def test_full_pipeline_with_full_config(
                     ),
                 ],
                 unexpected_failures=[],
-            ).model_dump(),
+            ),
         )
         mock_aggregate.return_value = State(
             type=StateType.COMPLETED,
@@ -369,7 +369,7 @@ async def test_full_pipeline_with_inference_failure(
                         ),
                     ],
                     unexpected_failures=[],
-                ).model_dump(),
+                ),
             ),
         )
         mock_aggregate.return_value = State(

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -557,18 +557,12 @@ async def test_inference_batch_of_documents(
             return_state=True,
         )
 
-    assert (
-        result_state.message
-        == f"Successfully ran inference on all ({len(batch)}) documents in batch."
-    )
     result = await result_state.result()
-    assert isinstance(result, dict)
-    assert set(result.keys()) == set(BatchInferenceResult.model_fields.keys())
-    result_obj = BatchInferenceResult(**result)
-    assert result_obj.successful_document_stems == batch
-    assert result_obj.failed_document_stems == []
-    assert result_obj.classifier_name == classifier_name
-    assert result_obj.classifier_alias == classifier_alias
+    assert isinstance(result, BatchInferenceResult)
+    assert result.successful_document_stems == batch
+    assert result.failed_document_stems == []
+    assert result.classifier_name == classifier_name
+    assert result.classifier_alias == classifier_alias
 
     # Verify W&B was initialized
     mock_wandb_init.assert_called_once_with(
@@ -657,6 +651,7 @@ async def test_inference_batch_of_documents_with_failures(
         )
 
         assert exc_info.value.msg == "Failed to run inference on 2/2 documents."
+        assert isinstance(exc_info.value.data, BatchInferenceResult)
 
     # Even with failures, an artifact should be created to track the failures
     from prefect.client.orchestration import get_client


### PR DESCRIPTION
This Pull Request: 
---
- Updates the inference flows to no longer return prefect `States` but now the types we want.