### PR TITLE
Big alias upload to concept store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,8 @@ tests/local_vespa/test_app/search/query-profiles/lower_max_hits.xml
 
 # Output report created by the scripts/audit/do_s3_passages_align_with_vespa.py audit script
 missing_passages.csv
+
+data.db
+data.db.wal
+impacts.png
+scripts/build_dataset/subset_dataset_sexual_minority.py


### PR DESCRIPTION
Harrison added back in functionality to add aliases in bath to the concept store. This worked but I needed it to upload some stupid long lists, so I added batching. Also, if one session failed, it all fell over. Cursor added some error handling and delays between request. Not super familiar with async things so may well be terrible code, but it did work :) 

Not sure why the gitignore had to be changed too. 