### PR TITLE
Fix: Add recursive subconcept and alias parameters to vibe checker

### DIFF
--- a/static_sites/vibe_check/__main__.py
+++ b/static_sites/vibe_check/__main__.py
@@ -375,7 +375,11 @@ def main():
 
         for concept_id in all_concept_ids:
             try:
-                if concept := wikibase.get_concept(wikibase_id=concept_id):
+                if concept := wikibase.get_concept(
+                    wikibase_id=concept_id,
+                    include_recursive_has_subconcept=True,
+                    include_labels_from_subconcepts=True,
+                ):
                     concepts[concept_id] = concept
                     valid_concept_ids.append(concept_id)
                 else:


### PR DESCRIPTION
From ticket PLA-791: https://linear.app/climate-policy-radar/issue/PLA-791/support-vibe-checker

Updates the vibe checker to recursively include subconcepts and their labels, bringing it to parity with the train script. 

I do not have the knowledge-graph repo flows running locally right now, which means I cannot test this change locally. But it's a small change and well-evidenced so I'm keen to (in)validate the hypothesis before rabbit holing on local setup for hours. 

The vibe checker static site was only highlighting parent concepts (e.g., "solar energy") but not their subconcepts (e.g., "photovoltaic", "solar thermal", "concentrated solar power"), even though the trained classifiers include subconcept labels.

The wikibase get_concept method has parameters for include_recursive_has_subconcept and include_labels_from_subconcepts which default to False, and are used by other code updates throughout the codebase. It doesn't appear that these were propagated through to the vibe checker, and the timeline for these parameters being added to the wikibase object but this issue not being identified tracks with Policy team usage of the vibe checker (they last used vibe checker in anger >6 months ago). 