### PR TITLE
Updating the default job variables to match latest revision.

### DIFF
--- a/deployments.py
+++ b/deployments.py
@@ -39,6 +39,7 @@ DEFAULT_FLOW_VARIABLES = {
     "cpu": MEGABYTES_PER_GIGABYTE * 4,
     "memory": MEGABYTES_PER_GIGABYTE * 16,
     "ephemeralStorage": {"sizeInGiB": 50},
+    "match_latest_revision_in_family": True,
 }
 
 
@@ -162,6 +163,7 @@ create_deployment(
     flow_variables={
         "cpu": MEGABYTES_PER_GIGABYTE * 16,
         "memory": MEGABYTES_PER_GIGABYTE * 64,
+        "match_latest_revision_in_family": True,
     },
     extra_tags=["type:sub"],
 )


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix following the below error:

> ClientException('An error occurred (ClientException) when calling the RegisterTaskDefinition operation: Too many concurrent attempts to create a new revision of the specified family.')

- The fix was found from [this](https://github.com/PrefectHQ/prefect/issues/15865) issue page. We're already at a prefect-aws version above 0.5.11 so making this change is expected to be the only required change for the fix. 
- Confirmed that the variable can be set within the job variables [here](https://github.com/PrefectHQ/prefect/blob/5625e0d086995762bcf5c45d41a21c33a7d2ef4b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py#L299). It can also be set at the work pool level.  