### PR TITLE
fix: typo for stale workflow env variable

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days.'
-          stale-pr-message: 'This PR is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_PR_CLOSE }} days.'
+          stale-issue-message: 'This issue is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days.'
+          stale-pr-message: 'This PR is stale because it has been open ${{ env.DAYS_BEFORE_STALE }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days.'
           close-issue-message: 'This issue was closed because it has been stalled for ${{ env.DAYS_BEFORE_CLOSE }} days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for ${{ env.DAYS_BEFORE_CLOSE }} days with no activity.'
           exempt-pr-labels: 'stale-exempt'


### PR DESCRIPTION
Looks like this is working! [Example PR marked as stale](https://github.com/climatepolicyradar/knowledge-graph/pull/369#issuecomment-3173910583), when checking that comment I realised this variable was mistyped.