### PR TITLE
load `free-disk-space` github action from tagged release

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Remove unused software
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
It was loading from `@main` which feels like it could open us up to running whatever code is pushed to that repo. This PR swaps uses [the latest tagged version](https://github.com/jlumbroso/free-disk-space/tree/v1.3.1/) which is up to date with the latest on `main` anyway. 