### PR TITLE
Bugfix for default flow variables not being passed in to inference deployment.

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -143,7 +143,6 @@ create_deployment(
     description="Run concept classifier inference on a batch of documents with CPU compute",
     extra_tags=["type:sub"],
     gpu=False,
-    flow_variables={},
 )
 
 create_deployment(
@@ -151,7 +150,6 @@ create_deployment(
     description="Run concept classifier inference on a batch of documents with GPU compute",
     extra_tags=["type:sub"],
     gpu=True,
-    flow_variables={},
 )
 
 # Aggregate inference results


### PR DESCRIPTION
This Pull Request: 
--- 
- Is a bug fix for the SIGKILL (memory error) being experienced in the inference stage.
- The bug is that providing an empty dictionary to the `create_deployment` function is resulting in the `DEFAULT_FLOW_VARIABLES` not being set and thus the default job variables having very low mem / cpu. 
- This can be validated with some code below as well as these default job [variables](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/deployments/deployment/99479d91-159a-4b09-95b4-0fef97d98936?tab=Configuration) on prod: 

```python
from typing import Any


def my(x: Any | None = {"the": "default"}):
    print(x)

my()
my(x={})

# {'the': 'default'}
# {}

``` 


- Deployed this branch to staging and observed the default job configuration change with the increased resources. 

<img width="648" height="944" alt="image" src="https://github.com/user-attachments/assets/e665d9b1-41f2-416c-a32c-b861001e6db9" />


- Triggered a [run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068a6f21-26e3-75f7-8000-bde36b97208f?state=pending&entity_id=068a6f21-7229-7710-8000-5e05ffbc14f9) and inference jobs are running with the desired resources: 
<img width="1721" height="396" alt="image" src="https://github.com/user-attachments/assets/27bf6bb7-3f96-480e-83a3-450a2f8be1fb" />


- The ECS tasks have now been running for a few minutes with completions each without the sigkill memory errors. 
<img width="862" height="662" alt="image" src="https://github.com/user-attachments/assets/3f6393e7-a5b6-45f0-b6a7-e7cbc6a39710" />


- The one crashed task is listed as having failed due the following error which will be ticketed and followed up: 
> Failed due to a(n) ClientException when calling the RegisterTaskDefinition operation: Too many concurrent attempts to create a new revision of the specified family.
