### PR TITLE
refac: rename to `refresh_all_available_classifiers`

### DIFF
--- a/scripts/classifier_metadata.py
+++ b/scripts/classifier_metadata.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from flows.classifier_specs.spec_interface import load_classifier_specs
 from scripts.cloud import AwsEnv
 from scripts.config import WANDB_ENTITY
-from scripts.update_classifier_spec import get_all_available_classifiers
+from scripts.update_classifier_spec import refresh_all_available_classifiers
 from scripts.utils import DontRunOnEnum, ModelPath
 from src.identifiers import ClassifierID, WikibaseID
 
@@ -82,7 +82,7 @@ def update_entire_env(
             future.result()
 
     if update_specs:
-        get_all_available_classifiers([aws_env])
+        refresh_all_available_classifiers([aws_env])
 
 
 @app.command()
@@ -183,7 +183,7 @@ def update(
         artifact.save()
 
     if update_specs:
-        get_all_available_classifiers([aws_env])
+        refresh_all_available_classifiers([aws_env])
 
 
 if __name__ == "__main__":

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -12,7 +12,7 @@ import scripts.promote
 import scripts.train
 from scripts.cloud import AwsEnv, parse_aws_env, parse_spec_file, validate_transition
 from scripts.update_classifier_spec import (
-    get_all_available_classifiers,
+    refresh_all_available_classifiers,
 )
 from src.identifiers import WikibaseID
 
@@ -73,7 +73,7 @@ def existing(
                     primary=True,
                 )
 
-    get_all_available_classifiers([to_aws_env])
+    refresh_all_available_classifiers([to_aws_env])
 
 
 @app.command()
@@ -130,7 +130,7 @@ def new(
             failed_wikibase_ids.append((wikibase_id, e))
             continue
 
-    get_all_available_classifiers([aws_env])
+    refresh_all_available_classifiers([aws_env])
 
     if failed_wikibase_ids:
         for wikibase_id, e in failed_wikibase_ids:

--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -41,7 +41,7 @@ def sort_specs(specs: list[ClassifierSpec]) -> list[ClassifierSpec]:
 
 
 @app.command()
-def get_all_available_classifiers(aws_envs: list[AwsEnv] | None = None) -> None:
+def refresh_all_available_classifiers(aws_envs: list[AwsEnv] | None = None) -> None:
     """Refreshes the classifier specs with the latest state of wandb."""
     if not aws_envs:
         aws_envs = [e for e in AwsEnv]

--- a/tests/scripts/test_update_classifier_spec.py
+++ b/tests/scripts/test_update_classifier_spec.py
@@ -8,7 +8,7 @@ import pytest
 from flows.classifier_specs.spec_interface import ClassifierSpec
 from scripts.cloud import AwsEnv
 from scripts.update_classifier_spec import (
-    get_all_available_classifiers,
+    refresh_all_available_classifiers,
     sort_specs,
 )
 from src.identifiers import WikibaseID
@@ -61,11 +61,11 @@ def mock_wandb_api():
         yield mock_api
 
 
-def test_get_all_available_classifiers(mock_wandb_api):
+def test_refresh_all_available_classifiers(mock_wandb_api):
     with TemporaryDirectory() as temp_dir:
         temp_dir = Path(temp_dir)
         with patch("flows.classifier_specs.spec_interface.SPEC_DIR", temp_dir):
-            get_all_available_classifiers(aws_envs=[AwsEnv.sandbox])
+            refresh_all_available_classifiers(aws_envs=[AwsEnv.sandbox])
             output_path = temp_dir / "sandbox.yaml"
 
             with open(output_path, "r") as file:


### PR DESCRIPTION
follows up on an earlier suggestion: https://github.com/climatepolicyradar/knowledge-graph/pull/638#discussion_r2303976444