### PR TITLE
Use the default time out when retrieving redirects.

### DIFF
--- a/src/wikibase.py
+++ b/src/wikibase.py
@@ -205,6 +205,7 @@ class WikibaseSession:
                     "ids": "|".join(ids_to_fetch),
                     "props": "info",
                 },
+                timeout=self.DEFAULT_TIMEOUT,
             )
             data = response.json()
 


### PR DESCRIPTION
This Pull Request: 
---
- Updates the wikibase class to use the default time out when running `_get_all_redirects`. 
- This is as during a local run of `just train` this request was timing out. The addition of the timeout resulted in success. 

```shell
poetry run train --wikibase-id Q1651
```