### PR TITLE
Update collect_unique_file_stems_under_prefix and dependencies to be async

### DIFF
--- a/flows/aggregate.py
+++ b/flows/aggregate.py
@@ -375,7 +375,7 @@ async def create_aggregate_inference_overall_summary_artifact(
     )
 
 
-def collect_stems_by_specs(config: Config) -> list[DocumentStem]:
+async def collect_stems_by_specs(config: Config) -> list[DocumentStem]:
     """Collect the stems for the given specs."""
     document_stems = []
     specs = load_classifier_specs(config.aws_env)
@@ -386,9 +386,10 @@ def collect_stems_by_specs(config: Config) -> list[DocumentStem]:
             spec.classifier_id,
         )
         document_stems.extend(
-            collect_unique_file_stems_under_prefix(
+            await collect_unique_file_stems_under_prefix(
                 bucket_name=config.cache_bucket_str,
                 prefix=prefix,
+                bucket_region=config.bucket_region,
             )
         )
 
@@ -500,7 +501,7 @@ async def aggregate(
             "no document stems provided, collecting all available from S3 under prefix: "
             + f"{config.aggregate_document_source_prefix}"
         )
-        document_stems = collect_stems_by_specs(config)
+        document_stems = await collect_stems_by_specs(config)
 
     run_output_identifier = build_run_output_identifier()
     classifier_specs = load_classifier_specs(config.aws_env)

--- a/flows/index.py
+++ b/flows/index.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, Final
 
+import aioboto3
 import boto3
 import httpx
 from cpr_sdk.models.search import Passage as VespaPassage
@@ -72,6 +73,19 @@ def load_json_data_from_s3(bucket: str, key: str) -> dict[str, Any]:
     response = s3.get_object(Bucket=bucket, Key=key)
     body = response["Body"].read().decode("utf-8")
     return json.loads(body)
+
+
+async def load_async_json_data_from_s3(
+    bucket: str, key: str, config: Config
+) -> dict[str, Any]:
+    """Load JSON data from an S3 URI asynchronously"""
+    session = aioboto3.Session(region_name=config.bucket_region)
+    async with session.client("s3") as s3client:
+        response = await s3client.get_object(Bucket=bucket, Key=key)
+        response_body = response["Body"]
+        read_body = await response_body.read()
+        decoded_body = read_body.decode("utf-8")
+        return json.loads(decoded_body)
 
 
 async def _update_vespa_passage_concepts(
@@ -222,8 +236,10 @@ async def index_document_passages(
 
     print(f"Loading aggregated inference results from S3: {aggregated_results_s3_uri}")
 
-    raw_data = load_json_data_from_s3(
-        bucket=aggregated_results_s3_uri.bucket, key=aggregated_results_s3_uri.key
+    raw_data = await load_async_json_data_from_s3(
+        bucket=aggregated_results_s3_uri.bucket,
+        key=aggregated_results_s3_uri.key,
+        config=config,
     )
     aggregated_inference_results: dict[TextBlockId, SerialisedVespaConcept] = {
         TextBlockId(k): v for k, v in raw_data.items()
@@ -724,13 +740,14 @@ async def index(
         logger.info(
             f"Running on all documents under run_output_identifier: {run_output_identifier}"
         )
-        collected_document_stems: list[DocumentStem] = (
-            collect_unique_file_stems_under_prefix(
-                bucket_name=config.cache_bucket_str,
-                prefix=os.path.join(
-                    config.aggregate_inference_results_prefix, run_output_identifier
-                ),
-            )
+        collected_document_stems: list[
+            DocumentStem
+        ] = await collect_unique_file_stems_under_prefix(
+            bucket_name=config.cache_bucket_str,
+            prefix=os.path.join(
+                config.aggregate_inference_results_prefix, run_output_identifier
+            ),
+            bucket_region=config.bucket_region,
         )
         document_stems = collected_document_stems
         logger.info(f"Found {len(document_stems)} document import ids to process.")

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -234,12 +234,12 @@ def local_vespa_search_adapter(
 @pytest_asyncio.fixture
 async def mock_async_bucket(
     mock_aws_creds, mock_s3_async_client, test_config
-) -> AsyncGenerator[tuple[str, S3Client], None]:
+) -> AsyncGenerator[str, None]:
     await mock_s3_async_client.create_bucket(
         Bucket=test_config.cache_bucket,
         CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
     )
-    yield test_config.cache_bucket, mock_s3_async_client
+    yield test_config.cache_bucket
 
     await mock_s3_async_client.delete_bucket(Bucket=test_config.cache_bucket)
 
@@ -523,12 +523,13 @@ def s3_prefix_inference_results(mock_run_output_identifier_str: str) -> str:
 
 @pytest_asyncio.fixture
 async def mock_bucket_inference_results(
-    mock_async_bucket_and_client,
+    mock_s3_async_client,
+    mock_async_bucket,
     s3_prefix_inference_results: str,
     aggregate_inference_results_document_stems: list[DocumentStem],
-) -> dict[str, dict[str, Any]]:
+) -> AsyncGenerator[dict[str, dict[str, Any]], None]:
     """A version of the inference results bucket with more files"""
-    mock_bucket, mock_s3_client = mock_async_bucket_and_client
+
     fixture_root = FIXTURE_DIR / "inference_results"
     fixture_files = [
         fixture_root / f"{document_stem}.json"
@@ -544,11 +545,22 @@ async def mock_bucket_inference_results(
         key = s3_prefix_inference_results + str(file_path.relative_to(fixture_root))
         inference_results[key] = json.loads(data)
 
-        await mock_s3_client.put_object(
-            Bucket=mock_bucket, Key=key, Body=body, ContentType="application/json"
+        await mock_s3_async_client.put_object(
+            Bucket=mock_async_bucket, Key=key, Body=body, ContentType="application/json"
         )
 
-    return inference_results
+    yield inference_results
+
+    # Teardown for objects
+    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(Bucket=mock_async_bucket):
+        delete_keys = []
+        for obj in page.get("Contents", []):
+            delete_keys.append({"Key": obj["Key"]})
+        if delete_keys:
+            await mock_s3_async_client.delete_objects(
+                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
+            )
 
 
 @pytest.fixture
@@ -570,10 +582,10 @@ def mock_bucket_labelled_passages_b(
 
 @pytest_asyncio.fixture
 async def mock_bucket_labelled_passages_large(
+    mock_s3_async_client,
     mock_async_bucket,
 ) -> AsyncGenerator[tuple[list[str], str, S3Client], None]:
     """A version of the labelled_passage bucket with more files"""
-    bucket, mock_s3_async_client = mock_async_bucket
     fixture_root = FIXTURE_DIR / "labelled_passages"
     fixture_files = list(fixture_root.glob("**/*.json"))
 
@@ -587,41 +599,20 @@ async def mock_bucket_labelled_passages_large(
         keys.append(key)
 
         await mock_s3_async_client.put_object(
-            Bucket=bucket, Key=key, Body=body, ContentType="application/json"
+            Bucket=mock_async_bucket, Key=key, Body=body, ContentType="application/json"
         )
 
-    yield (keys, bucket, mock_s3_async_client)
+    yield (keys, mock_async_bucket, mock_s3_async_client)
 
     # Teardown for objects
     paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=bucket):
+    async for page in paginator.paginate(Bucket=mock_async_bucket):
         delete_keys = []
         for obj in page.get("Contents", []):
             delete_keys.append({"Key": obj["Key"]})
         if delete_keys:
             await mock_s3_async_client.delete_objects(
-                Bucket=bucket, Delete={"Objects": delete_keys}
-            )
-
-
-@pytest_asyncio.fixture
-async def mock_async_bucket_and_client(
-    mock_async_bucket,
-) -> AsyncGenerator[tuple[str, S3Client], None]:
-    """Create mock async bucket"""
-    bucket, mock_s3_async_client = mock_async_bucket
-
-    yield (bucket, mock_s3_async_client)
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=bucket, Delete={"Objects": delete_keys}
+                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
             )
 
 
@@ -932,3 +923,38 @@ async def mock_prefect_s3_block():
     """Create an S3 block against the local prefect server."""
     async with s3_block_context() as block:
         yield block
+
+
+@pytest_asyncio.fixture
+async def mock_bucket_stem(
+    mock_s3_async_client,
+    mock_async_bucket,
+) -> AsyncGenerator[None, None]:
+    s3_paths = [
+        "test_prefix/Q1/v1/CCLW.executive.1.1.json",
+        "test_prefix/Q1/v1/CCLW.executive.2.2.json",
+        "test_prefix/Q1/v1/CCLW.executive.2.2_translated_en.json",
+        "test_prefix/Q1/v2/CCLW.executive.1.1.json",
+        "test_prefix/Q1/v2/CCLW.executive.2.2.json",
+        "test_prefix/Q2/v1/CCLW.executive.1.1.json",
+        "test_prefix/Q2/v1/CCLW.executive.2.2.json",
+        "test_prefix/Q3/v2/CCLW.executive.1.1.json",
+        "test_prefix/Q3/v2/CCLW.executive.2.2.json",
+        "test_prefix/Q3/v2/CCLW.executive.3.3.json",
+        "some_other_prefix/Q1/v1/CCLW.some_other_doc.4.4.json",
+    ]
+    for s3_path in s3_paths:
+        await mock_s3_async_client.put_object(Bucket=mock_async_bucket, Key=s3_path)
+
+    yield
+
+    # Teardown for objects
+    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(Bucket=mock_async_bucket):
+        delete_keys = []
+        for obj in page.get("Contents", []):
+            delete_keys.append({"Key": obj["Key"]})
+        if delete_keys:
+            await mock_s3_async_client.delete_objects(
+                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
+            )

--- a/tests/flows/test_aggregate.py
+++ b/tests/flows/test_aggregate.py
@@ -369,10 +369,11 @@ async def test_process_single_document__value_error(
     assert result == snapshot
 
 
-def test_collect_stems_by_specs(
+@pytest.mark.asyncio
+async def test_collect_stems_by_specs(
     mock_classifier_specs, mock_bucket_labelled_passages_large, test_config
 ):
-    stems = collect_stems_by_specs(test_config)
+    stems = await collect_stems_by_specs(test_config)
     assert set(stems) == set(
         [
             "UNFCCC.non-party.467.0",

--- a/tests/flows/test_index.py
+++ b/tests/flows/test_index.py
@@ -39,15 +39,12 @@ from flows.utils import (
 async def test_index_document_passages(
     vespa_app,
     local_vespa_search_adapter: VespaSearchAdapter,
-    mock_s3_client,
-    mock_bucket: str,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     mock_run_output_identifier_str: str,
     s3_prefix_inference_results: str,
     test_config,
 ) -> None:
     """Test that we loaded the inference results from the mock bucket."""
-
     run_output_identifier = RunOutputIdentifier(mock_run_output_identifier_str)
 
     async with local_vespa_search_adapter.client.asyncio() as vespa_connection_pool:
@@ -130,8 +127,6 @@ async def test_index_document_passages(
 async def test_index_document_passages__error_handling(
     vespa_app,
     local_vespa_search_adapter: VespaSearchAdapter,
-    mock_s3_client,
-    mock_bucket: str,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     mock_run_output_identifier_str: str,
     s3_prefix_inference_results: str,
@@ -171,8 +166,6 @@ async def test_index_document_passages__error_handling(
 async def test_index_batch_of_documents(
     vespa_app,
     local_vespa_search_adapter: VespaSearchAdapter,
-    mock_s3_client,
-    mock_bucket: str,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     aggregate_inference_results_document_stems: list[DocumentStem],
     mock_run_output_identifier_str: str,
@@ -289,8 +282,6 @@ async def test_index_batch_of_documents(
 async def test_index_batch_of_documents__failure(
     vespa_app,
     local_vespa_search_adapter: VespaSearchAdapter,
-    mock_s3_client,
-    mock_bucket: str,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     aggregate_inference_results_document_stems: list[DocumentStem],
     mock_run_output_identifier_str: str,
@@ -331,7 +322,6 @@ async def test_index_batch_of_documents__failure(
 @pytest.mark.asyncio
 async def test_run_indexing_from_aggregate_results__invokes_subdeployments_correctly(
     vespa_app,
-    mock_s3_client,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     aggregate_inference_results_document_stems: list[DocumentStem],
     mock_run_output_identifier_str: str,
@@ -420,8 +410,6 @@ async def test_run_indexing_from_aggregate_results__invokes_subdeployments_corre
 async def test_run_indexing_from_aggregate_results__handles_failures(
     vespa_app,
     local_vespa_search_adapter: VespaSearchAdapter,
-    mock_s3_client,
-    mock_bucket: str,
     mock_bucket_inference_results: dict[str, dict[str, Any]],
     mock_run_output_identifier_str: str,
     aggregate_inference_results_document_stems: list[DocumentStem],

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -182,7 +182,7 @@ async def test_collect_file_stems_under_prefix(
 ) -> None:
     """Test that we can collect file stems under a prefix."""
     bucket, mock_s3_async_client = mock_async_bucket_and_client
-    print("Running test")
+
     s3_paths = [
         "test_prefix/Q1/v1/CCLW.executive.1.1.json",
         "test_prefix/Q1/v1/CCLW.executive.2.2.json",
@@ -196,11 +196,9 @@ async def test_collect_file_stems_under_prefix(
         "test_prefix/Q3/v2/CCLW.executive.3.3.json",
         "some_other_prefix/Q1/v1/CCLW.some_other_doc.4.4.json",
     ]
-    print("Creating session")
     for s3_path in s3_paths:
-        print(f"Put {s3_path} in {bucket}")
         await mock_s3_async_client.put_object(Bucket=bucket, Key=s3_path)
-    print("Running utils collect function")
+
     file_stems = await collect_unique_file_stems_under_prefix(
         bucket_name=bucket,
         prefix="test_prefix",

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -176,9 +176,13 @@ def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> N
     assert file_stems == [f"{document_id}_translated_en"]
 
 
-def test_collect_file_stems_under_prefix(test_config, mock_bucket) -> None:
+@pytest.mark.asyncio
+async def test_collect_file_stems_under_prefix(
+    test_config, mock_async_bucket_and_client
+) -> None:
     """Test that we can collect file stems under a prefix."""
-
+    bucket, mock_s3_async_client = mock_async_bucket_and_client
+    print("Running test")
     s3_paths = [
         "test_prefix/Q1/v1/CCLW.executive.1.1.json",
         "test_prefix/Q1/v1/CCLW.executive.2.2.json",
@@ -192,13 +196,15 @@ def test_collect_file_stems_under_prefix(test_config, mock_bucket) -> None:
         "test_prefix/Q3/v2/CCLW.executive.3.3.json",
         "some_other_prefix/Q1/v1/CCLW.some_other_doc.4.4.json",
     ]
-    s3_client = boto3.client("s3")
+    print("Creating session")
     for s3_path in s3_paths:
-        s3_client.put_object(Bucket=test_config.cache_bucket, Key=s3_path)
-
-    file_stems = collect_unique_file_stems_under_prefix(
-        bucket_name=test_config.cache_bucket,
+        print(f"Put {s3_path} in {bucket}")
+        await mock_s3_async_client.put_object(Bucket=bucket, Key=s3_path)
+    print("Running utils collect function")
+    file_stems = await collect_unique_file_stems_under_prefix(
+        bucket_name=bucket,
         prefix="test_prefix",
+        bucket_region=test_config.bucket_region,
     )
 
     assert set(file_stems) == set(

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -177,30 +177,11 @@ def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> N
 
 
 @pytest.mark.asyncio
-async def test_collect_file_stems_under_prefix(
-    test_config, mock_async_bucket_and_client
-) -> None:
+async def test_collect_file_stems_under_prefix(test_config, mock_bucket_stem) -> None:
     """Test that we can collect file stems under a prefix."""
-    bucket, mock_s3_async_client = mock_async_bucket_and_client
-
-    s3_paths = [
-        "test_prefix/Q1/v1/CCLW.executive.1.1.json",
-        "test_prefix/Q1/v1/CCLW.executive.2.2.json",
-        "test_prefix/Q1/v1/CCLW.executive.2.2_translated_en.json",
-        "test_prefix/Q1/v2/CCLW.executive.1.1.json",
-        "test_prefix/Q1/v2/CCLW.executive.2.2.json",
-        "test_prefix/Q2/v1/CCLW.executive.1.1.json",
-        "test_prefix/Q2/v1/CCLW.executive.2.2.json",
-        "test_prefix/Q3/v2/CCLW.executive.1.1.json",
-        "test_prefix/Q3/v2/CCLW.executive.2.2.json",
-        "test_prefix/Q3/v2/CCLW.executive.3.3.json",
-        "some_other_prefix/Q1/v1/CCLW.some_other_doc.4.4.json",
-    ]
-    for s3_path in s3_paths:
-        await mock_s3_async_client.put_object(Bucket=bucket, Key=s3_path)
 
     file_stems = await collect_unique_file_stems_under_prefix(
-        bucket_name=bucket,
+        bucket_name=test_config.cache_bucket,
         prefix="test_prefix",
         bucket_region=test_config.bucket_region,
     )


### PR DESCRIPTION
+ Update `collect_unique_file_stems_under_prefix` to be asnyc (utils)
+ Update dependency `collect_stems_by_specs` (aggregate)
+ Update dependency `load_async_json_data_from_s3` (index)
+ Removed references to `mock_bucket` and `mock_s3_client` when not needed - already created by `mock_bucket_inference_results`
+ Refactored `mock_async_bucket` to remove unpacking tuple and added teardown to remove files from s3 
+ Added new fixture `mock_bucket_stem` to simplify test