### PR TITLE
Creating aioboto3 session within process_document function.

### DIFF
--- a/flows/aggregate.py
+++ b/flows/aggregate.py
@@ -199,13 +199,13 @@ def task_run_name(parameters: dict[str, Any]) -> str:
 )
 async def process_document(
     document_stem: DocumentStem,
-    session: aioboto3.Session,
     classifier_specs: Sequence[ClassifierSpec],
     config: Config,
     run_output_identifier: RunOutputIdentifier,
 ) -> DocumentStem:
     """Process a single document and return its status."""
     try:
+        session = aioboto3.Session(region_name=config.bucket_region)
         async with session.client("s3") as s3:
             print("Fetching labelled passages for", document_stem)
 
@@ -396,8 +396,6 @@ async def aggregate_batch_of_documents(
     """Aggregate the inference results for the given document ids."""
     config = Config.model_validate(config_json)
 
-    session = aioboto3.Session(region_name=config.bucket_region)
-
     tasks: list[PrefectFuture[DocumentStem]] = []
 
     print("submitting tasks")
@@ -430,7 +428,6 @@ async def aggregate_batch_of_documents(
                 asset_deps=asset_deps,  # pyright: ignore[reportArgumentType]
             ).submit(
                 document_stem=document_stem,
-                session=session,
                 classifier_specs=classifier_specs,
                 config=config,
                 run_output_identifier=run_output_identifier,

--- a/tests/flows/test_aggregate.py
+++ b/tests/flows/test_aggregate.py
@@ -5,7 +5,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import aioboto3
 import pydantic
 import pytest
 from cpr_sdk.models.search import Concept as VespaConcept
@@ -213,10 +212,8 @@ async def test_process_single_document__success(
     _, classifier_specs = mock_classifier_specs
     document_stem = DocumentStem("CCLW.executive.10061.4515")
 
-    session = aioboto3.Session(region_name=test_config.bucket_region)
     assert document_stem == await process_document.fn(
         document_stem,
-        session,
         classifier_specs,
         test_config,
         "run_output_identifier",
@@ -254,11 +251,9 @@ async def test_process_single_document__client_error(
     classifier_specs.append(ClassifierSpec(name="Q9999999999", alias="v99"))
     write_spec_file(spec_file_path, classifier_specs)
 
-    session = aioboto3.Session(region_name=test_config.bucket_region)
     result = await asyncio.gather(
         process_document.fn(
             document_stem,
-            session,
             classifier_specs,
             test_config,
             "run_output_identifier",
@@ -310,11 +305,9 @@ async def test_process_single_document__value_error(
         Body=json.dumps(new_data_short),
     )
 
-    session = aioboto3.Session(region_name=test_config.bucket_region)
     result = await asyncio.gather(
         process_document.fn(
             document_stem,
-            session,
             classifier_specs,
             test_config,
             "run_output_identifier",


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for an intermittent error that was seen within the knowledge graph `full-pipeline`. 
- Logs of the error can be seen [here](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/task-run/0198e653-78b4-73ba-98a2-a83a3546b865/logs). 

> got Future attached to a different loop

- I believe the issue is that when we submit `process_document` tasks they may be submitted to a different thread than the `aggregate_batch_of_documents` flow. 
- `aioboto3.Session` is created inside the `aggregate_batch_of_documents` flow, and passed into the `process_document` tasks which are then run asynchronously. The session is not thread safe which I believe is causing the error should the process document task be submitted to a different thread. 
- [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html#multithreading-or-multiprocessing-with-sessions). 
- [aioboto3 issue](https://github.com/aio-libs/aiobotocore/issues/1088)

- Testing on staging [here](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068adbe6-f30a-7a7b-8000-19400d8eac99?entity_id=068adbe6-f30a-7a7b-8000-19400d8eac99&state=pending).

Note: Due to CD being slow I've enabled auto merge so don't approve for anything blocking. 