### PR TITLE
fix: Use latest AWS environment name

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -89,7 +89,13 @@ def create_deployment(
     image_name = os.path.join(docker_registry, docker_repository)
 
     if gpu:
-        work_pool_name = f"coiled-{AwsEnv(os.getenv('AWS_ENV', 'sandbox'))}"
+        aws_env = AwsEnv(os.getenv("AWS_ENV", "sandbox"))
+        if aws_env == AwsEnv.production:
+            aws_env_str = AwsEnv.production.name
+        else:
+            aws_env_str = str(aws_env)
+
+        work_pool_name = f"coiled-{aws_env_str}"
         work_queue_name = "default"
         default_variables = JSON.load(
             f"coiled-default-job-variables-prefect-mvp-{aws_env}"


### PR DESCRIPTION
CD failed[^1], as `coiled-prod` was used instead of the correct `coiled-production` work pool name.

From some ADR, we decided on using `production` over `prod`.

I did consider handling this on the enum. It didn't seem like the right place, or not elegant, at least. I may come back to that.

Could the `name` attribute be used everywhere? I don't think so. It's a hack, so we don't want to encourage it.

TOWARDS PLA-759

[^1]: https://github.com/climatepolicyradar/knowledge-graph/actions/runs/16970954247/job/48107589223

