### PR TITLE
docs: Update documentation following id/version changes

### DIFF
--- a/docs/docs/developers/justfile.md
+++ b/docs/docs/developers/justfile.md
@@ -42,13 +42,13 @@ Or to also track in W&B:
 just evaluate Q992 --track
 ```
 
-You can promote a model version to be the primary version that's used in that account.
+You can promote a model to be the primary used in that environment using its ClassifierID.
 
 ```bash
-poetry run promote Q992 --classifier RulesBasedClassifier --version v13 --aws-env labs --primary
+poetry run promote Q992 --classifier_id abcd2345  --aws-env labs --primary
 ```
 
-You can also demote (aka disable) a promoted model version in an AWS account/environment, for a concept.
+You can also demote (aka disable) a promoted model in an AWS account/environment, for a concept.
 
 ```bash
 just demote Q787 labs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ Individual scripts' docstrings contain more information about their purpose and 
 
 ## Updating a Classifier
 
-First we run the training scripts. This will increment the version of the classifier in the projects registry in weights and biases. You can then run the promote script which is used for promoting a model to primary within or cross aws environment. Promotion will not affect the version / alias.
+First we run the training scripts. This will upload the classifier to s3 and link to it from its weights and biases project. You can then run the promote script which is used for promoting a model to primary within an aws environment. Promotion as adds the model to the weights and bias registry and setting it as primary gives it the environment alias.
 
 _Note: You will need a profile in your `.aws/config` file with an active terminal session to use the following command as the upload command requires s3 access._
 
@@ -18,7 +18,7 @@ just train "Q123" --track --upload --aws-env sandbox
 Then we promote:
 
 ```shell
-just promote "Q123" --classifier KeywordClassifier --version v3 --aws-env sandbox --primary
+just promote "Q123" --classifier_id abcd2345 --aws-env sandbox --primary
 ```
 
 You can also achieve the above directly with:

--- a/scripts/demote.py
+++ b/scripts/demote.py
@@ -67,8 +67,8 @@ def main(
     """
     Demote a model within an AWS environment.
 
-    This removes the environment alias from the specified version, effectively
-    making it no longer the primary version for that environment.
+    This removes the environment alias from the specified model in the registery,
+    effectively making it no longer the primary version for that environment.
     """
     log.info("Starting model demotion process")
 

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -78,7 +78,7 @@ def check_existing_artifact_aliases(
         model_collection, classifier_id, aws_env=aws_env
     )
 
-    # It's okay if there isn't yet an registry artifact for this version, and
+    # It's okay if there isn't yet an registry artifact for this artifact, and
     # if there isn't, then there's nothing to check.
     if not target_artifact:
         log.info(f"Model collection artifact with alias {aws_env.value} not found")
@@ -123,7 +123,7 @@ def main(
     primary: Annotated[
         bool,
         typer.Option(
-            help="Whether this will be the primary version for this AWS environment",
+            help="Whether this will be primary for this AWS environment",
         ),
     ] = False,
 ):
@@ -134,8 +134,9 @@ def main(
     as an artefact in wandb, with a linked model in s3 for the environment.
 
     This script adds a link to the chosen model from the wandb registry as a
-    collection. Optionally the model can be made the primary version for the
-    AWS environment.
+    collection. Optionally the model can be made primary for the AWS
+    environment, this means applying an environment alias to the model in the
+    collection.
 
     If a W&B model registry collection doesn't exist, it'll automatically be
     made as part of this script.


### PR DESCRIPTION
There are more pieces of the model lifecycle that need updating but this follows a skim over the docs for what has changed so far and updates them.

Following a request for more documentation [here](https://github.com/climatepolicyradar/knowledge-graph/pull/574#pullrequestreview-3091805133), more should come as I go though