### PR TITLE
Bugfix for output attentions.

### DIFF
--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -175,7 +175,7 @@ class Classifier(ABC):
             pipeline_model_config = classifier.pipeline.model.config  # type: ignore
 
             pipeline_model_config._output_attentions = False  # type: ignore
-            pipeline_model_config._output_attentions = False  # type: ignore
+            pipeline_model_config.output_attentions = False  # type: ignore
 
         return classifier
 

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -155,7 +155,12 @@ class Classifier(ABC):
             pickle.dump(self, f)
 
     @classmethod
-    def load(cls, path: Union[str, Path], model_to_cuda: bool = False) -> "Classifier":
+    def load(
+        cls,
+        path: Union[str, Path],
+        model_to_cuda: bool = False,
+        set_missing_attributes: bool = True,
+    ) -> "Classifier":
         """
         Load a classifier from a file.
 
@@ -170,6 +175,13 @@ class Classifier(ABC):
             import torch  # type: ignore[import-untyped]
 
             classifier.pipeline.device = torch.device("cuda:0")  # type: ignore
+
+        if set_missing_attributes:
+            pipeline_model_config = classifier.pipeline.model.config  # type: ignore
+
+            pipeline_model_config._output_attentions = False  # type: ignore
+            pipeline_model_config._output_attentions = False  # type: ignore
+
         return classifier
 
 

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -159,7 +159,7 @@ class Classifier(ABC):
         cls,
         path: Union[str, Path],
         model_to_cuda: bool = False,
-        set_missing_attributes: bool = True,
+        set_missing_attributes: bool = False,
     ) -> "Classifier":
         """
         Load a classifier from a file.

--- a/src/classifier/classifier.py
+++ b/src/classifier/classifier.py
@@ -155,12 +155,7 @@ class Classifier(ABC):
             pickle.dump(self, f)
 
     @classmethod
-    def load(
-        cls,
-        path: Union[str, Path],
-        model_to_cuda: bool = False,
-        set_missing_attributes: bool = False,
-    ) -> "Classifier":
+    def load(cls, path: Union[str, Path], model_to_cuda: bool = False) -> "Classifier":
         """
         Load a classifier from a file.
 
@@ -176,7 +171,7 @@ class Classifier(ABC):
 
             classifier.pipeline.device = torch.device("cuda:0")  # type: ignore
 
-        if set_missing_attributes:
+        if type(classifier).__name__ == "TargetClassifier":
             pipeline_model_config = classifier.pipeline.model.config  # type: ignore
 
             pipeline_model_config._output_attentions = False  # type: ignore


### PR DESCRIPTION
This Pull Request: 
---
- Sets missing attributes when loading a classifier. 


Currently draft (just for viewing) 
- There is now a more preferred solution as defined [here](https://github.com/climatepolicyradar/knowledge-graph/pull/583). 