### PR TITLE
Bugfix/fix result persistence from inference batch jobs

### DIFF
--- a/flows/full_pipeline.py
+++ b/flows/full_pipeline.py
@@ -87,7 +87,7 @@ async def full_pipeline(
         classifier_specs=classifier_specs,
         document_ids=document_ids,
         use_new_and_updated=inference_use_new_and_updated,
-        pipeline_config=config,
+        config=config,
         batch_size=inference_batch_size,
         classifier_concurrency_limit=inference_classifier_concurrency_limit,
         return_state=True,

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -66,6 +66,8 @@ BLOCKED_BLOCK_TYPES: Final[set[BlockType]] = {
 
 CLASSIFIER_CONCURRENCY_LIMIT: Final[PositiveInt] = 20
 INFERENCE_BATCH_SIZE_DEFAULT: Final[PositiveInt] = 1000
+AWS_ENV: str = os.environ["AWS_ENV"]
+S3_BLOCK_RESULTS_CACHE: str = f"s3-bucket/cpr-{AWS_ENV}-prefect-results-cache"
 
 DocumentRunIdentifier: TypeAlias = tuple[str, str, str]
 
@@ -871,7 +873,7 @@ async def _inference_batch_of_documents(
 # then a custom serialiser should be considered.
 
 
-@flow(log_prints=True)
+@flow(log_prints=True, result_storage=S3_BLOCK_RESULTS_CACHE)
 async def inference_batch_of_documents_cpu(
     batch: list[DocumentStem],
     config_json: JsonDict,
@@ -886,7 +888,7 @@ async def inference_batch_of_documents_cpu(
     )
 
 
-@flow(log_prints=True)
+@flow(log_prints=True, result_storage=S3_BLOCK_RESULTS_CACHE)
 @coiled.function(  # pyright: ignore[reportUnknownMemberType]
     vm_type=DEFAULT_GPU_VM_TYPES,
 )

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -620,9 +620,11 @@ async def map_as_sub_flow(
                             # the return.
                             raise_on_failure=True,
                         )
+                        breakpoint()
                         flow_result: R = (
                             await result_fn() if fn_is_async(fn) else result_fn()
                         )
+                        breakpoint()
                         successes.append(flow_result)
                     else:
                         successes.append(result)

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -620,11 +620,9 @@ async def map_as_sub_flow(
                             # the return.
                             raise_on_failure=True,
                         )
-                        breakpoint()
                         flow_result: R = (
                             await result_fn() if fn_is_async(fn) else result_fn()
                         )
-                        breakpoint()
                         successes.append(flow_result)
                     else:
                         successes.append(result)

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -38,6 +38,7 @@ from vespa.application import Vespa
 from vespa.io import VespaQueryResponse
 
 from flows.config import Config
+from flows.inference import S3_BLOCK_RESULTS_CACHE
 from flows.utils import DocumentStem
 from flows.wikibase_to_s3 import Config as WikibaseToS3Config
 from scripts.cloud import AwsEnv
@@ -882,7 +883,7 @@ def vespa_lower_max_hit_limit(vespa_lower_max_hit_limit_query_profile_name: str)
 @asynccontextmanager
 async def s3_block_context():
     """Context manager for creating and cleaning up S3 blocks."""
-    bucket_name = f"cpr-{os.environ['AWS_ENV']}-prefect-results-cache"
+    bucket_name = S3_BLOCK_RESULTS_CACHE.replace("s3-bucket/", "")
 
     test_block = S3Bucket(bucket_name=bucket_name)
 

--- a/tests/flows/test_full_pipeline.py
+++ b/tests/flows/test_full_pipeline.py
@@ -33,7 +33,7 @@ async def test_full_pipeline_no_config_provided(
     # Mock the sub-flows
     with (
         patch(
-            "flows.full_pipeline.inference_with_result_cache",
+            "flows.full_pipeline.inference",
             new_callable=AsyncMock,
         ) as mock_inference,
         patch(
@@ -125,7 +125,7 @@ async def test_full_pipeline_with_full_config(
     # Mock the sub-flows
     with (
         patch(
-            "flows.full_pipeline.inference_with_result_cache",
+            "flows.full_pipeline.inference",
             new_callable=AsyncMock,
         ) as mock_inference,
         patch(
@@ -229,7 +229,7 @@ async def test_full_pipeline_with_inference_failure(
     # Mock the sub-flows
     with (
         patch(
-            "flows.full_pipeline.inference_with_result_cache",
+            "flows.full_pipeline.inference",
             new_callable=AsyncMock,
         ) as mock_inference,
         patch(

--- a/tests/flows/test_full_pipeline.py
+++ b/tests/flows/test_full_pipeline.py
@@ -90,7 +90,7 @@ async def test_full_pipeline_no_config_provided(
         # Verify sub-flows were called with correct parameters
         mock_inference.assert_called_once()
         call_args = mock_inference.call_args
-        assert call_args.kwargs["pipeline_config"] == test_config
+        assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["classifier_specs"] is None
         assert call_args.kwargs["document_ids"] is None
         assert call_args.kwargs["use_new_and_updated"] is False
@@ -195,7 +195,7 @@ async def test_full_pipeline_with_full_config(
             ]
         )
         assert call_args.kwargs["use_new_and_updated"] is True
-        assert call_args.kwargs["pipeline_config"] == test_config
+        assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
         assert call_args.kwargs["classifier_concurrency_limit"] == 5
 
@@ -307,7 +307,7 @@ async def test_full_pipeline_with_inference_failure(
             ]
         )
         assert call_args.kwargs["use_new_and_updated"] is True
-        assert call_args.kwargs["pipeline_config"] == test_config
+        assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
         assert call_args.kwargs["classifier_concurrency_limit"] == 5
 


### PR DESCRIPTION
This Pull Request: 
---
- Reverts a prior [PR](https://github.com/climatepolicyradar/knowledge-graph/pull/551/files) that I made to attempt to dynamically load the results cache bucket from the default job variables. 
- This change was incorrect in that we removed caching from the batch level inference jobs and put it onto the top level inference flow. 
- Making this reversion in an attempt to get the pipeline fixed as soon as possible to unblock running it on the latest docs. 