### PR TITLE
ci: add stale pr detection

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '12 9 * * 1' # every monday at 9:12 AM
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    env:
+      DAYS_BEFORE_STALE: 30
+      DAYS_BEFORE_CLOSE: 10
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days.'
+          stale-pr-message: 'This PR is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_PR_CLOSE }} days.'
+          close-issue-message: 'This issue was closed because it has been stalled for ${{ env.DAYS_BEFORE_CLOSE }} days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for ${{ env.DAYS_BEFORE_CLOSE }} days with no activity.'
+          exempt-pr-labels: 'stale-exempt'
+          remove-stale-when-updated: 'True'
+          days-before-issue-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-issue-close: ${{ env.DAYS_BEFORE_CLOSE }}
+          days-before-pr-close: ${{ env.DAYS_BEFORE_CLOSE }}
+
+


### PR DESCRIPTION
We have a number of stale PRs across our codebase, I'd like to find a way of keeping these cleaned up and am interested in trying this out here in the knowledge graph repo first. I've taken 40 days as the amount of time before a PR should actually be closed for now. My view is that after this time the PR is probably never going to be merged because the rest of the repo has changed, so it either should have gotten merged earlier or needs to be reopened. The specific timing could be adjusted though.

Note that for exceptions the label `stale-exempt` can be added to a PR.

See for reference: https://github.com/actions/stale