### PR TITLE
ci: Avail space for Docker image building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: "Build"
-    needs: [lint]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,16 @@ jobs:
       - name: Confirm Prefect binary availability
         run: docker run --rm dummy/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }} prefect version
 
+      - name: Confirm Coiled binary availability
+        run: docker run --rm dummy/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }} coiled --version
+
       - name: Confirm dependencies availability
         run: docker run --rm dummy/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }} python -c "import aioboto3; print('aioboto3 imported successfully')"
+
+      # AWS_ENV is needed, for now, since there's a module with a
+      # side-effect that calls the OS environment.
+      - name: Confirm package availability
+        run: docker run --rm -e AWS_ENV=sandbox dummy/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }} python -c "import flows.inference; print('flows.inference imported successfully')"
 
   deploy_prefect_sandbox:
     name: "Deploy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,18 +112,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
       - name: Install just
         run: pipx install rust-just
-
-      - name: Install python or load from cache with dependencies
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: pyproject.toml
 
       - name: Get version
         id: get_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,27 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Remove unused software
+        # This is a "works for now" step. The underlying runner may
+        # change. Don't block CI on this.
+        continue-on-error: true
+        run: |
+          # Space before
+          df -h
+          # .Net
+          sudo rm -rf /usr/share/dotnet || true &
+          # Android
+          sudo rm -rf /usr/local/lib/android || true &
+          # GHC
+          sudo rm -rf /opt/ghc || true &
+          sudo rm -rf /usr/local/.ghcup || true &
+          # CodeQL
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true &
+          # Wait for all removlas
+          wait
+          # Space after
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
 FROM python:3.12-slim-bookworm
-
-# The installer requires curl (and certificates) to download the release archive
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-
-# Download the latest installer
-ADD https://astral.sh/uv/install.sh /uv-installer.sh
-
-# Run the installer then remove it
-RUN sh /uv-installer.sh && rm /uv-installer.sh
-
-# Ensure the installed binary is on the `PATH`
-ENV PATH="/root/.local/bin/:$PATH"
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_SYSTEM_PYTHON=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,20 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_SYSTEM_PYTHON=1
 
+WORKDIR /app
+
 # This allows the dependencies of the project (which do not change
 # often) to be cached separately from the project itself (which
 # changes very frequently).
-COPY pyproject.toml .
+COPY pyproject.toml README.md ./
 RUN uv pip install -r pyproject.toml --extra transformers --extra coiled
-COPY . .
+
+# Copy the project into the image
+COPY src ./src/
+COPY flows ./flows/
+COPY scripts ./scripts/
+
+# Install the project
 RUN uv pip install -e .
 
 ENV PREFECT_LOGGING_LEVEL=DEBUG

--- a/justfile
+++ b/justfile
@@ -114,7 +114,7 @@ push-image:
     docker push ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}:${VERSION}
 
 get-version:
-    uv run python -c "import importlib.metadata; print(importlib.metadata.version('knowledge-graph'))"
+    @grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/'
 
 export-env-vars:
 	export $(cat .env | xargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "knowledge-graph"
-version = "0.11.0"
+version = "0.11.1"
 description = ""
 authors = [
     {name = "CPR Data Science", email = "dsci@climatepolicyradar.org"}

--- a/uv.lock
+++ b/uv.lock
@@ -1957,7 +1957,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-graph"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
This has arisen post-migrating to uv with Python 3.12, utilising a GH cache for the images.

- Removing unused software (available space before 27G, after: 44G). This is done via background jobs, to significantly speed it up—from a few minutes to near instantaneous
- Don't install Python and uv outside of the Docker image
- Don't copy everything carte blanche
- Let building start immediately, since it's the longest job to run
- Do more post-build checks

**Test**

Built successfully: https://github.com/climatepolicyradar/knowledge-graph/actions/runs/17066912735/job/48386151210?pr=610. There's been others after this too.

I've cleaned out our [caches](https://github.com/climatepolicyradar/knowledge-graph/actions/caches) (`$ gh cache list`):

<img width="992" height="316" alt="CleanShot 2025-08-19 at 10 48 36" src="https://github.com/user-attachments/assets/68298de5-89ca-4369-95c1-878077d6c4ae" />

I'm not sure if the loading of the cache contributed to the high disk usage.

**Appendix**

- In the future, we may want to have separate CPU and GPU images.
- Loading the image, to run the post-build checks, takes a bit of time (` DONE 79.8s`). We could remove them, since we have pretty high confidence in the Dockerfile. We lived without them, until recently. They could at least be put into 1 script, though I think the time saved would be negligible.
- I have experimented with multi-layer images to reduce the final image size. It's still TBD.
