### PR TITLE
Feat: Run full pipeline on new documents

### DIFF
--- a/automations.py
+++ b/automations.py
@@ -84,7 +84,7 @@ def create_target_automation(
             # > event.
             #
             # NB: Currently a set due to the Prefect Python class used
-            expect=set(["prefect.flow-run.Completed"]),
+            expect=set(["prefect.flow-run.Running"]),
         ),
         actions=[
             RunDeployment(

--- a/automations.py
+++ b/automations.py
@@ -144,6 +144,7 @@ async def a_triggers_b(
     description: str,
     ignore: list[AwsEnv],
     aws_env: AwsEnv,
+    expect_state: StateType = StateType.COMPLETED,
 ) -> None:
     """Automation to after Deployment A completes trigger Deployment B."""
     client = get_client()
@@ -190,6 +191,7 @@ async def a_triggers_b(
         description=description,
         parameters=b_parameters,
         enabled=enabled,
+        expect_state=expect_state,
     )
 
     print("deleting, if already exists...")
@@ -213,6 +215,7 @@ async def main() -> None:
         description="Start the knowledge graph full pipeline.",
         enabled=False,
         aws_env=aws_env,
+        expect_state=StateType.RUNNING,
         ignore=[AwsEnv.labs],
     )
 

--- a/automations.py
+++ b/automations.py
@@ -10,6 +10,7 @@ import prefect.events.schemas.automations as automations
 import prefect.events.schemas.events as events
 from prefect.automations import Automation
 from prefect.client.orchestration import get_client
+from prefect.client.schemas.objects import StateType
 from prefect.client.schemas.responses import DeploymentResponse
 from prefect.events.actions import RunDeployment
 from prefect.exceptions import ObjectNotFound
@@ -30,12 +31,12 @@ logger.addHandler(ch)
 
 
 def create_target_automation(
-    a_flow_name: str,
     a_deployment: DeploymentResponse,
     b_deployment: DeploymentResponse,
     description: str,
     parameters: dict,
     enabled: bool,
+    expect_state: StateType = StateType.COMPLETED,
 ) -> Automation:
     """
     Create a copy of the `Automation` that triggers another `Deployment`.
@@ -84,7 +85,7 @@ def create_target_automation(
             # > event.
             #
             # NB: Currently a set due to the Prefect Python class used
-            expect=set(["prefect.flow-run.Running"]),
+            expect=set([f"prefect.flow-run.{expect_state.title()}"]),
         ),
         actions=[
             RunDeployment(
@@ -184,7 +185,6 @@ async def a_triggers_b(
     )
 
     target = create_target_automation(
-        a_flow_name=a_flow_name,
         a_deployment=a_deployment,
         b_deployment=b_deployment,
         description=description,

--- a/automations.py
+++ b/automations.py
@@ -209,7 +209,7 @@ async def main() -> None:
         a_deployment_name=f"navigator-data-s3-backup-pipeline-cache-{aws_env}",
         b_flow_name=full_pipeline.name,
         b_deployment_name=generate_deployment_name(full_pipeline.name, aws_env),
-        b_parameters={"use_new_and_updated": True},
+        b_parameters={"inference_use_new_and_updated": True},
         description="Start the knowledge graph full pipeline.",
         enabled=False,
         aws_env=aws_env,

--- a/automations.py
+++ b/automations.py
@@ -14,7 +14,7 @@ from prefect.client.schemas.responses import DeploymentResponse
 from prefect.events.actions import RunDeployment
 from prefect.exceptions import ObjectNotFound
 
-from flows.inference import inference
+from flows.full_pipeline import full_pipeline
 from scripts.cloud import AwsEnv, generate_deployment_name
 
 # Create logger
@@ -207,10 +207,10 @@ async def main() -> None:
     await a_triggers_b(
         a_flow_name="navigator-data-s3-backup",
         a_deployment_name=f"navigator-data-s3-backup-pipeline-cache-{aws_env}",
-        b_flow_name=inference.name,
-        b_deployment_name=generate_deployment_name(inference.name, aws_env),
+        b_flow_name=full_pipeline.name,
+        b_deployment_name=generate_deployment_name(full_pipeline.name, aws_env),
         b_parameters={"use_new_and_updated": True},
-        description="Start concept store inference with classifiers.",
+        description="Start the knowledge graph full pipeline.",
         enabled=False,
         aws_env=aws_env,
         ignore=[AwsEnv.labs],


### PR DESCRIPTION
This Pull Request: 
---
- Adds an automation for triggering the `full_pipeline` when the s3 backup is run. 
- Currently disabled until we fix the targets classifiers. 