### PR TITLE
Update promote script to use classifier ID

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -64,16 +64,11 @@ def existing(
                 aws_env=to_aws_env,
             )
 
-            if classifier.version is None:
-                print(f"classifier {classifier.name} is missing a version, so skipping")
-                continue
-
             if promote:
                 print("promoting")
                 scripts.promote.main(
                     wikibase_id=WikibaseID(spec.name),
-                    classifier=classifier.name,
-                    version=classifier.version,
+                    classifier_id=classifier.id,
                     aws_env=to_aws_env,
                     primary=True,
                 )
@@ -119,16 +114,11 @@ def new(
                 aws_env=aws_env,
             )
 
-            if classifier.version is None:
-                print(f"classifier {classifier.name} is missing a version, so skipping")
-                continue
-
             if promote:
                 print("promoting")
                 scripts.promote.main(
                     wikibase_id=wikibase_id,
-                    classifier=classifier.name,
-                    version=classifier.version,
+                    classifier_id=classifier.id,
                     aws_env=aws_env,
                     primary=True,
                 )

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -13,7 +13,8 @@ from scripts.cloud import (
     is_logged_in,
     parse_aws_env,
 )
-from src.identifiers import WikibaseID
+from scripts.utils import ModelPath
+from src.identifiers import Identifier, WikibaseID
 from src.version import Version
 
 log = logging.getLogger(__name__)
@@ -95,10 +96,11 @@ def main(
             parser=WikibaseID,
         ),
     ],
-    classifier: Annotated[
-        str,
+    classifier_id: Annotated[
+        Identifier,
         typer.Option(
-            help="Classifier name that aligns with the Python class name",
+            help="Classifier ID that aligns with the Python class name",
+            parser=Identifier,
         ),
     ],
     version: Annotated[
@@ -165,7 +167,8 @@ def main(
         # This also validates that the classifier exists. It relies on an
         # artifiact not existing. That is, when trying to `use_artifact`
         # below, it'll throw an exception.
-        artifact_id = f"{wikibase_id}/{classifier}:{version}"
+        model_path = ModelPath(wikibase_id=wikibase_id, classifier_id=classifier_id)
+        artifact_id = f"{model_path}:{version}"
         log.info(f"Using model artifact: {artifact_id}...")
         artifact: wandb.Artifact = run.use_artifact(artifact_id)
 

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -103,13 +103,6 @@ def main(
             parser=Identifier,
         ),
     ],
-    version: Annotated[
-        Version,
-        typer.Option(
-            help="Version of the model (e.g., v3)",
-            parser=Version,
-        ),
-    ],
     aws_env: Annotated[
         AwsEnv,
         typer.Option(
@@ -168,7 +161,7 @@ def main(
         # artifiact not existing. That is, when trying to `use_artifact`
         # below, it'll throw an exception.
         model_path = ModelPath(wikibase_id=wikibase_id, classifier_id=classifier_id)
-        artifact_id = f"{model_path}:{version}"
+        artifact_id = f"{model_path}:{aws_env.value}"
         log.info(f"Using model artifact: {artifact_id}...")
         artifact: wandb.Artifact = run.use_artifact(artifact_id)
 
@@ -177,7 +170,7 @@ def main(
         check_existing_artifact_aliases(
             api,
             target_path,
-            version,
+            Version(artifact.version),
             aws_env,
         )
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -20,7 +20,7 @@ from src.version import Version
         (
             {  # Labs environment, logged in
                 "wikibase_id": "Q123",
-                "classifier": "TestClassifier",
+                "classifier_id": "abcd2345",
                 "version": Version("v1"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,
@@ -31,7 +31,7 @@ from src.version import Version
         (
             {  # Staging environment, logged in, primary
                 "wikibase_id": "Q456",
-                "classifier": "AnotherClassifier",
+                "classifier_id": "abcd2345",
                 "version": Version("v2"),
                 "aws_env": AwsEnv.staging,
                 "primary": True,
@@ -42,7 +42,7 @@ from src.version import Version
         (
             {  # Labs environment, logged in
                 "wikibase_id": "Q789",
-                "classifier": "ThirdClassifier",
+                "classifier_id": "abcd2345",
                 "version": Version("v3"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,
@@ -53,7 +53,7 @@ from src.version import Version
         (
             {  # Labs environment, not logged in
                 "wikibase_id": "Q789",
-                "classifier": "ThirdClassifier",
+                "classifier_id": "abcd2345",
                 "version": Version("v3"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -21,7 +21,6 @@ from src.version import Version
             {  # Labs environment, logged in
                 "wikibase_id": "Q123",
                 "classifier_id": "abcd2345",
-                "version": Version("v1"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,
             },
@@ -32,7 +31,6 @@ from src.version import Version
             {  # Staging environment, logged in, primary
                 "wikibase_id": "Q456",
                 "classifier_id": "abcd2345",
-                "version": Version("v2"),
                 "aws_env": AwsEnv.staging,
                 "primary": True,
             },
@@ -43,7 +41,6 @@ from src.version import Version
             {  # Labs environment, logged in
                 "wikibase_id": "Q789",
                 "classifier_id": "abcd2345",
-                "version": Version("v3"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,
             },
@@ -54,7 +51,6 @@ from src.version import Version
             {  # Labs environment, not logged in
                 "wikibase_id": "Q789",
                 "classifier_id": "abcd2345",
-                "version": Version("v3"),
                 "aws_env": AwsEnv.labs,
                 "primary": False,
             },
@@ -72,8 +68,19 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
 
     init_mock = Mock(return_value=nullcontext(Mock()))
 
+    artifact_mock = Mock()
+    artifact_mock.version = "v1"
+
+    run_mock = Mock()
+    run_mock.use_artifact.return_value = artifact_mock
+    run_mock.link_artifact = Mock()
+
+    api_mock = Mock()
+    api_mock.artifact_collection_exists.return_value = False
+
+    init_mock = Mock(return_value=nullcontext(run_mock))
     monkeypatch.setattr("wandb.init", init_mock)
-    monkeypatch.setattr("wandb.Artifact", lambda **kwargs: Mock())
+    monkeypatch.setattr("wandb.Artifact", lambda **kwargs: artifact_mock)
     monkeypatch.setattr("os.environ.__setitem__", lambda *args: None)
 
     with patch("scripts.promote.is_logged_in", return_value=logged_in):


### PR DESCRIPTION
Switches promote to use classifier ID. For this

* The project model now gets looked up using the `classifier_id` argument (which has replaced `classifier`).
* The version is no longer a necessary parameter so it is removed and the id:env is used to look up the classifier instead.
* The lookup of existing collection artifacts is revised to use the artifact id instead of just the version

Interestingly, it looks like we had a bug in the way we looked up existing registry items, as the code had some confusion about which version was being used (project artifact version versus collection artifact version, which are not in sync). This has been resolved by using the `classifier_id` to make sure we are actually looking up the right classifier.