### PR TITLE
refactor: add ClassifierID wrapper for typing clarity

### DIFF
--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -5,7 +5,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 from scripts.cloud import AwsEnv
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 from src.version import Version
 
 SPEC_DIR = Path("flows") / "classifier_specs" / "v2"
@@ -27,7 +27,7 @@ class ClassifierSpec(BaseModel):
             "The wikibase id for the underlying concept being classified. e.g. 'Q992'"
         ),
     )
-    classifier_id: Identifier = Field(
+    classifier_id: ClassifierID = Field(
         description=(
             "The unique identifier for the classifier, built from its internals."
         ),

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -15,7 +15,7 @@ from scripts.cloud import (
     throw_not_logged_in,
 )
 from scripts.utils import ModelPath
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -30,7 +30,7 @@ app = typer.Typer()
 
 
 def find_artifact_in_registry(
-    model_collection, classifier_id: Identifier, aws_env: AwsEnv
+    model_collection, classifier_id: ClassifierID, aws_env: AwsEnv
 ) -> Optional[wandb.Artifact]:
     """
     Find an artifact with the specified alias in the model collection.
@@ -48,7 +48,7 @@ def find_artifact_in_registry(
 def check_existing_artifact_aliases(
     api: wandb.apis.public.api.Api,
     target_path: str,
-    classifier_id: Identifier,
+    classifier_id: ClassifierID,
     aws_env: AwsEnv,
 ) -> None:
     """
@@ -107,10 +107,10 @@ def main(
         ),
     ],
     classifier_id: Annotated[
-        Identifier,
+        ClassifierID,
         typer.Option(
             help="Classifier ID that aligns with the Python class name",
-            parser=Identifier,
+            parser=ClassifierID,
         ),
     ],
     aws_env: Annotated[

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -3,14 +3,14 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from scripts.config import classifier_dir
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 
 
 class ModelPath(BaseModel):
     """Represents the expected path to a model artifact locally or in S3."""
 
     wikibase_id: WikibaseID
-    classifier_id: Identifier
+    classifier_id: ClassifierID
 
     def __str__(self) -> str:
         """

--- a/src/classifier/bert_based.py
+++ b/src/classifier/bert_based.py
@@ -18,7 +18,7 @@ from typing_extensions import Self
 from src.classifier.classifier import Classifier, GPUBoundClassifier
 from src.classifier.uncertainty_mixin import UncertaintyMixin
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
@@ -74,9 +74,9 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
         self.model.to(self.training_device)  # type: ignore[attr-defined]
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(
+        return ClassifierID.generate(
             self.name,
             self.concept.id,
             self.base_model,

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -6,7 +6,7 @@ from typing import Optional, Sequence, Union
 from typing_extensions import Self
 
 from src.concept import Concept
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 from src.span import Span
 from src.version import Version
 
@@ -107,7 +107,7 @@ class Classifier(ABC):
 
     @property
     @abstractmethod
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """
         Return a deterministic, human-readable identifier for the classifier.
 
@@ -128,7 +128,7 @@ class Classifier(ABC):
         Classifier subclasses should override this method to return a unique identifier
         for the classifier according to its specific parameters and implementation.
 
-        :return Identifier: A deterministic 8-character identifier
+        :return ClassifierID: A deterministic 8-character identifier
         """
         ...
 

--- a/src/classifier/embedding.py
+++ b/src/classifier/embedding.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.span import Span
 
 
@@ -48,9 +48,9 @@ class EmbeddingClassifier(Classifier, ZeroShotClassifier):
         )
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(
+        return ClassifierID.generate(
             self.name, self.concept.id, self.embedding_model, self.threshold
         )
 

--- a/src/classifier/keyword.py
+++ b/src/classifier/keyword.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.span import Span
 
 
@@ -72,9 +72,9 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
         )
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(self.name, self.concept.id)
+        return ClassifierID.generate(self.name, self.concept.id)
 
     def predict(self, text: str) -> list[Span]:
         """

--- a/src/classifier/keyword_expansion.py
+++ b/src/classifier/keyword_expansion.py
@@ -5,7 +5,7 @@ from anthropic import Anthropic
 
 from src.classifier.rules_based import RulesBasedClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 
 
 class KeywordExpansionClassifier(RulesBasedClassifier):
@@ -32,9 +32,9 @@ class KeywordExpansionClassifier(RulesBasedClassifier):
         super().__init__(self.concept)
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(self.name, self.concept.id)
+        return ClassifierID.generate(self.name, self.concept.id)
 
     def _generate_prompt(self) -> str:
         """Generate the prompt for keyword expansion."""

--- a/src/classifier/large_language_model.py
+++ b/src/classifier/large_language_model.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.classifier.uncertainty_mixin import UncertaintyMixin
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.labelled_passage import LabelledPassage
 from src.span import Span
 
@@ -121,9 +121,9 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, UncertaintyMixin, ABC):
         raise NotImplementedError
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(
+        return ClassifierID.generate(
             self.name,
             self.concept.id,
             self.model_name,

--- a/src/classifier/rules_based.py
+++ b/src/classifier/rules_based.py
@@ -1,7 +1,7 @@
 from src.classifier.classifier import Classifier, ZeroShotClassifier
 from src.classifier.keyword import KeywordClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.span import Span
 
 
@@ -48,9 +48,9 @@ class RulesBasedClassifier(Classifier, ZeroShotClassifier):
             self.negative_matcher = None
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(self.name, self.concept.id)
+        return ClassifierID.generate(self.name, self.concept.id)
 
     def predict(self, text: str) -> list[Span]:
         """Predict whether the supplied text contains an instance of the concept."""

--- a/src/classifier/stemmed_keyword.py
+++ b/src/classifier/stemmed_keyword.py
@@ -6,7 +6,7 @@ from nltk.tokenize import word_tokenize  # type: ignore
 
 from src.classifier.rules_based import RulesBasedClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.span import Span
 
 nltk.download("punkt_tab", quiet=True)
@@ -66,9 +66,9 @@ class StemmedKeywordClassifier(RulesBasedClassifier):
         self.concept = concept
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(self.name, self.concept.id)
+        return ClassifierID.generate(self.name, self.concept.id)
 
     def _stem_label(self, label: str) -> str:
         """

--- a/src/classifier/targets.py
+++ b/src/classifier/targets.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from src.classifier.classifier import Classifier, GPUBoundClassifier
 from src.concept import Concept
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 from src.span import Span
 
 # optimal threshold for the "ClimatePolicyRadar/national-climate-targets" model as defined in
@@ -59,9 +59,9 @@ class BaseTargetClassifier(Classifier, GPUBoundClassifier):
         )
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return a deterministic, human-readable identifier for the classifier."""
-        return Identifier.generate(
+        return ClassifierID.generate(
             self.name, self.concept.id, self.model_name, self.commit_hash
         )
 

--- a/src/identifiers.py
+++ b/src/identifiers.py
@@ -4,6 +4,7 @@ from enum import Enum
 from functools import total_ordering
 
 from pydantic import BaseModel, Field
+from typing_extensions import Self
 
 
 @total_ordering
@@ -111,7 +112,7 @@ class Identifier(str):
     pattern = re.compile(rf"^[{valid_characters}]{{8}}$")
 
     @classmethod
-    def generate(cls, *args) -> "Identifier":
+    def generate(cls, *args) -> "Self":
         """Generates a new Identifier from the supplied data."""
         if not args:
             raise TypeError(
@@ -157,3 +158,13 @@ class Identifier(str):
     def __get_validators__(cls):
         """Return a generator of validators for Pydantic compatibility."""
         yield cls._validate
+
+
+class ClassifierID(Identifier):
+    """
+    A unique identifier specifically for classifiers.
+
+    This is intended for typing clarity rather than extending the Identifier class.
+    """
+
+    pass

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from flows.classifier_specs.spec_interface import ClassifierSpec, load_classifier_specs
 from scripts.cloud import AwsEnv
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 
 
 @pytest.mark.parametrize(
@@ -21,7 +21,7 @@ from src.identifiers import Identifier, WikibaseID
         (
             {  # Bad registry version - bad
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": Identifier("abcd2345"),
+                "classifier_id": ClassifierID("abcd2345"),
                 "wandb_registry_version": "latest",
             },
             pytest.raises(ValidationError),
@@ -29,7 +29,7 @@ from src.identifiers import Identifier, WikibaseID
         (
             {  # missing optional fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": Identifier("abcd2345"),
+                "classifier_id": ClassifierID("abcd2345"),
                 "wandb_registry_version": "v1",
             },
             does_not_raise(),
@@ -37,7 +37,7 @@ from src.identifiers import Identifier, WikibaseID
         (
             {  # extra fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": Identifier("abcd2345"),
+                "classifier_id": ClassifierID("abcd2345"),
                 "wandb_registry_version": "v1",
                 "extra_info": "will be ignored",
             },
@@ -46,7 +46,7 @@ from src.identifiers import Identifier, WikibaseID
         (
             {  # all fields - fine
                 "wikibase_id": WikibaseID("Q123"),
-                "classifier_id": Identifier("abcd2345"),
+                "classifier_id": ClassifierID("abcd2345"),
                 "wandb_registry_version": "v1",
                 "compute_environment": {
                     "gpu": True,

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -9,7 +9,7 @@ from src.classifier.keyword import KeywordClassifier
 from src.classifier.rules_based import RulesBasedClassifier
 from src.classifier.stemmed_keyword import StemmedKeywordClassifier
 from src.concept import Concept
-from src.identifiers import Identifier, WikibaseID
+from src.identifiers import ClassifierID, WikibaseID
 from src.span import Span
 from tests.common_strategies import concept_label_strategy, concept_strategy
 
@@ -265,7 +265,7 @@ def test_whether_classifier_hashes_are_generated_correctly(
     classifier_class: Type[Classifier], concept: Concept
 ):
     classifier = classifier_class(concept)
-    assert classifier.id == Identifier.generate(classifier.name, concept.id)
+    assert classifier.id == ClassifierID.generate(classifier.name, concept.id)
     assert classifier == classifier_class(concept)
 
 
@@ -346,8 +346,8 @@ def test_whether_a_classifier_with_a_small_change_to_the_internal_concept_produc
 def test_whether_a_classifier_which_does_not_specify_allowed_concept_ids_accepts_any_concept():
     class UnrestrictedClassifier(Classifier):
         @property
-        def id(self) -> Identifier:
-            return Identifier("unrestricted")
+        def id(self) -> ClassifierID:
+            return ClassifierID("unrestricted")
 
         def predict(self, text: str) -> list[Span]:
             return []
@@ -364,8 +364,8 @@ def test_whether_a_classifier_with_a_single_allowed_concept_id_validates_correct
         allowed_concept_ids = [WikibaseID("Q123")]
 
         @property
-        def id(self) -> Identifier:
-            return Identifier("single_id")
+        def id(self) -> ClassifierID:
+            return ClassifierID("single_id")
 
         def predict(self, text: str) -> list[Span]:
             return []
@@ -386,8 +386,8 @@ def test_whether_a_classifier_with_multiple_allowed_concept_ids_validates_correc
         allowed_concept_ids = [WikibaseID("Q123"), WikibaseID("Q456")]
 
         @property
-        def id(self) -> Identifier:
-            return Identifier("multi_id")
+        def id(self) -> ClassifierID:
+            return ClassifierID("multi_id")
 
         def predict(self, text: str) -> list[Span]:
             return []
@@ -408,8 +408,8 @@ def test_whether_allowed_concept_ids_validation_works_correctly_with_inheritance
         allowed_concept_ids = [WikibaseID("Q123"), WikibaseID("Q456")]
 
         @property
-        def id(self) -> Identifier:
-            return Identifier("parent_id")
+        def id(self) -> ClassifierID:
+            return ClassifierID("parent_id")
 
         def predict(self, text: str) -> list[Span]:
             return []
@@ -444,8 +444,8 @@ def test_whether_an_empty_allowed_concept_ids_list_accepts_all_concepts():
         allowed_concept_ids = []
 
         @property
-        def id(self) -> Identifier:
-            return Identifier("empty_id")
+        def id(self) -> ClassifierID:
+            return ClassifierID("empty_id")
 
         def predict(self, text: str) -> list[Span]:
             return []

--- a/tests/test_classifier_mixins.py
+++ b/tests/test_classifier_mixins.py
@@ -2,7 +2,7 @@
 
 from src.classifier.classifier import Classifier, GPUBoundClassifier, ZeroShotClassifier
 from src.concept import Concept
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 from src.span import Span
 
 
@@ -14,9 +14,9 @@ class DummyClassifier(Classifier):
         return []
 
     @property
-    def id(self) -> Identifier:
+    def id(self) -> ClassifierID:
         """Return the ID of the classifier."""
-        return Identifier("dummy")
+        return ClassifierID("dummy")
 
 
 class DummyZeroShotClassifier(DummyClassifier, ZeroShotClassifier):

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -11,7 +11,7 @@ from scripts.promote import (
     check_existing_artifact_aliases,
     find_artifact_in_registry,
 )
-from src.identifiers import Identifier
+from src.identifiers import ClassifierID
 
 
 @pytest.mark.parametrize(
@@ -98,7 +98,7 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
         (
             False,
             [],
-            Identifier("abcd2345"),
+            ClassifierID("abcd2345"),
             AwsEnv.labs,
             "test/path",
             None,
@@ -107,7 +107,7 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
         (
             True,
             ["labs"],
-            Identifier("abcd2345"),
+            ClassifierID("abcd2345"),
             AwsEnv.labs,
             "test/path",
             None,
@@ -116,7 +116,7 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
         (
             True,
             ["staging", "labs"],
-            Identifier("abcd2345"),
+            ClassifierID("abcd2345"),
             AwsEnv.labs,
             "test/path",
             "Something has gone wrong with the source artifact",
@@ -201,7 +201,9 @@ def test_find_artifact_in_registry(artifacts, aws_env, expected):
     mock_collection = Mock()
     mock_collection.artifacts.return_value = artifacts
 
-    result = find_artifact_in_registry(mock_collection, Identifier("abcd2345"), aws_env)
+    result = find_artifact_in_registry(
+        mock_collection, ClassifierID("abcd2345"), aws_env
+    )
 
     if expected is None:
         assert result is None


### PR DESCRIPTION
When Identifier is a ClassifierID, its nice to clearly show this is the case. For this a new model is used that inherits from Identifier and then applied wherever the `Identifier` is being used as a `ClassifierID`.

[This follows up on a discussion here](https://github.com/climatepolicyradar/knowledge-graph/pull/574#discussion_r2256643258).

For future consideration, Identifer is also used for other items such as concepts, maybe we'd like the same logic applying? I'm going to leave this for someone else / later though