### PR TITLE
ci: Add checks, and fixes, for spelling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: detect-aws-credentials
@@ -10,9 +10,10 @@ repos:
     hooks:
       - id: nbstripout
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    # Ruff version.
+    rev: v0.12.9
     hooks:
-      - id: ruff
+      - id: ruff-check
         types_or: [ python, pyi, jupyter ]
         args: [ --fix ]
       - id: ruff-format
@@ -27,11 +28,11 @@ repos:
         types: [python]
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.8.5
+    rev: 0.8.12
     hooks:
       - id: uv-lock
   - repo: https://github.com/boidolr/ast-grep-pre-commit
-    rev: 0.39.1
+    rev: 0.39.4
     hooks:
       - id: ast-grep
   - repo: https://github.com/crate-ci/typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     rev: 0.39.1
     hooks:
       - id: ast-grep
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.35.5
+    hooks:
+      - id: typos
+        exclude: ^(tests/fixtures|tests/flows/fixtures|tests/local_vespa/test_documents|tests/__snapshots__)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In the longer term, we expect the graph to be a useful artefact in its own right
 
 ## Testing
 
-### Local Prequisites
+### Local Prerequisites
 
 * Install [Git LFS](https://git-lfs.com)
 * Start Docker (Desktop) locally and follow instructions in [Vespa README.md](./tests/local_vespa/README.md)
@@ -141,7 +141,7 @@ Prefect Deployments are defined in [deployments.py](./deployments.py)
 The [Prefect Dashboard shows all deployments, flows and runs](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/deployments?g_range={%22type%22:%22span%22,%22seconds%22:-2592000}),
 which you can filter by name and date of last deployment.
 
-The name of the knowlege graph deployments all have the same prefix of `kg-` and they are programmatically generated following the format:
+The name of the knowledge graph deployments all have the same prefix of `kg-` and they are programmatically generated following the format:
 
 `kg-<flow_name>-<environment>`
 
@@ -159,7 +159,7 @@ All helper scripts are located in [/scripts directory](./scripts) directory
 
 ## Classifier training, promotion and deployment 
 
-These are performed via helper scripts run by the [justfile](./justfile) commands. These are currently excecuted manually on a local laptop are are not part of a CI/CD pipeline.
+These are performed via helper scripts run by the [justfile](./justfile) commands. These are currently executed manually on a local laptop are are not part of a CI/CD pipeline.
 
 They can be found in the [/scripts directory](./scripts) directory
 

--- a/automations.py
+++ b/automations.py
@@ -130,7 +130,7 @@ async def delete_if_exists(name: str) -> None:
             print("automation doesn't exist already, so nothing to do")
             return None
         else:
-            # It was a real problem, re-raise the excpetion
+            # It was a real problem, re-raise the exception
             raise
 
 

--- a/docs/docs/developers/environment-variables.md
+++ b/docs/docs/developers/environment-variables.md
@@ -15,6 +15,6 @@ WIKIBASE_RELATED_CONCEPT_PROPERTY_ID=
 
 `WIKIBASE_URL` is the base URL for the Wikibase instance (including protocol). For the climate policy radar concept store, this should be `https://climatepolicyradar.wikibase.cloud`.
 
-`WIKIBASE_USERNAME` and `WIKIBASE_PASSWORD` are the credentials for the accessing the wikibase instance programatically. In most cases, you should use a set of bot account credentials (derived from your main account). See instructions for creating a bot user account [here](./bot-users.md).
+`WIKIBASE_USERNAME` and `WIKIBASE_PASSWORD` are the credentials for the accessing the wikibase instance programmatically. In most cases, you should use a set of bot account credentials (derived from your main account). See instructions for creating a bot user account [here](./bot-users.md).
 
 `WIKIBASE_HAS_SUBCONCEPT_PROPERTY_ID`, `WIKIBASE_SUBCONCEPT_OF_PROPERTY_ID`, and `WIKIBASE_RELATED_CONCEPT_PROPERTY_ID` are the property IDs for the properties that define the relationships between concepts. These should be set to the IDs of the properties that you have created in your Wikibase instance. For the climate policy radar concept store, these are `P1`, `P2`, and `P3` respectively.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,6 +2,6 @@
 
 Welcome to the documentation for [Climate Policy Radar's concept store](https://climatepolicyradar.wikibase.cloud/wiki/Main_Page).
 
-If you're a user (eg a member of the Climate Policy Radar policy team, or an extarnal contributor), you're probably interested in the [user documentation](users/README.md).
+If you're a user (eg a member of the Climate Policy Radar policy team, or an external contributor), you're probably interested in the [user documentation](users/README.md).
 
 If you're a developer, you might be interested in the [developer documentation](developers/README.md).

--- a/docs/docs/users/hierarchy-heuristics.md
+++ b/docs/docs/users/hierarchy-heuristics.md
@@ -41,7 +41,7 @@ Nevertheless, we should be prepared to adjust the hierarchical representations w
 
 We should aim to keep our hierarchies relatively shallow. Doing so will (hopefully) keep the concepts abstract enough to be useful to users, while making it easier for us to maintain the hierarchy as the world changes.
 
-The concepts inhereted from [GST](https://gst1.org) worked over three levels of abstraction, and we should aim to keep our future hierarchies at a similar depth.
+The concepts inherited from [GST](https://gst1.org) worked over three levels of abstraction, and we should aim to keep our future hierarchies at a similar depth.
 
 ## Hierarchies can overlap
 

--- a/flows/boundary.py
+++ b/flows/boundary.py
@@ -543,7 +543,7 @@ async def get_document_passages_from_vespa__generator(
     - vespa_connection_pool: The vespa connection pool to use as the query client.
     - continuation_tokens: The tokens used to paginate over the vespa hits.
     - grouping_max: The maximum amount of grouping subquery hits to return at once.
-    - grouping_precision: How much do we want to value accuracy over bandiwdth.
+    - grouping_precision: How much do we want to value accuracy over bandwidth.
     - query_profile: The query profile to use for the query. This is defined in the
         search/query-profiles/ subdirectory of the application package for vespa.
     """

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -521,7 +521,7 @@ class Percentage(
 
     @staticmethod
     def from_lists(r: Sequence[T], t: Sequence[U]) -> "Percentage":
-        """Relative size of 2 lists as a precentage."""
+        """Relative size of 2 lists as a percentage."""
         return Percentage((len(r) / len(t)) * 100.0)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "pulumi-aws>=6.66.2",
     "jinja2>=3.1.4",
     "pyright>=1.1.403",
+    "duckdb>=1.3.2",
 ]
 
 [project.scripts]

--- a/scripts/demote.py
+++ b/scripts/demote.py
@@ -65,7 +65,7 @@ def main(
     """
     Demote a model within an AWS environment.
 
-    This removes the environment alias from the specified model in the registery,
+    This removes the environment alias from the specified model in the registry,
     effectively making it no longer the primary version for that environment.
     """
     log.info("Starting model demotion process")

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -90,9 +90,9 @@ def load_classifier_remote(
     os.environ["AWS_PROFILE"] = aws_env
 
     artifact_dir = artifact.download()
-    artifiact_path = Path(artifact_dir) / model_artifact_name
+    artifact_path = Path(artifact_dir) / model_artifact_name
 
-    return Classifier.load(artifiact_path)
+    return Classifier.load(artifact_path)
 
 
 def add_artifact_to_run_lineage_local(

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -35,7 +35,7 @@ def find_artifact_in_registry(
     Find an artifact with the specified alias in the model collection.
 
     This runs through artifacts in the collection and inspects them, checking if they
-    have the id we are looking for, and also inspecting the alias for the aws_env.
+    have the ID we are looking for, and also inspecting the alias for the `aws_env`.
     """
     for art in model_collection.artifacts():
         found_classifier_id, _ = art.source_name.split(":")
@@ -51,9 +51,9 @@ def check_existing_artifact_aliases(
     aws_env: AwsEnv,
 ) -> None:
     """
-    Review current state of the model in the wandb registry.
+    Review current state of the model in the W&B registry.
 
-    This means first checking wether the collection itself exists (/Q123).
+    This means first checking whether the collection itself exists (/Q123).
     Then if found, will look if the artifact already exists within the collection.
     If the artifact exists, will check the aliases to see if there are any conflicts.
 
@@ -168,7 +168,7 @@ def main(
         # Regardless of the promotion, we'll always be using some artifact.
         #
         # This also validates that the classifier exists. It relies on an
-        # artifiact not existing. That is, when trying to `use_artifact`
+        # artifact not existing. That is, when trying to `use_artifact`
         # below, it'll throw an exception.
         model_path = ModelPath(wikibase_id=wikibase_id, classifier_id=classifier_id)
         artifact_id = f"{model_path}:{aws_env.value}"

--- a/scripts/upload_targets_data.py
+++ b/scripts/upload_targets_data.py
@@ -23,7 +23,7 @@ console = Console()
 
 
 def relevant_spans(hf_spans: list[list], concept_id: WikibaseID | None) -> list[list]:
-    """Filters the spans that are irrelevent for the given concept"""
+    """Filters the spans that are irrelevant for the given concept"""
     concept_to_label_map = {
         "Q1651": {"NZT", "Reduction", "Other", "Conditional"},
         "Q1652": {"NZT", "Reduction"},

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -73,7 +73,7 @@ def test_vespa_search_adapter_from_aws_secrets(
     mock_vespa_credentials,
     tmp_path,
 ) -> None:
-    """Test that we can successfully instantiate the VespaSearchAdpater from ssm params."""
+    """Test that we can successfully instantiate the VespaSearchAdapter from ssm params."""
     vespa_search_adapter = get_vespa_search_adapter_from_aws_secrets(
         cert_dir=str(tmp_path),
         vespa_public_cert_param_name="VESPA_PUBLIC_CERT_FULL_ACCESS",

--- a/uv.lock
+++ b/uv.lock
@@ -1068,6 +1068,21 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/24/a2e7fb78fba577641c286fe33185789ab1e1569ccdf4d142e005995991d2/duckdb-1.3.2.tar.gz", hash = "sha256:c658df8a1bc78704f702ad0d954d82a1edd4518d7a04f00027ec53e40f591ff5", size = 11627775, upload-time = "2025-07-08T10:41:14.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/f0/8cac9713735864899e8abc4065bbdb3d1617f2130006d508a80e1b1a6c53/duckdb-1.3.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3418c973b06ac4e97f178f803e032c30c9a9f56a3e3b43a866f33223dfbf60b", size = 15535350, upload-time = "2025-07-08T10:40:45.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/26/6698bbb30b7bce8b8b17697599f1517611c61e4bd68b37eaeaf4f5ddd915/duckdb-1.3.2-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:2a741eae2cf110fd2223eeebe4151e22c0c02803e1cfac6880dbe8a39fecab6a", size = 32534715, upload-time = "2025-07-08T10:40:47.615Z" },
+    { url = "https://files.pythonhosted.org/packages/10/75/8ab4da3099a2fac7335ecebce4246706d19bdd5dad167aa436b5b27c43c4/duckdb-1.3.2-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:51e62541341ea1a9e31f0f1ade2496a39b742caf513bebd52396f42ddd6525a0", size = 17110300, upload-time = "2025-07-08T10:40:49.674Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/46/af81b10d4a66a0f27c248df296d1b41ff2a305a235ed8488f93240f6f8b5/duckdb-1.3.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3e519de5640e5671f1731b3ae6b496e0ed7e4de4a1c25c7a2f34c991ab64d71", size = 19180082, upload-time = "2025-07-08T10:40:51.679Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fc/259a54fc22111a847981927aa58528d766e8b228c6d41deb0ad8a1959f9f/duckdb-1.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4732fb8cc60566b60e7e53b8c19972cb5ed12d285147a3063b16cc64a79f6d9f", size = 21128404, upload-time = "2025-07-08T10:40:53.772Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/dc/5d5140383e40661173dacdceaddee2a97c3f6721a5e8d76e08258110595e/duckdb-1.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97f7a22dcaa1cca889d12c3dc43a999468375cdb6f6fe56edf840e062d4a8293", size = 22779786, upload-time = "2025-07-08T10:40:55.826Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c9/2fcd86ab7530a5b6caff42dbe516ce7a86277e12c499d1c1f5acd266ffb2/duckdb-1.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:cd3d717bf9c49ef4b1016c2216517572258fa645c2923e91c5234053defa3fb5", size = 11395370, upload-time = "2025-07-08T10:40:57.655Z" },
+]
+
+[[package]]
 name = "dulwich"
 version = "0.21.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2027,6 +2042,7 @@ coiled = [
 dev = [
     { name = "azure-pdf-parser" },
     { name = "boto3" },
+    { name = "duckdb" },
     { name = "hypothesis" },
     { name = "jinja2" },
     { name = "mkdocs-material" },
@@ -2065,6 +2081,7 @@ requires-dist = [
     { name = "dask", marker = "extra == 'coiled'", specifier = ">=2025.7.0" },
     { name = "datasets", specifier = ">=2.18.0" },
     { name = "distributed", marker = "extra == 'coiled'", specifier = ">=2025.7.0" },
+    { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "griffe", specifier = "==1.5.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.112.2" },


### PR DESCRIPTION
This was prompted by a spelling mistake of mine almost slipping through today. It can auto-fix spelling mistakes too, which is how all of these corrections came about, by running `$ just lint-all`.

I've used [typos](https://github.com/crate-ci/typos/) for a while personally, to great success, via the CLI, LSP, and in other repositories. It's fined for spelling within software.

**Appendix**

- I've updated all pre-commit hooks too.
- Add missing dependency: As surfaced by pyright.
- Migrated to the new name for `ruff-check`.

