### PR TITLE
feat: include env in the wandb `artifact` alias

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -109,7 +109,7 @@ def create_and_link_model_artifact(
     artifact.add_reference(uri=uri, checksum=True)
 
     # Log the artifact to W&B, creating it within a wandb project
-    artifact = run.log_artifact(artifact)
+    artifact = run.log_artifact(artifact, aliases=[storage_link.aws_env.value])
     artifact = artifact.wait()
 
     return artifact

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -125,7 +125,10 @@ def test_create_and_link_model_artifact():
         )
 
         # Then the artifact was logged in W&B
-        mock_run.log_artifact.assert_called_once_with(mock_artifact_instance)
+        mock_run.log_artifact.assert_called_once_with(
+            mock_artifact_instance,
+            aliases=[aws_env.value],
+        )
 
         # Then the artifact was waited for
         mock_run.log_artifact.return_value.wait.assert_called_once()


### PR DESCRIPTION
The model connection between artifacts and s3 stores is a one to one, which means unless we revisit this our models will all have a coupling with a specific environment. This is now the only tangible difference between versions of a model. This adds the env as an alias to each model. We already do this in the registry at promotion, but as models stay in their env it makes sense to do it in training too

The benefits to this is are:

* Clarity for humans when reviewing wandb which model is for which environment
* Easily identify the environment for a model programmatically in a more dynamic way.