### PR TITLE
fix nasty event loop conflicts in the labelling librarian

### DIFF
--- a/static_sites/concept_librarian/template.py
+++ b/static_sites/concept_librarian/template.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 from src.concept import Concept, WikibaseID
-from src.wikibase import WikibaseSession
 from static_sites.concept_librarian.checks import (
     ConceptIssue,
     ConceptStoreIssue,
@@ -21,8 +20,6 @@ env = Environment(loader=FileSystemLoader(current_dir / "templates"))
 env.tests["concept_issue"] = lambda x: isinstance(x, ConceptIssue)
 env.tests["relationship_issue"] = lambda x: isinstance(x, RelationshipIssue)
 env.tests["multi_concept_issue"] = lambda x: isinstance(x, MultiConceptIssue)
-
-wikibase = WikibaseSession()
 
 
 def get_issues_for_concept(

--- a/static_sites/labelling_librarian/__main__.py
+++ b/static_sites/labelling_librarian/__main__.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import shutil
 from pathlib import Path
@@ -30,6 +31,12 @@ current_dir = Path(__file__).parent.resolve()
 
 @app.command()
 def main():
+    """CLI entry point to generate the Labelling Librarian static site."""
+    asyncio.run(async_main())
+
+
+async def async_main():
+    """Fetch datasets from Argilla, run checks, and generate static HTML pages."""
     client = rg.Argilla(
         api_url=os.getenv("ARGILLA_API_URL"),
         api_key=os.getenv("ARGILLA_API_KEY"),
@@ -60,7 +67,7 @@ def main():
     output_dir.mkdir(parents=True)
 
     # Generate and save the index page
-    html_content = create_index_page(issues)
+    html_content = await create_index_page(issues)
     output_path = output_dir / "index.html"
     output_path.write_text(html_content)
     console.log("Generated index page")
@@ -73,7 +80,7 @@ def main():
         relevant_issues = [
             issue for issue in issues if issue.dataset_name == dataset_name
         ]
-        html_content = create_dataset_page(
+        html_content = await create_dataset_page(
             dataset_name=dataset_name, issues=relevant_issues
         )
         output_path = output_dir / f"{dataset_name}.html"

--- a/static_sites/labelling_librarian/template.py
+++ b/static_sites/labelling_librarian/template.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from pathlib import Path
 from typing import Counter
 
@@ -15,22 +14,21 @@ from static_sites.labelling_librarian.checks import (
 
 load_dotenv()
 
-session = WikibaseSession()
-
 
 # Get the directory where this file lives and load the templates
 current_dir = Path(__file__).parent.resolve()
 env = Environment(loader=FileSystemLoader(current_dir / "templates"))
 
 
-@lru_cache(maxsize=1024)
-def get_dataset_to_preferred_label_map(dataset_name: str) -> str:
+async def get_dataset_to_preferred_label_map(
+    dataset_name: str, wikibase_session: WikibaseSession
+) -> str:
     """Retrieves the name of the dataset to present in the UI"""
-    concept = session.get_concept(WikibaseID(dataset_name))
+    concept = await wikibase_session.get_concept_async(WikibaseID(dataset_name))
     return concept.preferred_label
 
 
-def create_index_page(issues: list[LabellingIssue]) -> str:
+async def create_index_page(issues: list[LabellingIssue]) -> str:
     """Create an HTML report of all issues found using the Jinja template"""
     passage_issues = dict(
         Counter(
@@ -48,22 +46,29 @@ def create_index_page(issues: list[LabellingIssue]) -> str:
         )
     )
 
-    dataset_info = {
-        dataset_name: {
-            "passage_issue_count": passage_issues.get(dataset_name, 0),
-            "dataset_issue_count": dataset_issues.get(dataset_name, 0),
-            "issue_types": list(
-                set(
-                    issue.type for issue in issues if issue.dataset_name == dataset_name
-                )
-            ),
-            "preferred_label": get_dataset_to_preferred_label_map(dataset_name),
-        }
-        for dataset_name in {issues.dataset_name for issues in issues}
-    }
+    unique_dataset_names = {issue.dataset_name for issue in issues}
 
-    # Sorting, bringing those with the most issues to the top. Considering there are ~130 passages per dataset
-    # discounting the passage-level issues as such.
+    dataset_info = {}
+    async with WikibaseSession() as wikibase_session:
+        for dataset_name in unique_dataset_names:
+            preferred_label = await get_dataset_to_preferred_label_map(
+                dataset_name, wikibase_session
+            )
+            dataset_info[dataset_name] = {
+                "passage_issue_count": passage_issues.get(dataset_name, 0),
+                "dataset_issue_count": dataset_issues.get(dataset_name, 0),
+                "issue_types": list(
+                    set(
+                        issue.type
+                        for issue in issues
+                        if issue.dataset_name == dataset_name
+                    )
+                ),
+                "preferred_label": preferred_label,
+            }
+
+    # Sorting, bringing those with the most issues to the top. Considering there are
+    # ~130 passages per dataset discounting the passage-level issues as such.
     dataset_info = dict(
         sorted(
             dataset_info.items(),
@@ -79,7 +84,7 @@ def create_index_page(issues: list[LabellingIssue]) -> str:
     )
 
 
-def create_dataset_page(dataset_name: str, issues: list[LabellingIssue]) -> str:
+async def create_dataset_page(dataset_name: str, issues: list[LabellingIssue]) -> str:
     """Create an HTML report of all issues found for a single dataset using the Jinja template"""
     assert all(issue.dataset_name == dataset_name for issue in issues)  # type: ignore
 
@@ -93,9 +98,14 @@ def create_dataset_page(dataset_name: str, issues: list[LabellingIssue]) -> str:
 
     passage_issue_counts = dict(Counter(issue.type for issue in passage_issues))
 
+    async with WikibaseSession() as wikibase_session:
+        preferred_label = await get_dataset_to_preferred_label_map(
+            dataset_name, wikibase_session
+        )
+
     return env.get_template("dataset.html").render(
         dataset_name=dataset_name,
-        preferred_label=get_dataset_to_preferred_label_map(dataset_name),
+        preferred_label=preferred_label,
         dataset_issues=dataset_issues,
         passage_issues=passage_issues,
         passage_issue_counts=passage_issue_counts,


### PR DESCRIPTION
Despite all of the work that we've done over the last week or so, the labelling_librarian was still throwing `RuntimeError: Event loop is closed` errors 😖

<img width="1129" height="205" alt="Screenshot 2025-08-07 at 20 30 35" src="https://github.com/user-attachments/assets/b69e4f3c-5be1-409d-a5c7-d6940e07b2cb" />

After a bit of digging, it seems like the error comes from the caching of calls to `WikibaseSession.get_concept()` - the cache was sync, but the calls are run async. That, in combination with prefect's own event loop management, seemed enough to tie the whole system in knots...

The other static sites have been generating just fine under the new async pattern, so I've switched to use the async-first pattern in `labelling_librarian` too. With any luck, this should _finally_ get the vibe checker and other tools publishing nightly again 🤞 