### PR TITLE
fix: resolve pydantic warnings for serialisation

### DIFF
--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -12,6 +12,7 @@ from flows.classifier_specs.spec_interface import (
     determine_spec_file_path,
 )
 from scripts.cloud import AwsEnv
+from scripts.utils import DontRunOnEnum
 from src.identifiers import WikibaseID
 
 load_dotenv()
@@ -27,7 +28,7 @@ WANDB_MODEL_REGISTRY = "wandb-registry-model"
 
 def write_spec_file(file_path: Path, data: list[ClassifierSpec]):
     """Save a classifier spec YAML"""
-    serialised_data = [d.model_dump(exclude_none=True) for d in data]
+    serialised_data = [d.model_dump(exclude_none=True, mode="json") for d in data]
     with open(file_path, "w") as file:
         yaml.dump(serialised_data, file, explicit_start=True, sort_keys=False)
 
@@ -72,18 +73,20 @@ def refresh_all_available_classifiers(aws_envs: list[AwsEnv] | None = None) -> N
         wikibase_id, wandb_registry_version = art.name.split(":")
         classifier_id, wandb_project_version = art.source_name.split(":")  # noqa: F841
         WikibaseID(wikibase_id)
-        spec = ClassifierSpec(
-            wikibase_id=wikibase_id,
-            classifier_id=classifier_id,
-            wandb_registry_version=wandb_registry_version,
-        )
+
+        spec_data = {
+            "wikibase_id": wikibase_id,
+            "classifier_id": classifier_id,
+            "wandb_registry_version": wandb_registry_version,
+        }
 
         if dont_run_on := art.metadata.get("dont_run_on"):
-            spec.dont_run_on = dont_run_on
+            spec_data["dont_run_on"] = [DontRunOnEnum(item) for item in dont_run_on]
 
         if compute_environment := art.metadata.get("compute_environment"):
-            spec.compute_environment = compute_environment
+            spec_data["compute_environment"] = compute_environment
 
+        spec = ClassifierSpec(**spec_data)
         specs[env].append(spec)
 
     for env in aws_envs:


### PR DESCRIPTION
When serialising the `run_only_on` and `compute_environment` fields, where causing warnings to be emitted:

```
PydanticSerializationUnexpectedValue(Expected `ComputeEnvironment` -
serialized value may not be as expected [input_value={'gpu': True},
input_type=dict])
```

```
PydanticSerializationUnexpectedValue(Expected `enum` - serialized value
may not be as expected [input_value='sabin', input_type=str])
```

This is resolved by refactoring how the model is built in the refresh so the field's classes are instantiated correctly first. Also to ensure the fields are subsequently serialised correctly the model dump is configured to use objects that work for json (converting the enums to strings)