### PR TITLE
Make use of the BaseParserOutput method to get text blocks.

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -408,18 +408,8 @@ def document_passages(
     document: BaseParserOutput,
 ) -> Generator[tuple[str, str], None, None]:
     """Yield the text block irrespective of content type."""
-    match document.document_content_type:
-        case "application/pdf":
-            text_blocks = document.pdf_data.text_blocks  # type: ignore
-        case "text/html":
-            text_blocks = document.html_data.text_blocks  # type: ignore
-        case _:
-            text_blocks = []
-            print(
-                "Unsupported document content type: "
-                f"{document.document_content_type}, for "
-                f"document: {document.document_id}"
-            )
+    text_blocks = document.get_text_blocks()
+
     for text_block in text_blocks:
         if text_block.type not in BLOCKED_BLOCK_TYPES:
             yield _stringify(text_block.text), text_block.text_block_id


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for the function to retrieve document passages during the KG pipeline. 
- Prefect flow [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068a5ab0-0f44-73c9-8000-370c357f9520?entity_id=068a5ab0-0f44-73c9-8000-370c357f9520&state=pending).
- When we look at the content of the parser output json in the embeddings input directory we see the cause of the issue. The content type is html but the data is pdf. This is due to changes earlier this year where we convert html docs to pdfs to extract text. 
<img width="430" height="259" alt="image" src="https://github.com/user-attachments/assets/7d138e31-d09f-48e9-8146-40810370940f" />
