### PR TITLE
test: Run concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           python-version-file: pyproject.toml
 
       - name: Install dependencies
-        run: just install
+        run: just install-transformers
 
       - name: Install latest Vespa CLI
         env:
@@ -77,9 +77,11 @@ jobs:
       - name: Setup local Vespa
         run: just vespa_dev_setup
 
-      - name: Run tests
-        run: just test
+      - name: Run tests excl. Vespa
+        run: just test-without-vespa
 
+      - name: Run tests only Vespa
+        run: just test-with-vespa
 
   deploy_prefect_sandbox:
     name: "Deploy"

--- a/justfile
+++ b/justfile
@@ -9,21 +9,28 @@ default:
 
 # install dependencies and set up the project
 install +OPTS="":
-    uv sync --locked --extra dev --extra transformers --extra coiled {{OPTS}}
+    uv sync --locked --extra dev --extra coiled {{OPTS}}
     uv run pre-commit install
     uv run ipython kernel install --user
+
+install-transformers:
+  just install --extra transformers
 
 # test the project
 test +OPTS="":
     uv run pytest --disable-pytest-warnings --color=yes {{OPTS}}
 
+test-concurrently +OPTS="":
+    just test-without-vespa {{OPTS}}
+    just test-with-vespa {{OPTS}}
+
+# test the project, excluding tests that rely on a local Vespa instance
+test-with-vespa +OPTS="":
+    uv run pytest --disable-pytest-warnings --color=yes -m 'vespa' {{OPTS}}
+
 # test the project, excluding tests that rely on a local Vespa instance
 test-without-vespa +OPTS="":
-    uv run pytest --disable-pytest-warnings --color=yes {{OPTS}} -m 'not vespa'
-
-# test the project, excluding slow tests
-test-without-slow +OPTS="":
-    uv run pytest --disable-pytest-warnings --color=yes {{OPTS}} -m 'not slow'
+    uv run pytest -n logical --disable-pytest-warnings --color=yes -m 'not vespa' {{OPTS}}
 
 # update the snapshots for the tests
 test-snapshot-update +OPTS="":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "jinja2>=3.1.4",
     "pyright>=1.1.403",
     "duckdb>=1.3.2",
+    "pytest-xdist[psutil]>=3.8.0",
 ]
 
 [project.scripts]
@@ -99,7 +100,7 @@ env = [
   "ARGILLA_API_KEY=argilla.apikey",
   "WANDB_API_KEY=test_wandb_api_key"
 ]
-markers = ["vespa", "transformers", "slow"]
+markers = ["vespa", "transformers"]
 asyncio_default_fixture_loop_scope = "function"
 
 [build-system]

--- a/src/classifier/stemmed_keyword.py
+++ b/src/classifier/stemmed_keyword.py
@@ -9,8 +9,6 @@ from src.concept import Concept
 from src.identifiers import ClassifierID
 from src.span import Span
 
-nltk.download("punkt_tab", quiet=True)
-
 
 class StemmedKeywordClassifier(RulesBasedClassifier):
     """
@@ -28,6 +26,11 @@ class StemmedKeywordClassifier(RulesBasedClassifier):
 
         :param Concept concept: The concept which the classifier will identify in text
         """
+        # Ensure NLTK data is available
+        try:
+            nltk.data.find("tokenizers/punkt_tab")
+        except LookupError:
+            nltk.download("punkt_tab", quiet=True)
 
         self.stemmer = PorterStemmer()
 

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -301,7 +301,7 @@ def test_filter_non_english_file_stems() -> None:
     _ = filter_non_english_language_file_stems(file_stems=file_stems)
     end_time = time.time()
 
-    assert end_time - start_time < 1, "Filtering took too long"
+    assert end_time - start_time < 1.5, "Filtering took too long"
 
 
 def test_fn_is_async():

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -89,6 +89,7 @@ classifier_classes: list[Type[Classifier]] = [
 ]
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy(), text=st.data())
 def test_whether_classifier_matches_concept_labels_in_text(
@@ -105,6 +106,7 @@ def test_whether_classifier_matches_concept_labels_in_text(
     ), f"{classifier} matched incorrect text in '{text}'"
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy(), text=st.data())
 def test_whether_classifier_finds_no_spans_in_negative_text(
@@ -117,6 +119,7 @@ def test_whether_classifier_finds_no_spans_in_negative_text(
     assert not spans, f"{classifier} matched text in '{text}'"
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(data=st.data())
 def test_whether_classifier_respects_negative_labels(
@@ -149,6 +152,7 @@ def test_whether_classifier_respects_negative_labels(
     assert not spans, f"{classifier} matched text in '{text}'"
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @pytest.mark.parametrize(
     "concept_data,test_text,should_match",
@@ -232,6 +236,7 @@ def test_concrete_negative_label_examples(
         assert not spans, f"{classifier} incorrectly matched text in '{test_text}'"
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy(), text=st.data())
 def test_whether_returned_spans_are_valid(
@@ -248,6 +253,7 @@ def test_whether_returned_spans_are_valid(
         assert span.concept_id == concept.wikibase_id
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy())
 def test_whether_classifier_repr_is_correct(
@@ -259,6 +265,7 @@ def test_whether_classifier_repr_is_correct(
     )
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy())
 def test_whether_classifier_hashes_are_generated_correctly(
@@ -269,6 +276,7 @@ def test_whether_classifier_hashes_are_generated_correctly(
     assert classifier == classifier_class(concept)
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy())
 def test_whether_classifier_id_generation_is_affected_by_internal_state(
@@ -284,6 +292,7 @@ def test_whether_classifier_id_generation_is_affected_by_internal_state(
     assert classifier.id == classifier_class(concept).id
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concepts=st.sets(concept_strategy(), min_size=10, max_size=10))
 def test_whether_different_concepts_produce_different_hashes_when_using_the_same_classifier_class(
@@ -295,6 +304,7 @@ def test_whether_different_concepts_produce_different_hashes_when_using_the_same
     assert len(set(hashes)) == len(hashes)
 
 
+@pytest.mark.xdist_group(name="classifier")
 @given(concept=concept_strategy())
 def test_whether_different_classifier_models_produce_different_hashes_when_based_on_the_same_concept(
     concept: Concept,
@@ -305,6 +315,7 @@ def test_whether_different_classifier_models_produce_different_hashes_when_based
     assert len(set(hashes)) == len(hashes)
 
 
+@pytest.mark.xdist_group(name="classifier")
 @pytest.mark.parametrize("classifier_class", classifier_classes)
 @given(concept=concept_strategy())
 def test_whether_a_classifier_with_a_small_change_to_the_internal_concept_produces_a_different_id(
@@ -343,6 +354,7 @@ def test_whether_a_classifier_with_a_small_change_to_the_internal_concept_produc
     assert classifier != new_classifier
 
 
+@pytest.mark.xdist_group(name="classifier")
 def test_whether_a_classifier_which_does_not_specify_allowed_concept_ids_accepts_any_concept():
     class UnrestrictedClassifier(Classifier):
         @property
@@ -359,6 +371,7 @@ def test_whether_a_classifier_which_does_not_specify_allowed_concept_ids_accepts
     assert UnrestrictedClassifier(concept2)
 
 
+@pytest.mark.xdist_group(name="classifier")
 def test_whether_a_classifier_with_a_single_allowed_concept_id_validates_correctly():
     class SingleIDClassifier(Classifier):
         allowed_concept_ids = [WikibaseID("Q123")]
@@ -381,6 +394,7 @@ def test_whether_a_classifier_with_a_single_allowed_concept_id_validates_correct
     assert "not Q456" in str(exc_info.value)
 
 
+@pytest.mark.xdist_group(name="classifier")
 def test_whether_a_classifier_with_multiple_allowed_concept_ids_validates_correctly():
     class MultiIDClassifier(Classifier):
         allowed_concept_ids = [WikibaseID("Q123"), WikibaseID("Q456")]
@@ -403,6 +417,7 @@ def test_whether_a_classifier_with_multiple_allowed_concept_ids_validates_correc
     assert "not Q789" in str(exc_info.value)
 
 
+@pytest.mark.xdist_group(name="classifier")
 def test_whether_allowed_concept_ids_validation_works_correctly_with_inheritance():
     class ParentClassifier(Classifier):
         allowed_concept_ids = [WikibaseID("Q123"), WikibaseID("Q456")]
@@ -432,6 +447,7 @@ def test_whether_allowed_concept_ids_validation_works_correctly_with_inheritance
     assert "not Q456" in str(exc_info.value)
 
 
+@pytest.mark.xdist_group(name="classifier")
 def test_whether_an_empty_allowed_concept_ids_list_accepts_all_concepts():
     """
     Test whether supplying an empty list of allowed_concept_ids is prohibitive.

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2054,6 +2063,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-env" },
+    { name = "pytest-xdist", extra = ["psutil"] },
     { name = "syrupy" },
 ]
 transformers = [
@@ -2105,6 +2115,7 @@ requires-dist = [
     { name = "pytest-aioboto3", specifier = ">=0.6.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.1.5" },
+    { name = "pytest-xdist", extras = ["psutil"], marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyvespa", specifier = ">=0.54.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -3772,6 +3783,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911, upload-time = "2024-09-17T22:39:18.566Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/b8/87cfb16045c9d4092cfcf526135d73b88101aac83bc1adcf82dfb5fd3833/pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30", size = 6141, upload-time = "2024-09-17T22:39:16.942Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[package.optional-dependencies]
+psutil = [
+    { name = "psutil" },
 ]
 
 [[package]]


### PR DESCRIPTION
This uses the well-known pytest-xdist to run tests concurrently. The logical cores, vs physical cores, was chosen.

The bottleneck are the Vespa tests. We'll need to make those concurrent-safe eventually. I tested with using `testcontainers`, and had some success. I'm leaving it out for now, as it still needs work.

Still, this makes it faster overall, and, lets people iterate faster locally.

**Benchmark**

[_Before_
](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/17136655410?pr=605)

<img width="1056" height="238" alt="CleanShot 2025-08-21 at 22 17 29@2x" src="https://github.com/user-attachments/assets/98427c9c-fa2a-4d21-b9e5-39b348694202" />

[_After_](https://github.com/climatepolicyradar/knowledge-graph/actions/runs/17139071235)

<img width="1054" height="236" alt="CleanShot 2025-08-21 at 22 33 34@2x" src="https://github.com/user-attachments/assets/6158b554-040b-46ee-a7fe-0dda5a65b155" />

**Appendix**

- Removed the unused `slow` marker
- Separated again, the transformers installation, to make linting faster, so it doesn't install so much
- I added a group so far just for the classifier` tests. This means they run in the same worker thread. I did try doing this for the Vespa tests, but it had failures. I didn't look into it
- The NLTK test data is conditionally downloaded. Makes it thread safe, in how it was being used here