### PR TITLE
test: scope test prefect server to test flows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,20 +8,11 @@ from urllib.parse import parse_qs
 import httpx
 import pandas as pd
 import pytest
-from prefect.logging import disable_run_logger
-from prefect.testing.utilities import prefect_test_harness
 
 from scripts.config import get_git_root
 from src.classifier.classifier import Classifier
 from src.concept import Concept
 from src.wikibase import WikibaseSession
-
-
-@pytest.fixture(autouse=True, scope="session")
-def prefect_test_fixture():
-    with prefect_test_harness(server_startup_timeout=120):
-        with disable_run_logger():
-            yield
 
 
 @pytest.fixture(scope="function")

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -28,6 +28,8 @@ from cpr_sdk.parser_models import (
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from moto import mock_aws
 from prefect import Flow, State
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
 from prefect_aws.s3 import S3Bucket
 from pydantic import SecretStr
 from requests.exceptions import ConnectionError
@@ -46,6 +48,13 @@ from src.identifiers import WikibaseID
 from src.labelled_passage import LabelledPassage
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def prefect_test_fixture():
+    with prefect_test_harness(server_startup_timeout=120):
+        with disable_run_logger():
+            yield
 
 
 @pytest.fixture


### PR DESCRIPTION
When running `pytest tests/test_promote.py` with this line tests take 17.6 seconds. Removing it and they take 1.2 seconds. All of our prefect test flows live in `flows/`, which has its own conftest file that spins up this prefect server. Meaning any time we are running just on a module outside this repo we are losing ~15 seconds per test run for no reason.

I don't expect this to have any benefit in ci, but when running non-flow tests locally this should save time. Note that if we ever have flows outside of the flow directory we'll now need to ensure they have the harness.