### PR TITLE
test: always skip the tests that contact argilla

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: just vespa_dev_setup
 
       - name: Run tests
-        run: just test -v -m "'not flaky_on_ci and not transformers'" --ignore tests/test_labelling.py
+        run: just test -v -m "'not flaky_on_ci and not transformers'"
 
   deploy_prefect_sandbox:
     name: "Deploy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ env = [
   "AWS_ENV=sandbox",
   "WIKIBASE_USERNAME=test_username",
   "WIKIBASE_PASSWORD=test_password",
-  "WIKIBASE_URL=https://test.test.test"
+  "WIKIBASE_URL=https://test.test.test",
+  "ARGILLA_API_URL=http://localhost:6900",
+  "ARGILLA_API_KEY=argilla.apikey",
 ]
 markers = ["vespa", "flaky_on_ci", "transformers", "slow"]
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -8,6 +8,10 @@ from dotenv import find_dotenv, load_dotenv
 from src.labelling import ArgillaSession
 
 load_dotenv(find_dotenv())
+pytest.skip(
+    reason="These tests actually create a dataset in Argilla when run, so skipping",
+    allow_module_level=True,
+)
 
 
 def test_combine_datasets():


### PR DESCRIPTION
These tests were actually creating a dataset in argilla. Judging by the docstring it is not intended to be run on a normally in tests and that shows in ci where we ignore it. However when running locally its easy not to ignore this module, I've therefore set it to always skip for now. I've also ensured local env variables for argilla are not picked up on by defining them for pytest with test values.