### PR TITLE
Refactor training to use classifier ID instead of name

### DIFF
--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -83,7 +83,11 @@ def main(
         console.log(f"✅ Created a {classifier}")
 
         # Save the classifier
-        classifier_path = get_local_classifier_path(concept, classifier)
+        target_path = f"{concept.wikibase_id}/{classifier.id}"
+        version = str(classifier.version if classifier.version else "v0")
+        classifier_path = get_local_classifier_path(
+            target_path=target_path, version=version
+        )
         classifier_path.parent.mkdir(parents=True, exist_ok=True)
         classifier.save(classifier_path)
         console.log(f"✅ Saved {classifier} to {classifier_path}")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -284,7 +284,7 @@ def main(
         # Save the classifier to a file locally
         classifier_path = get_local_classifier_path(
             target_path=target_path,
-            next_version=next_version,
+            version=next_version,
         )
         classifier_path.parent.mkdir(parents=True, exist_ok=True)
         classifier.save(classifier_path)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -94,7 +94,7 @@ def create_and_link_model_artifact(
     os.environ["AWS_PROFILE"] = storage_link.aws_env.value
 
     artifact = wandb.Artifact(  # type: ignore
-        name=classifier.name,
+        name=classifier.id,
         type="model",
         metadata=metadata,
     )
@@ -261,11 +261,12 @@ def main(
         classifier = ClassifierFactory.create(concept=concept)
         classifier.fit()
 
+        target_path = f"{namespace.project}/{classifier.id}"  # e.g. 'Q123/v4prnc54'
+
         # Lookup the next version (aka the new version) before saving, even if we're
         # not uploading or tracking, so the classifier has the correct version
-        target_path = (
-            f"{namespace.project}/{classifier.name}"  # e.g. 'Q123/KeywordClassifier'
-        )
+        # Note that as we use the id and the id changes whenever the model changes,
+        # the version would almost always be v0 in practice.
         next_version = get_next_version(
             namespace=namespace,
             target_path=target_path,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -88,7 +88,10 @@ def create_and_link_model_artifact(
     :return: The created W&B artifact.
     :rtype: wandb.Artifact
     """
-    metadata = {"aws_env": storage_link.aws_env.value}
+    metadata = {
+        "aws_env": storage_link.aws_env.value,
+        "classifier_name": classifier.name,
+    }
 
     # Set this, so W&B knows where to look for AWS credentials profile
     os.environ["AWS_PROFILE"] = storage_link.aws_env.value

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -257,18 +257,18 @@ def main(
         classifier = ClassifierFactory.create(concept=concept)
         classifier.fit()
 
-        # In both scenarios, we need the next version aka the new version
-        if track or upload:
-            next_version = get_next_version(
-                namespace,
-                wikibase_id,
-                classifier,
-            )
+        # Lookup the next version (aka the new version) before saving, even if we're
+        # not uploading or tracking, so the classifier has the correct version
+        next_version = get_next_version(
+            namespace,
+            wikibase_id,
+            classifier,
+        )
 
-            console.log(f"Using next version {next_version}")
+        console.log(f"Using next version {next_version}")
 
-            # Set this _before_ the model is saved to disk
-            classifier.version = Version(next_version)
+        # Set this _before_ the model is saved to disk
+        classifier.version = Version(next_version)
 
         # Save the classifier to a file with the concept ID in the name
         classifier_path = get_local_classifier_path(classifier)
@@ -281,7 +281,7 @@ def main(
             s3_client = get_s3_client(aws_env, region_name)
 
             storage_upload = StorageUpload(
-                next_version=next_version,  # type: ignore
+                next_version=next_version,
                 aws_env=aws_env,
             )
 
@@ -293,19 +293,17 @@ def main(
                 s3_client=s3_client,
             )
 
-        if track:
-            if upload:
-                storage_link = StorageLink(
-                    bucket=bucket,  # type: ignore
-                    key=key,  # type: ignore
-                    aws_env=aws_env,
-                )
+            storage_link = StorageLink(
+                bucket=bucket,
+                key=key,
+                aws_env=aws_env,
+            )
 
-                link_model_artifact(
-                    run,  # type: ignore
-                    classifier,
-                    storage_link,
-                )
+            link_model_artifact(
+                run,  # type: ignore
+                classifier,
+                storage_link,
+            )
 
     return classifier
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -175,7 +175,8 @@ def upload_model_artifact(
 
     key = os.path.join(
         storage_upload.target_path,
-        f"{storage_upload.next_version}.pickle",
+        storage_upload.next_version,
+        "model.pickle",
     )
 
     console.log(f"Uploading {classifier.name} to {key} in bucket {bucket}")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,10 +1,8 @@
 from pathlib import Path
 
 from scripts.config import classifier_dir
-from src.classifier import Classifier
 
 
-def get_local_classifier_path(classifier: Classifier) -> Path:
-    return (
-        classifier_dir / str(classifier.concept.wikibase_id) / f"{classifier.id}.pickle"
-    )
+def get_local_classifier_path(target_path: str, next_version: str) -> Path:
+    """Returns a path for a classifier file."""
+    return classifier_dir / target_path / f"{next_version}.pickle"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -5,4 +5,4 @@ from scripts.config import classifier_dir
 
 def get_local_classifier_path(target_path: str, version: str) -> Path:
     """Returns a path for a classifier file."""
-    return classifier_dir / target_path / f"{version}.pickle"
+    return classifier_dir / target_path / version / "model.pickle"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -3,6 +3,6 @@ from pathlib import Path
 from scripts.config import classifier_dir
 
 
-def get_local_classifier_path(target_path: str, next_version: str) -> Path:
+def get_local_classifier_path(target_path: str, version: str) -> Path:
     """Returns a path for a classifier file."""
-    return classifier_dir / target_path / f"{next_version}.pickle"
+    return classifier_dir / target_path / f"{version}.pickle"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,14 +1,10 @@
 from pathlib import Path
 
-from scripts.config import processed_data_dir
+from scripts.config import classifier_dir
 from src.classifier import Classifier
-from src.concept import Concept
 
 
-def get_local_classifier_path(concept: Concept, classifier: Classifier) -> Path:
+def get_local_classifier_path(classifier: Classifier) -> Path:
     return (
-        processed_data_dir
-        / Path("classifiers")
-        / str(concept.wikibase_id)
-        / f"{classifier.id}.pickle"
+        classifier_dir / str(classifier.concept.wikibase_id) / f"{classifier.id}.pickle"
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -9,8 +9,8 @@ from scripts.train import (
     Namespace,
     StorageLink,
     StorageUpload,
+    create_and_link_model_artifact,
     get_next_version,
-    link_model_artifact,
     main,
     upload_model_artifact,
 )
@@ -39,7 +39,9 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
     # Create a mock S3 client
     mock_s3_client = Mock()
 
+    target_path = "Q123/test_classifier"
     storage_upload = StorageUpload(
+        target_path=target_path,
         next_version="v3",
         aws_env=aws_env,
     )
@@ -49,7 +51,6 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
         classifier=mock_classifier,
         classifier_path=test_file_path,
         storage_upload=storage_upload,
-        namespace=Namespace(project=WikibaseID("Q123"), entity="test_entity"),
         s3_client=mock_s3_client,
     )
 
@@ -57,7 +58,7 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
     assert bucket == expected_bucket
 
     # Assert the key structure is correct
-    assert key == "Q123/test_classifier/v3/model.pickle"
+    assert key == "Q123/test_classifier/v3.pickle"
 
     # Verify that the upload_file method was called with correct arguments
     mock_s3_client.upload_file.assert_called_once_with(
@@ -82,7 +83,7 @@ def test_main_track_false_upload_true():
         )
 
 
-def test_link_model_artifact():
+def test_create_and_link_model_artifact():
     # Given there's a model that's been uploaded to S3
     mock_run = Mock()
     mock_classifier = Mock()
@@ -102,7 +103,7 @@ def test_link_model_artifact():
         mock_artifact_instance = Mock()
         mock_artifact_class.return_value = mock_artifact_instance
 
-        link_model_artifact(
+        create_and_link_model_artifact(
             mock_run,
             mock_classifier,
             storage_link,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -39,7 +39,7 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
     # Create a mock S3 client
     mock_s3_client = Mock()
 
-    target_path = "Q123/test_classifier"
+    target_path = "Q123/v4prnc54"
     storage_upload = StorageUpload(
         target_path=target_path,
         next_version="v3",
@@ -58,7 +58,7 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
     assert bucket == expected_bucket
 
     # Assert the key structure is correct
-    assert key == "Q123/test_classifier/v3.pickle"
+    assert key == "Q123/v4prnc54/v3.pickle"
 
     # Verify that the upload_file method was called with correct arguments
     mock_s3_client.upload_file.assert_called_once_with(
@@ -111,7 +111,7 @@ def test_create_and_link_model_artifact():
 
         # Then the artifact was created with correct parameters
         mock_artifact_class.assert_called_once_with(
-            name=mock_classifier.name,
+            name=mock_classifier.id,
             type="model",
             metadata={"aws_env": aws_env.value},
         )
@@ -136,10 +136,9 @@ def test_get_next_version_with_existing(mock_api):
 
     namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
     mock_classifier = Mock()
-    mock_classifier.name = "KeywordClassifier"
     mock_classifier.concept.wikibase_id = "Q123"
 
-    wandb_target_entity = f"{namespace.project}/{mock_classifier.name}"
+    wandb_target_entity = f"{namespace.project}/{mock_classifier.id}"
     next_version = get_next_version(namespace, wandb_target_entity, mock_classifier)
 
     assert next_version == "v3"
@@ -149,13 +148,12 @@ def test_get_next_version_with_existing(mock_api):
 def test_get_next_version_with_default(mock_api):
     namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
     mock_classifier = Mock()
-    mock_classifier.name = "KeywordClassifier"
     mock_classifier.concept.wikibase_id = "Q123"
 
     mock_api.side_effect = CommError(
         "artifact 'test_classifier:latest' not found in 'test_entity/Q123'"
     )
-    wandb_target_entity = f"{namespace.project}/{mock_classifier.name}"
+    wandb_target_entity = f"{namespace.project}/{mock_classifier.id}"
     next_version = get_next_version(namespace, wandb_target_entity, mock_classifier)
 
     assert next_version == "v0"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -113,7 +113,10 @@ def test_create_and_link_model_artifact():
         mock_artifact_class.assert_called_once_with(
             name=mock_classifier.id,
             type="model",
-            metadata={"aws_env": aws_env.value},
+            metadata={
+                "aws_env": aws_env.value,
+                "classifier_name": "test_classifier",
+            },
         )
 
         # Then the S3 reference was added to the artifact

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -58,7 +58,7 @@ def test_upload_model_artifact(aws_env, expected_bucket, tmp_path):
     assert bucket == expected_bucket
 
     # Assert the key structure is correct
-    assert key == "Q123/v4prnc54/v3.pickle"
+    assert key == "Q123/v4prnc54/v3/model.pickle"
 
     # Verify that the upload_file method was called with correct arguments
     mock_s3_client.upload_file.assert_called_once_with(
@@ -89,7 +89,7 @@ def test_create_and_link_model_artifact():
     mock_classifier = Mock()
     mock_classifier.name = "test_classifier"
     bucket = "cpr-labs-models"
-    key = "Q123/test_classifier/v3/model.pickle"
+    key = "Q123/v4prnc54/v3/model.pickle"
     aws_env = AwsEnv.labs
 
     storage_link = StorageLink(


### PR DESCRIPTION
This switches training to run using the id of a classifier rather than its name. To make this easier to update I also did some more general refactoring of the train script, if needed these changes can be seen progressively by clicking through the commits. The actual core change, where we switch from name to ids is in efec302b504418bcc9df45b67623ac2c29430a61

Extra things to note:
- We do still use the wandb version as the local & s3 file name for now, although I deliberated wether to or not as it should always be v0 in this way of doing things, but I think in practice its easier to hang on to it for now so we can see explicitly if the assumptions around it becoming irrelevant are wrong
- The context of what class is being used for a classifier (its name) is moved to metadata as it still seems like a useful detail when looking it up in wandb