### PR TITLE
fix: Surface total failure of inference

### DIFF
--- a/flows/full_pipeline.py
+++ b/flows/full_pipeline.py
@@ -177,10 +177,9 @@ async def full_pipeline(
     )
 
     if len(inference_result.fully_successfully_classified_document_stems) == 0:
-        logger.info(
+        raise ValueError(
             "Inference successfully ran on 0 documents, skipping aggregation and indexing."
         )
-        return
 
     aggregation_run: State = await aggregate(
         document_stems=list(


### PR DESCRIPTION
If inference entirely failed, don't simply return, as it gives the _full
pipeline_ and overall succeeded state, which is incorrect.

FIXES PLA-788
