### PR TITLE
fix: Parse concept as Wikibase ID

### DIFF
--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -16,7 +16,9 @@ app = typer.Typer()
 def main(
     wikibase_id: Annotated[
         WikibaseID,
-        typer.Option(..., help="The Wikibase ID of the concept to fetch"),
+        typer.Option(
+            ..., help="The Wikibase ID of the concept to fetch", parser=WikibaseID
+        ),
     ],
 ):
     with console.status("Connecting to Wikibase..."):


### PR DESCRIPTION
This was failing for me. Not sure when it started.

```shell
just get-concept Q1363
uv run python scripts/get_concept.py --wikibase-id Q1363
╭──────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────╮
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/scripts/get_concept.py:54 in <module>              │
│                                                                                                                   │
│   51                                                                                                              │
│   52                                                                                                              │
│   53 if __name__ == "__main__":                                                                                   │
│ ❱ 54 │   app()                                                                                                    │
│   55                                                                                                              │
│                                                                                                                   │
│ ╭─────────────────────────────────────────────────── locals ────────────────────────────────────────────────────╮ │
│ │   Annotated = typing.Annotated                                                                                │ │
│ │         app = <typer.main.Typer object at 0x117cac1a0>                                                        │ │
│ │ concept_dir = PosixPath('/Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/data/processed/conce… │ │
│ │     console = <console width=117 ColorSystem.TRUECOLOR>                                                       │ │
│ │       typer = <module 'typer' from                                                                            │ │
│ │               '/Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-pack… │ │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:3 │
│ 40 in __call__                                                                                                    │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:3 │
│ 23 in __call__                                                                                                    │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:3 │
│ 76 in get_command                                                                                                 │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:5 │
│ 85 in get_command_from_info                                                                                       │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:5 │
│ 61 in get_params_convertors_ctx_param_name_from_function                                                          │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:8 │
│ 66 in get_click_param                                                                                             │
│                                                                                                                   │
│ /Users/jesse/src/github.com/climatepolicyradar/knowledge-graph/.venv/lib/python3.13/site-packages/typer/main.py:7 │
│ 94 in get_click_type                                                                                              │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Type not yet supported: <class 'src.identifiers.WikibaseID'>
error: Recipe `get-concept` failed on line 53 with exit code 1
```
