### PR TITLE
Update flows s3 interactions as async

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -221,25 +221,6 @@ async def get_latest_ingest_documents(config: Config) -> Sequence[DocumentImport
     file_name = "new_and_updated_documents.json"
 
     # First get all matching files, then sort them
-    # matching_files: list[ObjectTypeDef] = [
-    #     item
-    #     async for item in page_iterator.search(
-    #         f"Contents[?contains(Key, '{file_name}')]"
-    #     )
-    #     if item is not None
-    # ]
-
-    # if not matching_files:
-    #     raise ValueError(
-    #         f"failed to find any `{file_name}` files in "
-    #         f"`{config.cache_bucket}/{config.pipeline_state_prefix}`"
-    #     )
-
-    # Sort by Key and get the last one
-    # latest = sorted(matching_files, key=lambda x: x["Key"])[-1]
-
-    # data = await download_s3_file(config, latest["Key"])  # pyright: ignore[reportGeneralTypeIssues]
-
     matching_files: list[ObjectTypeDef] = []
 
     # Iterate through pages and extract the "Contents" list
@@ -268,7 +249,6 @@ async def get_latest_ingest_documents(config: Config) -> Sequence[DocumentImport
     latest_key = latest["Key"]
 
     data = await download_s3_file(config, latest_key)
-
     content = json.loads(data)
     updated = list(content["updated_documents"].keys())
     new = [d["import_id"] for d in content["new_documents"]]

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -245,9 +245,7 @@ async def get_latest_ingest_documents(config: Config) -> Sequence[DocumentImport
     # Sort by "Key" and get the last one
     latest = sorted(filtered_files, key=lambda x: x["Key"])[-1]
 
-    # Safely access the "Key" field
     latest_key = latest["Key"]
-
     data = await download_s3_file(config, latest_key)
     content = json.loads(data)
     updated = list(content["updated_documents"].keys())

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -267,7 +267,7 @@ async def get_latest_ingest_documents(config: Config) -> Sequence[DocumentImport
     # Safely access the "Key" field
     latest_key = latest["Key"]
 
-    data = await download_s3_file(config, latest_key)  # pyright: ignore[reportGeneralTypeIssues]
+    data = await download_s3_file(config, latest_key)
 
     content = json.loads(data)
     updated = list(content["updated_documents"].keys())

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -9,7 +9,6 @@ import time
 from collections.abc import Awaitable, Generator, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from io import BytesIO
 from pathlib import Path
 from typing import (
     Annotated,
@@ -372,41 +371,6 @@ async def collect_unique_file_stems_under_prefix(
                 if obj["Key"].endswith(".json"):  # pyright: ignore[reportTypedDictNotRequiredAccess]
                     file_stems.append(DocumentStem(Path(obj["Key"]).stem))  # pyright: ignore[reportTypedDictNotRequiredAccess]
     return list(set(file_stems))
-
-
-def _s3_object_write_text(s3_uri: str, text: str) -> None:
-    """Write text content to an S3 object."""
-    # Parse the S3 URI
-    s3_path: Path = Path(s3_uri)
-    if len(s3_path.parts) < 3:
-        raise ValueError(f"Invalid S3 path: {s3_path}")
-
-    bucket: str = s3_path.parts[1]
-    key = str(Path(*s3_path.parts[2:]))
-
-    # Create BytesIO buffer with the text content
-    body = BytesIO(text.encode("utf-8"))
-
-    # Upload to S3
-    s3 = boto3.client("s3")
-    _ = s3.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
-
-
-def _s3_object_write_bytes(s3_uri: str, bytes: BytesIO) -> None:
-    """Write text content to an S3 object."""
-    # Parse the S3 URI
-    s3_path: Path = Path(s3_uri)
-    if len(s3_path.parts) < 3:
-        raise ValueError(f"Invalid S3 path: {s3_path}")
-
-    bucket: str = s3_path.parts[1]
-    key = str(Path(*s3_path.parts[2:]))
-
-    # Upload to S3
-    s3 = boto3.client("s3")
-    _ = s3.put_object(
-        Bucket=bucket, Key=key, Body=bytes, ContentType="application/json"
-    )
 
 
 def is_file_stem_for_english_language_document(

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -231,6 +231,19 @@ def local_vespa_search_adapter(
     yield adapter
 
 
+async def clean_up_bucket(mock_s3_async_client, mock_async_bucket):
+    # Teardown for objects
+    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(Bucket=mock_async_bucket):
+        delete_keys = []
+        for obj in page.get("Contents", []):
+            delete_keys.append({"Key": obj["Key"]})
+        if delete_keys:
+            await mock_s3_async_client.delete_objects(
+                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
+            )
+
+
 @pytest_asyncio.fixture
 async def mock_async_bucket(
     mock_aws_creds, mock_s3_async_client, test_config
@@ -242,6 +255,7 @@ async def mock_async_bucket(
     )
     yield test_config.cache_bucket
 
+    await clean_up_bucket(mock_s3_async_client, test_config.cache_bucket)
     await mock_s3_async_client.delete_bucket(Bucket=test_config.cache_bucket)
 
 
@@ -267,35 +281,10 @@ def mock_cdn_bucket(
     yield test_wikibase_to_s3_config.cdn_bucket_name
 
 
-@pytest.fixture
-def mock_bucket_b(
-    mock_aws_creds, mock_s3_client, test_config
-) -> Generator[str, Any, Any]:
-    bucket = test_config.cache_bucket + "b"
-    mock_s3_client.create_bucket(
-        Bucket=bucket,
-        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
-    )
-    yield bucket
-
-
 def load_fixture(file_name) -> str:
     fixture_path = FIXTURE_DIR / file_name
     with open(fixture_path) as f:
         return f.read()
-
-
-@pytest.fixture
-def mock_bucket_documents(mock_s3_client, mock_bucket):
-    fixture_files = ["GEF.document.0.1.json", "CPR.document.0.1.json"]
-    for file_name in fixture_files:
-        data = load_fixture(file_name)
-        body = BytesIO(data.encode("utf-8"))
-        key = os.path.join("embeddings_input", file_name)
-        mock_s3_client.put_object(
-            Bucket=mock_bucket, Key=key, Body=body, ContentType="application/json"
-        )
-    yield fixture_files
 
 
 @pytest_asyncio.fixture
@@ -309,17 +298,6 @@ async def mock_async_bucket_documents(mock_s3_async_client, mock_async_bucket):
             Bucket=mock_async_bucket, Key=key, Body=body, ContentType="application/json"
         )
     yield fixture_files
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
 
 
 @pytest_asyncio.fixture
@@ -350,7 +328,7 @@ async def mock_async_bucket_multiple_sources(mock_s3_async_client, mock_async_bu
 
 
 async def create_mock_new_and_updated_documents_json(
-    mock_s3_client, mock_bucket, doc_names: tuple[str, str], timestamp: str
+    mock_s3_async_client, mock_async_bucket, doc_names: tuple[str, str], timestamp: str
 ):
     first_doc, second_doc = doc_names
     content = {
@@ -361,8 +339,8 @@ async def create_mock_new_and_updated_documents_json(
     }
     data = BytesIO(json.dumps(content).encode("utf-8"))
     key = os.path.join("input", timestamp, "new_and_updated_documents.json")
-    await mock_s3_client.put_object(
-        Bucket=mock_bucket, Key=key, Body=data, ContentType="application/json"
+    await mock_s3_async_client.put_object(
+        Bucket=mock_async_bucket, Key=key, Body=data, ContentType="application/json"
     )
 
 
@@ -784,30 +762,6 @@ def mock_flow_run():
     mock_flow_run.state.type = StateType.COMPLETED
 
     yield mock_flow_run
-
-
-@pytest.fixture
-def mock_concepts_counts_document_keys() -> list[str]:
-    """Paths for all concepts_counts fixtures."""
-    keys = []
-    for path in FIXTURE_DIR.rglob("concepts_counts/**/*.json"):
-        keys.append(str(path.relative_to(FIXTURE_DIR)))
-    return keys
-
-
-@pytest.fixture
-def mock_bucket_concepts_counts(
-    mock_concepts_counts_document_keys,
-    mock_s3_client,
-    mock_bucket,
-) -> None:
-    """Puts the concept counts fixture files in the mock bucket."""
-    for key in mock_concepts_counts_document_keys:
-        data = load_fixture(key)
-        body = BytesIO(data.encode("utf-8"))
-        mock_s3_client.put_object(
-            Bucket=mock_bucket, Key=key, Body=body, ContentType="application/json"
-        )
 
 
 def mock_grouped_text_block_vespa_query_response_json() -> dict:

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -315,17 +315,6 @@ async def mock_async_bucket_multiple_sources(mock_s3_async_client, mock_async_bu
         )
     yield fixture_files
 
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
-
 
 async def create_mock_new_and_updated_documents_json(
     mock_s3_async_client, mock_async_bucket, doc_names: tuple[str, str], timestamp: str
@@ -364,17 +353,6 @@ async def mock_bucket_new_and_updated_documents_json(
         timestamp="2023-01-1T01.01.01.000001",
     )
     yield previous_docs, latest_docs
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
 
 
 @pytest.fixture
@@ -577,17 +555,6 @@ async def mock_async_bucket_inference_results(
 
     yield inference_results
 
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
-
 
 @pytest_asyncio.fixture
 async def mock_bucket_labelled_passages_large(
@@ -612,17 +579,6 @@ async def mock_bucket_labelled_passages_large(
         )
 
     yield (keys, mock_async_bucket, mock_s3_async_client)
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
 
 
 @pytest.fixture
@@ -932,30 +888,3 @@ async def mock_bucket_stem(
         await mock_s3_async_client.put_object(Bucket=mock_async_bucket, Key=s3_path)
 
     yield
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )
-
-
-@pytest_asyncio.fixture
-async def mock_async_bucket_labels(mock_s3_async_client, mock_async_bucket):
-    yield mock_async_bucket
-
-    # Teardown for objects
-    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
-    async for page in paginator.paginate(Bucket=mock_async_bucket):
-        delete_keys = []
-        for obj in page.get("Contents", []):
-            delete_keys.append({"Key": obj["Key"]})
-        if delete_keys:
-            await mock_s3_async_client.delete_objects(
-                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
-            )

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -3,12 +3,11 @@ import json
 import os
 import subprocess
 import xml.etree.ElementTree as ET
-from collections.abc import Generator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Generator
 from unittest.mock import MagicMock, Mock, patch
 
 import aioboto3

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -978,3 +978,19 @@ async def mock_bucket_stem(
             await mock_s3_async_client.delete_objects(
                 Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
             )
+
+
+@pytest_asyncio.fixture
+async def mock_async_bucket_labels(mock_s3_async_client, mock_async_bucket):
+    yield mock_async_bucket
+
+    # Teardown for objects
+    paginator = mock_s3_async_client.get_paginator("list_objects_v2")
+    async for page in paginator.paginate(Bucket=mock_async_bucket):
+        delete_keys = []
+        for obj in page.get("Contents", []):
+            delete_keys.append({"Key": obj["Key"]})
+        if delete_keys:
+            await mock_s3_async_client.delete_objects(
+                Bucket=mock_async_bucket, Delete={"Objects": delete_keys}
+            )

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -329,7 +329,7 @@ async def test_get_document_passages_from_vespa_over_limit(
 
 @pytest.mark.asyncio
 async def test_load_labelled_passages_by_uri_obj(
-    mock_async_bucket, mock_s3_async_client, mock_async_bucket_labels
+    mock_async_bucket, mock_s3_async_client
 ):
     fixture = load_fixture(
         "labelled_passages/Q218/q4xsgmjb/AF.document.002MMUCR.n0003.json"
@@ -498,7 +498,7 @@ async def test_load_labelled_passages_by_uri_obj(
 
 @pytest.mark.asyncio
 async def test_load_labelled_passages_by_uri_raw(
-    mock_async_bucket, mock_s3_async_client, mock_async_bucket_labels
+    mock_async_bucket, mock_s3_async_client
 ):
     fixture = load_fixture(
         "labelled_passages/Q857/sd6wjpa2/AF.document.i00000021.n0000_translated_en.json"

--- a/tests/flows/test_boundary.py
+++ b/tests/flows/test_boundary.py
@@ -327,18 +327,21 @@ async def test_get_document_passages_from_vespa_over_limit(
             )
 
 
-def test_load_labelled_passages_by_uri_obj(mock_bucket, mock_s3_client):
+@pytest.mark.asyncio
+async def test_load_labelled_passages_by_uri_obj(
+    mock_async_bucket, mock_s3_async_client, mock_async_bucket_labels
+):
     fixture = load_fixture(
         "labelled_passages/Q218/q4xsgmjb/AF.document.002MMUCR.n0003.json"
     )
-    mock_s3_client.put_object(
-        Bucket=mock_bucket,
+    await mock_s3_async_client.put_object(
+        Bucket=mock_async_bucket,
         Key="labelled_passages/Q218/q4xsgmjb/AF.document.002MMUCR.n0003.json",
         Body=fixture,
         ContentType="application/json",
     )
 
-    document_object_uri: DocumentObjectUri = f"s3://{mock_bucket}/labelled_passages/Q218/q4xsgmjb/AF.document.002MMUCR.n0003.json"
+    document_object_uri: DocumentObjectUri = f"s3://{mock_async_bucket}/labelled_passages/Q218/q4xsgmjb/AF.document.002MMUCR.n0003.json"
     assert load_labelled_passages_by_uri(document_object_uri) == [
         LabelledPassage(
             id="308",
@@ -493,18 +496,21 @@ def test_load_labelled_passages_by_uri_obj(mock_bucket, mock_s3_client):
     ]
 
 
-def test_load_labelled_passages_by_uri_raw(mock_bucket, mock_s3_client):
+@pytest.mark.asyncio
+async def test_load_labelled_passages_by_uri_raw(
+    mock_async_bucket, mock_s3_async_client, mock_async_bucket_labels
+):
     fixture = load_fixture(
         "labelled_passages/Q857/sd6wjpa2/AF.document.i00000021.n0000_translated_en.json"
     )
-    mock_s3_client.put_object(
-        Bucket=mock_bucket,
+    await mock_s3_async_client.put_object(
+        Bucket=mock_async_bucket,
         Key="labelled_passages/Q857/sd6wjpa2/AF.document.i00000021.n0000_translated_en.json",
         Body=fixture,
         ContentType="application/json",
     )
 
-    document_object_uri: DocumentObjectUri = f"s3://{mock_bucket}/labelled_passages/Q857/sd6wjpa2/AF.document.i00000021.n0000_translated_en.json"
+    document_object_uri: DocumentObjectUri = f"s3://{mock_async_bucket}/labelled_passages/Q857/sd6wjpa2/AF.document.i00000021.n0000_translated_en.json"
     assert load_labelled_passages_by_uri(document_object_uri) == [
         LabelledPassage(
             id="58",

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -108,14 +108,15 @@ def test_list_bucket_file_stems(test_config, mock_bucket_documents):
         (None, ["AF.document.002MMUCR.n0000"], ["AF.document.002MMUCR.n0000"]),
     ],
 )
-def test_determine_file_stems(
+@pytest.mark.asyncio
+async def test_determine_file_stems(
     mock_bucket_new_and_updated_documents_json,
     test_config,
     doc_ids,
     bucket_ids,
     expected,
 ):
-    got = determine_file_stems(
+    got = await determine_file_stems(
         config=test_config,
         use_new_and_updated=False,
         requested_document_ids=doc_ids,
@@ -124,11 +125,12 @@ def test_determine_file_stems(
     assert got == expected
 
 
-def test_determine_file_stems__error(
+@pytest.mark.asyncio
+async def test_determine_file_stems__error(
     mock_bucket_new_and_updated_documents_json, test_config
 ):
     with pytest.raises(ValueError):
-        _ = determine_file_stems(
+        _ = await determine_file_stems(
             config=test_config,
             use_new_and_updated=False,
             requested_document_ids=[
@@ -163,10 +165,11 @@ async def test_load_classifier__existing_classifier(
     assert classifier.id == classifier_id
 
 
-def test_load_document(test_config, mock_bucket_documents):
-    for doc_file_name in mock_bucket_documents:
+@pytest.mark.asyncio
+async def test_load_document(test_config, mock_async_bucket_documents):
+    for doc_file_name in mock_async_bucket_documents:
         file_stem = Path(doc_file_name).stem
-        doc = load_document(test_config, file_stem=file_stem)
+        doc = await load_document(test_config, file_stem=file_stem)
         assert file_stem == doc.document_id
 
 
@@ -403,15 +406,17 @@ async def test_inference_flow_returns_successful_batch_inference_result_with_doc
         assert inference_result.classifier_specs == [expected_classifier_spec]
 
 
-def test_get_latest_ingest_documents(
+@pytest.mark.asyncio
+async def test_get_latest_ingest_documents(
     test_config, mock_bucket_new_and_updated_documents_json
 ):
     _, latest_docs = mock_bucket_new_and_updated_documents_json
-    doc_ids = get_latest_ingest_documents(test_config)
+    doc_ids = await get_latest_ingest_documents(test_config)
     assert set(doc_ids) == latest_docs
 
 
-def test_get_latest_ingest_documents_no_latest(
+@pytest.mark.asyncio
+async def test_get_latest_ingest_documents_no_latest(
     test_config,
     # Setup the empty bucket
     mock_bucket,
@@ -420,7 +425,7 @@ def test_get_latest_ingest_documents_no_latest(
         ValueError,
         match="failed to find",
     ):
-        get_latest_ingest_documents(test_config)
+        await get_latest_ingest_documents(test_config)
 
 
 @pytest.mark.asyncio
@@ -429,7 +434,7 @@ async def test_run_classifier_inference_on_document(
     mock_classifiers_dir,
     mock_wandb,
     mock_bucket,
-    mock_bucket_documents,
+    mock_async_bucket_documents,
     snapshot,
 ):
     # Setup
@@ -450,7 +455,7 @@ async def test_run_classifier_inference_on_document(
     )
 
     # Run the function on a document with no language
-    document_stem = Path(mock_bucket_documents[1]).stem
+    document_stem = Path(mock_async_bucket_documents[1]).stem
     with pytest.raises(ValueError) as exc_info:
         result = await run_classifier_inference_on_document(
             config=test_config,
@@ -500,7 +505,7 @@ async def test_run_classifier_inference_on_document(
         assert result == snapshot
 
     # Run the function on a document with English language
-    document_stem = Path(mock_bucket_documents[0]).stem
+    document_stem = Path(mock_async_bucket_documents[0]).stem
     result = await run_classifier_inference_on_document(
         config=test_config,
         file_stem=DocumentStem(document_stem),
@@ -515,7 +520,7 @@ async def test_run_classifier_inference_on_document_missing(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
+    mock_async_bucket,
 ):
     # Setup
     _, mock_run, _ = mock_wandb
@@ -548,8 +553,8 @@ async def test_inference_batch_of_documents_cpu(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
-    mock_bucket_documents,
+    mock_s3_async_client,
+    mock_async_bucket_documents,
     mock_prefect_s3_block,
     snapshot,
 ):
@@ -559,7 +564,7 @@ async def test_inference_batch_of_documents_cpu(
 
     # Prepare test data - use only the PDF document which has languages field
     batch = [
-        DocumentStem(Path(mock_bucket_documents[0]).stem)
+        DocumentStem(Path(mock_async_bucket_documents[0]).stem)
     ]  # PDF.document.0.1 has languages
     classifier_spec = ClassifierSpec(
         wikibase_id=WikibaseID("Q788"),
@@ -635,22 +640,30 @@ async def test_inference_batch_of_documents_cpu(
 
         assert snapshot == artifact.data
 
-    # Verify that inference outputs were stored in S3
-    s3 = boto3.client("s3", region_name=test_config.bucket_region)
+    # Verify that inference outputs were stored in S3 using async s3 client
     expected_key = f"labelled_passages/{classifier_spec.wikibase_id}/{classifier_spec.classifier_id}/{batch[0]}.json"
 
     # Check that the S3 object exists
-    response = s3.head_object(Bucket=test_config.cache_bucket, Key=expected_key)
+    response = await mock_s3_async_client.head_object(
+        Bucket=test_config.cache_bucket, Key=expected_key
+    )
     assert response["ContentLength"] > 0, (
         f"Expected S3 object {expected_key} to have content"
     )
 
     # Verify the content of the stored labels
-    response = s3.get_object(Bucket=test_config.cache_bucket, Key=expected_key)
-    jsonl_content = response["Body"].read().decode("utf-8")
+    response = await mock_s3_async_client.get_object(
+        Bucket=test_config.cache_bucket, Key=expected_key
+    )
+    jsonl_content = await response["Body"].read()
+    jsonl_content_decoded = jsonl_content.decode("utf-8")
 
     # Parse JSONL format - each line is a JSON object
-    lines = [line.strip() for line in jsonl_content.strip().split("\n") if line.strip()]
+    lines = [
+        line.strip()
+        for line in jsonl_content_decoded.strip().split("\n")
+        if line.strip()
+    ]
 
     # Verify we have at least one label for successful processing
     assert len(lines) > 0, "Expected at least one labelled passage"
@@ -665,7 +678,8 @@ async def test_inference_batch_of_documents_cpu_with_failures(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
+    mock_async_bucket,
+    mock_s3_async_client,
     snapshot,
     mock_prefect_s3_block,
 ):
@@ -724,13 +738,15 @@ async def test_inference_batch_of_documents_cpu_with_failures(
 
     # For failed documents, no S3 files should be created since the documents don't exist
     # The failure happens before store_labels is called
-    s3 = boto3.client("s3", region_name=test_config.bucket_region)
+    # using async s3 client to check
 
     # Check that no labels were stored for the non-existent documents
     for doc_stem in batch:
         expected_key = f"labelled_passages/{classifier_spec.wikibase_id}/{classifier_spec.wandb_registry_version}/{doc_stem}.json"
         with pytest.raises(ClientError) as exc_info:
-            s3.head_object(Bucket=test_config.cache_bucket, Key=expected_key)
+            await mock_s3_async_client.head_object(
+                Bucket=test_config.cache_bucket, Key=expected_key
+            )
         assert exc_info.value.response["Error"]["Code"] == "404"
 
 
@@ -801,7 +817,7 @@ async def test__inference_batch_of_documents(
     mock_classifiers_dir,
     mock_wandb,
     mock_bucket,
-    mock_bucket_documents,
+    mock_async_bucket_documents,
     mock_prefect_s3_block,
 ):
     """Test the inner _inference_batch_of_documents function with mocked flow context."""
@@ -810,7 +826,7 @@ async def test__inference_batch_of_documents(
 
     # Prepare test data - use only the PDF document which has languages field
     batch = [
-        DocumentStem(Path(mock_bucket_documents[0]).stem)
+        DocumentStem(Path(mock_async_bucket_documents[0]).stem)
     ]  # PDF.document.0.1 has languages
     classifier_spec = ClassifierSpec(
         wikibase_id=WikibaseID("Q788"),

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -86,9 +86,10 @@ async def helper_list_labels_in_bucket(test_config, bucket_name, async_s3_client
     return labels
 
 
-def test_list_bucket_file_stems(test_config, mock_bucket_documents):
-    expected_ids = [Path(d).stem for d in mock_bucket_documents]
-    got_ids = list_bucket_file_stems(test_config)
+@pytest.mark.asyncio
+async def test_list_bucket_file_stems(test_config, mock_async_bucket_documents):
+    expected_ids = [Path(d).stem for d in mock_async_bucket_documents]
+    got_ids = await list_bucket_file_stems(test_config)
     assert sorted(expected_ids) == sorted(got_ids)
 
 
@@ -314,12 +315,12 @@ async def test_inference_with_dont_run_on_filter(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
-    mock_bucket_multiple_sources,
+    mock_async_bucket,
+    mock_async_bucket_multiple_sources,
     mock_deployment,
 ):
     input_doc_ids = [
-        DocumentImportId(Path(doc).stem) for doc in mock_bucket_multiple_sources
+        DocumentImportId(Path(doc).stem) for doc in mock_async_bucket_multiple_sources
     ]
     gef_doc_id, cpr_doc_id, sabin_doc_id = input_doc_ids
 
@@ -366,13 +367,14 @@ async def test_inference_flow_returns_successful_batch_inference_result_with_doc
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
-    mock_bucket_documents,
+    mock_async_bucket,
+    mock_async_bucket_documents,
     mock_deployment,
 ):
     """Test inference flow when creating batches of inference results"""
     input_doc_ids = [
-        DocumentImportId(Path(doc_file).stem) for doc_file in mock_bucket_documents
+        DocumentImportId(Path(doc_file).stem)
+        for doc_file in mock_async_bucket_documents
     ]
 
     expected_classifier_spec = ClassifierSpec(
@@ -422,7 +424,7 @@ async def test_get_latest_ingest_documents(
 async def test_get_latest_ingest_documents_no_latest(
     test_config,
     # Setup the empty bucket
-    mock_bucket,
+    mock_async_bucket,
 ):
     with pytest.raises(
         ValueError,

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -221,7 +221,7 @@ def test_document_passages__pdf(parser_output_pdf):
 
 @pytest.mark.asyncio
 async def test_store_labels(
-    test_config, mock_async_bucket_labels, mock_s3_async_client, snapshot
+    test_config, mock_async_bucket, mock_s3_async_client, snapshot
 ):
     text = "This is a test text block"
     spans = [Span(text=text, start_index=15, end_index=19)]
@@ -244,7 +244,7 @@ async def test_store_labels(
     assert unknown_failures == snapshot(name="unknown_failures")
 
     labels = await helper_list_labels_in_bucket(
-        test_config, mock_async_bucket_labels, mock_s3_async_client
+        test_config, mock_async_bucket, mock_s3_async_client
     )
 
     assert len(labels) == 1

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -367,12 +367,12 @@ async def test_inference_with_gpu_enabled(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
-    mock_bucket_multiple_sources,
+    mock_async_bucket,
+    mock_async_bucket_multiple_sources,
     mock_deployment,
 ):
     input_doc_ids = [
-        DocumentImportId(Path(doc).stem) for doc in mock_bucket_multiple_sources
+        DocumentImportId(Path(doc).stem) for doc in mock_async_bucket_multiple_sources
     ]
     output_doc_ids = [DocumentStem(doc) for doc in input_doc_ids]
 
@@ -409,7 +409,6 @@ async def test_inference_flow_returns_successful_batch_inference_result_with_doc
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_async_bucket,
     mock_async_bucket_documents,
     mock_deployment,
 ):
@@ -480,7 +479,6 @@ async def test_run_classifier_inference_on_document(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
     mock_async_bucket_documents,
     snapshot,
 ):
@@ -802,7 +800,7 @@ async def test_inference_batch_of_documents_cpu_empty_batch(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
+    mock_async_bucket,
     snapshot,
     mock_prefect_s3_block,
 ):
@@ -863,7 +861,6 @@ async def test__inference_batch_of_documents(
     test_config,
     mock_classifiers_dir,
     mock_wandb,
-    mock_bucket,
     mock_async_bucket_documents,
     mock_prefect_s3_block,
 ):

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -7,7 +7,6 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-import boto3
 import pytest
 from prefect.client.schemas.objects import FlowRun, State, StateType
 from prefect.flows import flow
@@ -125,27 +124,36 @@ def test_iterate_batch(data, expected_lengths):
         assert len(batch) == expected
 
 
-def test_s3_file_exists(test_config, mock_bucket_documents) -> None:
+@pytest.mark.asyncio
+async def test_s3_file_exists(test_config, mock_async_bucket_documents) -> None:
     """Test that we can check if a file exists in an S3 bucket."""
 
     key = os.path.join(
         test_config.inference_document_source_prefix, "PDF.document.0.1.json"
     )
 
-    s3_file_exists(test_config.cache_bucket, key)
+    await s3_file_exists(test_config.cache_bucket, key, test_config.bucket_region)
 
-    assert not s3_file_exists(test_config.cache_bucket, "non_existent_key")
+    assert not await s3_file_exists(
+        test_config.cache_bucket, "non_existent_key", test_config.bucket_region
+    )
 
 
-def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> None:
+@pytest.mark.asyncio
+async def test_get_file_stems_for_document_id(
+    test_config,
+    mock_s3_async_client,
+    mock_async_bucket_documents,
+) -> None:
     """Test that we can get the file stems for a document ID."""
 
-    document_id = Path(mock_bucket_documents[0]).stem
+    document_id = Path(mock_async_bucket_documents[0]).stem
 
-    file_stems = get_file_stems_for_document_id(
+    file_stems = await get_file_stems_for_document_id(
         document_id,
         test_config.cache_bucket,
         test_config.inference_document_source_prefix,
+        test_config.bucket_region,
     )
 
     assert file_stems == [document_id]
@@ -155,22 +163,22 @@ def test_get_file_stems_for_document_id(test_config, mock_bucket_documents) -> N
         test_config.inference_document_source_prefix,
         f"{document_id}_translated_en.json",
     )
-    s3_client = boto3.client("s3")
 
-    s3_client.put_object(
+    await mock_s3_async_client.put_object(
         Bucket=test_config.cache_bucket,
         Key=key,
         Body=body,
         ContentType="application/json",
     )
 
-    file_stems = get_file_stems_for_document_id(
+    file_stems = await get_file_stems_for_document_id(
         document_id=document_id,
         bucket_name=test_config.cache_bucket,
         document_key=os.path.join(
             test_config.inference_document_source_prefix,
             f"{document_id}.json",
         ),
+        bucket_region=test_config.bucket_region,
     )
 
     assert file_stems == [f"{document_id}_translated_en"]


### PR DESCRIPTION
+ Update Generator import in conftest
+ Remove unused functions in utils
+ Update download_s3_file in inference to be async and update dependencies and tests
+ Update store_labels in inference with tests and create new fixture to teardown bucket
+ Update get_bucket_paginator, list_bucket_file_stems in inference and s3_file_exists in utils (dependency), related bucket fixtures updated to be async, add pyright ignore to resolve before PR review
+ Update boundary tests for s3 to use async 
+ Remove unused fixtures from conftest
+ Refactor teardown by creating a function to remove objects from s3 bucket that is called as part of the teardown of `mock_async_bucket` instead of at the end of each downstream fixture
+ Refactor `get_latest_ingest_documents` to set type on `matching_files` and avoid pyright errors due to not recognising "Key" as a valid key in the `ListObjectsV2OutputTypeDef` type 