### PR TITLE
fix: re-enable targets in outdated specs

### DIFF
--- a/flows/classifier_specs/prod.yaml
+++ b/flows/classifier_specs/prod.yaml
@@ -66,10 +66,6 @@
 - Q1369:v11
 - Q1370:v11
 - Q1371:v11
-# Targets classifiers are currently broken. We want to omit them from the knowledge graph full-pipeline.
-# This would typically be done following the documentation below, however we are mid migration
-# to the version 2 of the classifier spec yaml:
-# scripts/README.md#remove-a-classifier-spec
-# - Q1651:v3
-# - Q1652:v2
-# - Q1653:v2
+- Q1651:v3
+- Q1652:v2
+- Q1653:v2


### PR DESCRIPTION
The concept-api depends on these specs, we disabled targets so that we could run on new documents, but when the concepts api redeployed the targets classifiers would have been hidden for the concepts api. We don't use the old specs file in our pipeline anymore but I'm re-adding the targets here until we can untangle the dependency

[Issue reported on slack](https://climate-policy-radar.slack.com/archives/C08J4KKQSFM/p1756745331361759)