### PR TITLE
test: Use stable mangled data

### DIFF
--- a/tests/flows/__snapshots__/test_aggregate.ambr
+++ b/tests/flows/__snapshots__/test_aggregate.ambr
@@ -1,0 +1,6 @@
+# serializer version: 1
+# name: test_process_single_document__value_error
+  list([
+    AggregationFailure("CCLW.executive.10061.4515 | exception: The number of passages diverge when appending Q767:v3: len(labelled_passages)=2 != len(concepts_for_vespa)=27 | context: ValueError('The number of passages diverge when appending Q767:v3: len(labelled_passages)=2 != len(concepts_for_vespa)=27')"),
+  ])
+# ---


### PR DESCRIPTION
We started seeing failures on GitHub runners[^1]. Why did it start? Who knows what's changed in the runners themselves.

There's several fixtures for a document with that stem (AKA ID), and they don't all have the same number of labelled passages. The string matching depends on a stable number of labelled passages.

All fixtures:

```
tests/flows/fixtures/labelled_passages/Q223/v3/CCLW.executive.10061.4515.json
tests/flows/fixtures/labelled_passages/Q767/v3/CCLW.executive.10061.4515.json
tests/flows/fixtures/labelled_passages/Q1286/v3/CCLW.executive.10061.4515.json
tests/flows/fixtures/labelled_passages/Q123/v4/CCLW.executive.10061.4515.json
tests/flows/fixtures/labelled_passages/Q218/v5/CCLW.executive.10061.4515.json
```

`tests/flows/fixtures/labelled_passages/Q218/v5/CCLW.executive.10061.4515.json`
has 25.

To avoid this, use specific classifiers, and the associated fixtures, to force
an error.

FIXES PLA-787

[^1]: https://github.com/climatepolicyradar/knowledge-graph/actions/runs/16875588172/job/47799425877
