### PR TITLE
Search for concepts and help pages through a WikibaseSession

### DIFF
--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -296,7 +296,12 @@ class WikibaseSession:
 
     @async_to_sync
     async def get_all_concept_ids(self) -> list[WikibaseID]:
-        """Sync wrapper for get_all_concept_ids_async"""
+        """
+        Get a complete list of all concept IDs in the Wikibase instance.
+
+        Returns:
+            List of all WikibaseID strings for concepts in the instance
+        """
         return await self.get_all_concept_ids_async()
 
     @retry(
@@ -397,7 +402,7 @@ class WikibaseSession:
     def _parse_wikibase_entity(
         self, wikibase_id: WikibaseID, entity: dict[str, Any]
     ) -> Concept:
-        """Parse a Wikibase entity JSON into a Concept object."""
+        """Parse a Wikibase entity (given in dict format) into a Concept object."""
         # Extract basic concept information
         preferred_label = (
             entity.get("labels", {})
@@ -522,6 +527,16 @@ class WikibaseSession:
 
         This is the core async implementation that provides high performance
         through concurrent HTTP requests.
+
+        Args:
+            limit: The maximum number of concepts to return
+            wikibase_ids: The Wikibase IDs of the concepts to return
+            timestamp: If specified, the retrieved concepts will contain the data as it
+                existed at the specified timestamp. Defaults to None, and retrieves the
+                latest version of the concept.
+
+        Returns:
+            List of Concept objects
         """
         client = await self._get_client()
 
@@ -650,10 +665,21 @@ class WikibaseSession:
         timestamp: Optional[datetime] = None,
     ) -> list[Concept]:
         """
-        Sync wrapper for get_concepts_async.
+        Fetches concepts from Wikibase with optional filtering and historical data.
 
-        This provides the familiar sync interface while leveraging
-        async performance internally.
+        This provides the familiar sync interface while leveraging async performance
+        internally. Supports fetching all concepts, specific concepts by ID, or
+        limiting the number of results.
+
+        Args:
+            limit: The maximum number of concepts to return
+            wikibase_ids: The Wikibase IDs of the concepts to return
+            timestamp: If specified, the retrieved concepts will contain the data as it
+                existed at the specified timestamp. Defaults to None, and retrieves the
+                latest version of the concept.
+
+        Returns:
+            List of Concept objects
         """
         return await self.get_concepts_async(limit, wikibase_ids, timestamp)
 
@@ -665,7 +691,21 @@ class WikibaseSession:
         include_recursive_subconcept_of: bool = False,
         include_recursive_has_subconcept: bool = False,
     ) -> Concept:
-        """Async version of get_concept"""
+        """
+        Async version of get_concept
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get
+            timestamp: If specified, the retrieved concept will contain the data as it
+            existed at the specified timestamp. Defaults to None, and retrieves the
+            latest version of the concept.
+            include_labels_from_subconcepts: If True, the concept's alternative_labels
+            field will include labels from all of its subconcepts, fetched recursively.
+            include_recursive_subconcept_of: If True, the concept will include a field
+            which lists its 'ancestors', ie its parent concepts, fetched recursively.
+            include_recursive_has_subconcept: If True, the concept will include a field
+            which lists its 'descendants', ie its subconcepts, fetched recursively.
+        """
         # Get the base concept first
         concepts = await self.get_concepts_async(
             wikibase_ids=[wikibase_id], timestamp=timestamp
@@ -727,7 +767,28 @@ class WikibaseSession:
         include_recursive_subconcept_of: bool = False,
         include_recursive_has_subconcept: bool = False,
     ) -> Concept:
-        """Sync wrapper for get_concept_async"""
+        """
+        Get a single concept from Wikibase with optional hierarchical relationships.
+
+        This provides the familiar sync interface while leveraging async performance
+        internally. Can include recursive subconcept relationships and aggregate
+        labels from child concepts.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get
+            timestamp: If specified, the retrieved concept will contain the data as it
+                existed at the specified timestamp. Defaults to None, and retrieves the
+                latest version of the concept.
+            include_labels_from_subconcepts: If True, the concept's alternative_labels
+                field will include labels from all of its subconcepts, fetched recursively.
+            include_recursive_subconcept_of: If True, the concept will include a field
+                which lists its 'ancestors', ie its parent concepts, fetched recursively.
+            include_recursive_has_subconcept: If True, the concept will include a field
+                which lists its 'descendants', ie its subconcepts, fetched recursively.
+
+        Returns:
+            Single Concept object with requested relationship data
+        """
         return await self.get_concept_async(
             wikibase_id,
             timestamp,
@@ -746,7 +807,18 @@ class WikibaseSession:
     async def get_recursive_has_subconcept_relationships_async(
         self, wikibase_id: WikibaseID
     ) -> list[WikibaseID]:
-        """Async version of recursive subconcept fetching"""
+        """
+        Get all subconcepts (descendants) of a concept recursively.
+
+        Returns a flat list of all concept IDs that are subconcepts of the given
+        concept, traversed recursively through the hierarchy.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get subconcepts for
+
+        Returns:
+            List of WikibaseID strings representing all recursive subconcepts
+        """
         return await self._get_recursive_relationships_async(
             wikibase_id, self.has_subconcept_property_id
         )
@@ -755,7 +827,18 @@ class WikibaseSession:
     async def get_recursive_has_subconcept_relationships(
         self, wikibase_id: WikibaseID
     ) -> list[WikibaseID]:
-        """Sync wrapper for get_recursive_has_subconcept_relationships_async"""
+        """
+        Get all subconcepts (descendants) of a concept recursively.
+
+        Returns a flat list of all concept IDs that are subconcepts of the given
+        concept, traversed recursively through the hierarchy.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get subconcepts for
+
+        Returns:
+            List of WikibaseID strings representing all recursive subconcepts
+        """
         return await self.get_recursive_has_subconcept_relationships_async(wikibase_id)
 
     @retry(
@@ -768,7 +851,18 @@ class WikibaseSession:
     async def get_recursive_subconcept_of_relationships_async(
         self, wikibase_id: WikibaseID
     ) -> list[WikibaseID]:
-        """Async version of recursive parent concept fetching"""
+        """
+        Get all parent concepts (ancestors) of a concept recursively.
+
+        Returns a flat list of all concept IDs that are parent concepts of the given
+        concept, traversed recursively through the hierarchy.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get parent concepts for
+
+        Returns:
+            List of WikibaseID strings representing all recursive parent concepts
+        """
         return await self._get_recursive_relationships_async(
             wikibase_id, self.subconcept_of_property_id
         )
@@ -777,7 +871,18 @@ class WikibaseSession:
     async def get_recursive_subconcept_of_relationships(
         self, wikibase_id: WikibaseID
     ) -> list[WikibaseID]:
-        """Sync wrapper for get_recursive_subconcept_of_relationships_async"""
+        """
+        Get all parent concepts (ancestors) of a concept recursively.
+
+        Returns a flat list of all concept IDs that are parent concepts of the given
+        concept, traversed recursively through the hierarchy.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get parent concepts for
+
+        Returns:
+            List of WikibaseID strings representing all recursive parent concepts
+        """
         return await self.get_recursive_subconcept_of_relationships_async(wikibase_id)
 
     @retry(
@@ -795,7 +900,16 @@ class WikibaseSession:
         current_depth: int = 0,
         visited: Optional[set[WikibaseID]] = None,
     ) -> list[WikibaseID]:
-        """Async version of recursive relationship fetching with concurrency"""
+        """
+        Async version of recursive relationship fetching with concurrency
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to get relationships for
+            property_id: The property ID of the relationship to fetch
+            max_depth: The maximum number of levels to recurse the relationships
+            current_depth: The current recursion depth, starting at 0
+            visited: The set of visited Wikibase IDs
+        """
         if visited is None:
             visited = set()
 
@@ -900,7 +1014,14 @@ class WikibaseSession:
         alternative_labels: list[str],
         language: str = "en",
     ):
-        """Add a list of alternative labels to a Wikibase item, preserving existing ones"""
+        """
+        Add a list of alternative labels to a Wikibase item, preserving existing ones
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to add alternative labels to
+            alternative_labels: The alternative labels to add
+            language: The language of the alternative labels. Defaults to "en".
+        """
         existing_alternative_labels = (
             await self.get_concept_async(wikibase_id)
         ).alternative_labels
@@ -944,13 +1065,34 @@ class WikibaseSession:
         alternative_labels: list[str],
         language: str = "en",
     ):
-        """Sync wrapper for add_alternative_labels_async"""
+        """
+        Add alternative labels (aliases) to a Wikibase concept.
+
+        Preserves existing alternative labels and adds new ones to the concept.
+        Duplicates are automatically removed.
+
+        Args:
+            wikibase_id: The Wikibase ID of the concept to add alternative labels to
+            alternative_labels: The alternative labels to add
+            language: The language of the alternative labels. Defaults to "en".
+
+        Returns:
+            Response data from the Wikibase API
+        """
         return await self.add_alternative_labels_async(
             wikibase_id, alternative_labels, language
         )
 
     async def search_help_pages_async(self, search_term: str) -> list[str]:
-        """Async method to search for help pages in Wikibase."""
+        """
+        Search for help pages in Wikibase by matching page titles and content.
+
+        Args:
+            search_term: Terms to search for in help page titles and content
+
+        Returns:
+            List of help page titles that match the search term
+        """
         client = await self._get_client()
         response = await client.get(
             url=self.api_url,
@@ -968,11 +1110,27 @@ class WikibaseSession:
 
     @async_to_sync
     async def search_help_pages(self, search_term: str) -> list[str]:
-        """Sync wrapper for search_help_pages_async"""
+        """
+        Search for help pages in Wikibase by matching page titles and content.
+
+        Args:
+            search_term: Terms to search for in help page titles and content
+
+        Returns:
+            List of help page titles that match the search term
+        """
         return await self.search_help_pages_async(search_term)
 
     async def get_help_page_async(self, page_title: str) -> str:
-        """Async method to get help page content as markdown."""
+        """
+        Get the content of a specific help page converted from HTML to markdown.
+
+        Args:
+            page_title: The exact title of the help page to retrieve
+
+        Returns:
+            The help page content converted from HTML to markdown format
+        """
         client = await self._get_client()
         response = await client.get(
             url=self.api_url,
@@ -992,16 +1150,39 @@ class WikibaseSession:
 
     @async_to_sync
     async def get_help_page(self, page_title: str) -> str:
-        """Sync wrapper for get_help_page_async"""
+        """
+        Get the content of a specific help page, converted from HTML to markdown.
+
+        Args:
+            page_title: The exact title of the help page to retrieve
+
+        Returns:
+            The help page content converted from HTML to markdown format
+        """
         return await self.get_help_page_async(page_title)
 
     async def search_concepts_async(
         self,
         search_term: str,
-        limit: Optional[int] = None,
+        limit: Optional[int],
         timestamp: Optional[datetime] = None,
     ) -> list[Concept]:
-        """Async method to search for concepts and return full Concept objects."""
+        """
+        Search for concepts by matching against labels and descriptions in Wikibase.
+
+        This performs a search in the Wikibase instance and returns full Concept
+        objects for matching items.
+
+        Args:
+            search_term: Terms to search for in concept labels/descriptions
+            limit: The maximum number of concepts to return
+            timestamp: If specified, the retrieved concepts will contain the data as it
+                existed at the specified timestamp. Defaults to None, and retrieves the
+                latest version of the concept.
+
+        Returns:
+            List of matching Concept objects, ordered by search relevance
+        """
         client = await self._get_client()
         response = await client.get(
             url=self.api_url,
@@ -1039,5 +1220,20 @@ class WikibaseSession:
         limit: Optional[int] = None,
         timestamp: Optional[datetime] = None,
     ) -> list[Concept]:
-        """Sync wrapper for search_concepts_async"""
+        """
+        Search for concepts by matching against labels and descriptions in Wikibase.
+
+        This performs a search in the Wikibase instance and returns full Concept
+        objects for matching items.
+
+        Args:
+            search_term: Terms to search for in concept labels/descriptions
+            limit: The maximum number of concepts to return
+            timestamp: If specified, the retrieved concepts will contain the data as it
+                existed at the specified timestamp. Defaults to None, and retrieves the
+                latest version of the concept.
+
+        Returns:
+            List of matching Concept objects, ordered by search relevance
+        """
         return await self.search_concepts_async(search_term, limit, timestamp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pytest-aioboto3>=0.6.0",
     "coiled>=1.115.0",
     "prefect-coiled>=0.0.4",
+    "html2text>=2025.4.15",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "urllib3", marker = "python_full_version == '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/d0/9d64261186cff650fe63168441edb4f4cd33f085a74c0c54455630a71f91/botocore-1.39.11.tar.gz", hash = "sha256:953b12909d6799350e346ab038e55b6efe622c616f80aef74d7a6683ffdd972c", size = 14217749 }
 wheels = [
@@ -588,7 +588,7 @@ name = "build"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' and sys_platform != 'linux'" },
+    { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
@@ -722,7 +722,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1543,6 +1543,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656 },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1701,7 +1710,7 @@ name = "ipykernel"
 version = "6.30.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2040,6 +2049,7 @@ dependencies = [
     { name = "cpr-sdk" },
     { name = "datasets" },
     { name = "griffe" },
+    { name = "html2text" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "more-itertools" },
@@ -2117,6 +2127,7 @@ requires-dist = [
     { name = "distributed", marker = "extra == 'coiled'", specifier = ">=2025.7.0" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "griffe", specifier = "==1.5.7" },
+    { name = "html2text", specifier = ">=2025.4.15" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.112.2" },
     { name = "ipykernel", specifier = ">=6.29.3" },
@@ -2381,7 +2392,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2742,7 +2753,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878 },
@@ -2754,7 +2765,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211 },
@@ -2784,9 +2795,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841 },
@@ -2798,7 +2809,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129 },
@@ -3066,7 +3077,7 @@ name = "pandas"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version == '3.13.*'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -3387,11 +3398,11 @@ dependencies = [
     { name = "uv" },
     { name = "uvicorn" },
     { name = "websockets" },
-    { name = "whenever" },
+    { name = "whenever", marker = "python_full_version == '3.13.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/fd/4b4593e29342218d020c3aa18b982afb54770746f3020707b15d4eafbd53/prefect-3.4.17.tar.gz", hash = "sha256:665225935a58e162afa4bc14aa5f880a8551d19a3f696e02f6c8dd7aba0cd5a0", size = 5597760, upload-time = "2025-09-05T19:36:16.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/fd/4b4593e29342218d020c3aa18b982afb54770746f3020707b15d4eafbd53/prefect-3.4.17.tar.gz", hash = "sha256:665225935a58e162afa4bc14aa5f880a8551d19a3f696e02f6c8dd7aba0cd5a0", size = 5597760 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/77/5414ab4740c392aaf8e1a51ed2e7fb892b17370c9d1feba85bcb046bdc80/prefect-3.4.17-py3-none-any.whl", hash = "sha256:962fd837c76bb3ea8350c9d0a60c42a23ea9149227968b3c17c51e4bda8a69c0", size = 6110119, upload-time = "2025-09-05T19:36:12.917Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/77/5414ab4740c392aaf8e1a51ed2e7fb892b17370c9d1feba85bcb046bdc80/prefect-3.4.17-py3-none-any.whl", hash = "sha256:962fd837c76bb3ea8350c9d0a60c42a23ea9149227968b3c17c51e4bda8a69c0", size = 6110119 },
 ]
 
 [package.optional-dependencies]
@@ -3711,7 +3722,7 @@ cli = [
     { name = "rich" },
 ]
 cohere = [
-    { name = "cohere", marker = "sys_platform != 'emscripten'" },
+    { name = "cohere", marker = "platform_system != 'Emscripten'" },
 ]
 evals = [
     { name = "pydantic-evals" },
@@ -4360,7 +4371,7 @@ name = "ruamel-yaml"
 version = "0.18.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython' and python_full_version == '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/87/6da0df742a4684263261c253f00edd5829e6aca970fff69e75028cccc547/ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7", size = 145511 }
 wheels = [
@@ -4602,7 +4613,7 @@ name = "sqlalchemy"
 version = "2.0.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "(platform_machine == 'AMD64' and python_full_version == '3.13.*') or (platform_machine == 'WIN32' and python_full_version == '3.13.*') or (platform_machine == 'aarch64' and python_full_version == '3.13.*') or (platform_machine == 'amd64' and python_full_version == '3.13.*') or (platform_machine == 'ppc64le' and python_full_version == '3.13.*') or (platform_machine == 'win32' and python_full_version == '3.13.*') or (platform_machine == 'x86_64' and python_full_version == '3.13.*')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/03/a0af991e3a43174d6b83fca4fb399745abceddd1171bdabae48ce877ff47/sqlalchemy-2.0.42.tar.gz", hash = "sha256:160bedd8a5c28765bd5be4dec2d881e109e33b34922e50a3b881a7681773ac5f", size = 9749972 }
@@ -4815,23 +4826,23 @@ dependencies = [
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "setuptools", marker = "python_full_version == '3.13.*'" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -4869,7 +4880,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
@@ -4917,7 +4928,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223 },
@@ -5085,7 +5096,7 @@ name = "tzlocal"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761 }
 wheels = [
@@ -5163,7 +5174,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "packaging" },
     { name = "platformdirs" },
-    { name = "protobuf" },
+    { name = "protobuf", marker = "python_full_version == '3.13.*'" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },


### PR DESCRIPTION
Context: Last week, I moved our concept store documentation into wikibase as a series of Help pages, eg [Help:Hierarchy_heuristics](https://climatepolicyradar.wikibase.cloud/wiki/Help:Hierarchy_heuristics)

This PR gives us the ability to:
- search for those pages
- retrieve the content of the pages as markdown
- also search for concepts

These methods alone aren't super interesting... But it's very easy to build an MCP server around a class like this these days, and I think that's where they _could_ start becoming useful 👀

If, at some point in the future, we want to give LLM agents direct access to our concept store data, I reckon they'll benefit _a lot_ from having access to all of the good thinking in eg [our style guide](https://climatepolicyradar.wikibase.cloud/wiki/Help:Style_guide)... Maybe we could set up a more advanced [librarian](https://djhoyps9k9bag.cloudfront.net/) which periodically suggests edits to concepts based on the latest heuristics etc. All speculation, obviously, but I think there are some interesting possibilities here which are enabled by these small additions!