### PR TITLE
PLA-769 Log count of excluded Sabin files

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -989,6 +989,12 @@ async def inference(
     )
     filtered_file_stems = remove_sabin_file_stems(validated_file_stems)
 
+    removed_sabin_file_count = len(validated_file_stems) - len(filtered_file_stems)
+
+    print(
+        f"excluded: {removed_sabin_file_count} Sabin files from being processed by the pipeline"
+    )
+
     if classifier_specs is None:
         classifier_specs = parse_spec_file(config.aws_env)
 


### PR DESCRIPTION
We currently exclude Sabin documents from being processed in the pipeline, but this is done silently. This commit counts the number of filtered Sabin documents and then print it to the console so it is visible when examining logs. Discovered as part of PLA-761