### PR TITLE
refactor: Allow all AWS environments to send Slack notifications

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -112,12 +112,6 @@ class SlackNotify:
         ```
         """
 
-        if cls.environment != AwsEnv.production:
-            print(
-                f"Not sending Slack notification as in {cls.environment.name} and now {AwsEnv.production.name}"
-            )
-            return None
-
         ui_url = cls.FLOW_RUN_URL.format(
             prefect_base_url=PREFECT_UI_URL.value(), flow_run=flow_run
         )

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -120,7 +120,7 @@ class SlackNotify:
         if inspect.isawaitable(slack_webhook):
             slack_webhook = await slack_webhook
 
-        blocks = cls.slack_blocks(flow_run, state, ui_url)
+        blocks = cls.slack_blocks(flow, flow_run, state, ui_url)
 
         client = slack_webhook.get_client()
         result = client.send(
@@ -138,15 +138,14 @@ class SlackNotify:
     @classmethod
     def slack_blocks(
         cls,
+        flow: Flow,
         flow_run: FlowRun,
         state: State,
         ui_url: str,
     ):
         """Create all Slack Blocks"""
 
-        header = (
-            "{cls.state_type_to_emoji(state.type)} Flow run *{flow.name}/{flow_run.name}* observed state `{state.name}`.",
-        )  # pyright: ignore[reportOptionalMemberAccess]
+        header = f"{cls.state_type_to_emoji(state.type)} Flow run *{flow.name}/{flow_run.name}* observed state `{state.name}`."  # pyright: ignore[reportOptionalMemberAccess]
 
         state_message = textwrap.shorten(
             state.message or "No message",

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -28,6 +28,7 @@ from cpr_sdk.parser_models import (
 from cpr_sdk.search_adaptors import VespaSearchAdapter
 from moto import mock_aws
 from prefect import Flow, State
+from prefect.client.schemas import StateType
 from prefect.logging import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from prefect_aws.s3 import S3Bucket
@@ -744,6 +745,7 @@ def mock_flow_run():
     mock_flow_run.state.name = "Completed"
     mock_flow_run.state.message = "message"
     mock_flow_run.state.timestamp = "2025-01-28T12:00:00+00:00"
+    mock_flow_run.state.type = StateType.COMPLETED
 
     yield mock_flow_run
 


### PR DESCRIPTION
I fixed an issue I introduced when making the notification pretty.

**Test**

<img width="1296" height="936" alt="CleanShot 2025-08-27 at 15 33 00" src="https://github.com/user-attachments/assets/eecf5913-99bd-4a23-96cb-27b203e2462f" />

```python
import asyncio

from prefect import flow

from flows.utils import SlackNotify


@flow(
    log_prints=True,
    on_failure=[SlackNotify.message],
    on_crashed=[SlackNotify.message],
    on_completion=[SlackNotify.message],
)
async def main():
    pass


if __name__ == "__main__":
    asyncio.run(main())
```

DEPENDS ON https://github.com/climatepolicyradar/orchestrator/pull/245

FIXES PLA-806
