### PR TITLE
Update wikibase_to_s3 and dependencies to be async

### DIFF
--- a/tests/flows/test_wikibase_to_s3.py
+++ b/tests/flows/test_wikibase_to_s3.py
@@ -14,70 +14,87 @@ from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import WikibaseID
 
 
-def helper_get_concept_from_s3(
-    mock_s3_client: S3Client, bucket_name: str, wikibase_id: str
+async def helper_get_concept_from_s3(
+    mock_s3_async_client: S3Client, bucket_name: str, wikibase_id: str
 ) -> str:
-    result = mock_s3_client.get_object(
+    result = await mock_s3_async_client.get_object(
         Bucket=bucket_name,
         Key=f"concepts/{wikibase_id}.json",
     )
-    return result["Body"].read().decode("utf-8")
+    response = await result["Body"].read()
+    return response.decode("utf-8")
 
 
-def helper_upload_concept_to_s3(
-    mock_s3_client: S3Client, bucket_name: str, concept: Concept
+async def helper_upload_concept_to_s3(
+    mock_s3_async_client: S3Client, bucket_name: str, concept: Concept
 ):
     body = BytesIO(concept.model_dump_json().encode("utf-8"))
     key = f"concepts/{concept.wikibase_id}.json"
-    mock_s3_client.put_object(
+    await mock_s3_async_client.put_object(
         Bucket=bucket_name, Key=key, Body=body, ContentType="application/json"
     )
 
 
-def test_upload_to_s3(
-    mock_s3_client, mock_cdn_bucket, test_wikibase_to_s3_config, mock_concepts
+@pytest.mark.asyncio
+async def test_upload_to_s3(
+    mock_s3_async_client,
+    mock_async_cdn_bucket,
+    test_wikibase_to_s3_config,
+    mock_concepts,
 ):
     mock_concept = mock_concepts[0]
     key = f"concepts/{mock_concept.wikibase_id}.json"
 
     # Ensure files are not there
     with pytest.raises(ClientError):
-        mock_s3_client.head_object(Bucket=mock_cdn_bucket, Key=key)
+        await mock_s3_async_client.head_object(Bucket=mock_async_cdn_bucket, Key=key)
 
     # Upload, now they should be there
-    upload_to_s3(config=test_wikibase_to_s3_config, concept=mock_concept)
-    assert mock_s3_client.head_object(Bucket=mock_cdn_bucket, Key=key)
+    await upload_to_s3(config=test_wikibase_to_s3_config, concept=mock_concept)
+    assert await mock_s3_async_client.head_object(Bucket=mock_async_cdn_bucket, Key=key)
 
 
-def test_delete_from_s3(
-    mock_s3_client, mock_cdn_bucket, test_wikibase_to_s3_config, mock_concepts
+@pytest.mark.asyncio
+async def test_delete_from_s3(
+    mock_s3_async_client,
+    mock_async_cdn_bucket,
+    test_wikibase_to_s3_config,
+    mock_concepts,
 ):
     mock_concept = mock_concepts[0]
     key = f"concepts/{mock_concept.wikibase_id}.json"
 
     # First upload the concept to S3
-    helper_upload_concept_to_s3(mock_s3_client, mock_cdn_bucket, mock_concept)
+    await helper_upload_concept_to_s3(
+        mock_s3_async_client, mock_async_cdn_bucket, mock_concept
+    )
 
     # Verify it exists
-    assert mock_s3_client.head_object(Bucket=mock_cdn_bucket, Key=key)
+    assert await mock_s3_async_client.head_object(Bucket=mock_async_cdn_bucket, Key=key)
 
     # Delete it
-    delete_from_s3(
+    await delete_from_s3(
         config=test_wikibase_to_s3_config, concept_id=mock_concept.wikibase_id
     )
 
     # Verify it's gone
     with pytest.raises(ClientError):
-        mock_s3_client.head_object(Bucket=mock_cdn_bucket, Key=key)
+        await mock_s3_async_client.head_object(Bucket=mock_async_cdn_bucket, Key=key)
 
 
-def test_list_s3_concepts(
-    mock_s3_client, mock_cdn_bucket, mock_concepts, test_wikibase_to_s3_config
+@pytest.mark.asyncio
+async def test_list_s3_concepts(
+    mock_s3_async_client,
+    mock_async_cdn_bucket,
+    mock_concepts,
+    test_wikibase_to_s3_config,
 ):
     for concept in mock_concepts:
-        helper_upload_concept_to_s3(mock_s3_client, mock_cdn_bucket, concept)
+        await helper_upload_concept_to_s3(
+            mock_s3_async_client, mock_async_cdn_bucket, concept
+        )
 
-    results = list_s3_concepts(config=test_wikibase_to_s3_config)
+    results = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert set(results) == {
         "Q10",
         "Q20",
@@ -88,31 +105,31 @@ def test_list_s3_concepts(
 @pytest.mark.asyncio
 async def test_wikibase_to_s3__empty_cdn_bucket(
     MockedWikibaseSession,
-    mock_cdn_bucket,
+    mock_async_cdn_bucket,
     mock_prefect_slack_webhook,
     test_wikibase_to_s3_config,
-    mock_s3_client,
+    mock_s3_async_client,
 ):
-    start = list_s3_concepts(config=test_wikibase_to_s3_config)
+    start = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert len(start) == 0
     await wikibase_to_s3.fn(config=test_wikibase_to_s3_config)
-    end = list_s3_concepts(config=test_wikibase_to_s3_config)
+    end = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert len(end) == 10
 
 
 @pytest.mark.asyncio
 async def test_wikibase_to_s3__repeat_runs(
     MockedWikibaseSession,
-    mock_cdn_bucket,
+    mock_async_cdn_bucket,
     mock_prefect_slack_webhook,
     test_wikibase_to_s3_config,
-    mock_s3_client,
+    mock_s3_async_client,
 ):
-    start = list_s3_concepts(config=test_wikibase_to_s3_config)
+    start = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert len(start) == 0
     await wikibase_to_s3.fn(config=test_wikibase_to_s3_config)
     await wikibase_to_s3.fn(config=test_wikibase_to_s3_config)
-    end = list_s3_concepts(config=test_wikibase_to_s3_config)
+    end = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert len(end) == 10
 
 
@@ -121,18 +138,20 @@ async def test_wikibase_to_s3__overwrite_concept(
     MockedWikibaseSession,
     mock_prefect_slack_webhook,
     test_wikibase_to_s3_config,
-    mock_s3_client,
+    mock_s3_async_client,
     mock_concepts,
-    mock_cdn_bucket,
+    mock_async_cdn_bucket,
 ):
     # Set up extra concept
-    helper_upload_concept_to_s3(mock_s3_client, mock_cdn_bucket, mock_concepts[0])
-    concept_before_overwrite = helper_get_concept_from_s3(
-        mock_s3_client, test_wikibase_to_s3_config.cdn_bucket_name, "Q10"
+    await helper_upload_concept_to_s3(
+        mock_s3_async_client, mock_async_cdn_bucket, mock_concepts[0]
+    )
+    concept_before_overwrite = await helper_get_concept_from_s3(
+        mock_s3_async_client, test_wikibase_to_s3_config.cdn_bucket_name, "Q10"
     )
     await wikibase_to_s3.fn(config=test_wikibase_to_s3_config)
-    concept_after_overwrite = helper_get_concept_from_s3(
-        mock_s3_client, test_wikibase_to_s3_config.cdn_bucket_name, "Q10"
+    concept_after_overwrite = await helper_get_concept_from_s3(
+        mock_s3_async_client, test_wikibase_to_s3_config.cdn_bucket_name, "Q10"
     )
 
     assert concept_before_overwrite != concept_after_overwrite
@@ -141,27 +160,28 @@ async def test_wikibase_to_s3__overwrite_concept(
 @pytest.mark.asyncio
 async def test_wikibase_to_s3__extra_concept_removed(
     MockedWikibaseSession,
-    mock_cdn_bucket,
+    mock_async_cdn_bucket,
     mock_prefect_slack_webhook,
     test_wikibase_to_s3_config,
-    mock_s3_client,
+    mock_s3_async_client,
 ):
     # Set up extra concept in S3 that's not in Wikibase
     extra_concept_id = "Q999"
     extra_concept = Concept(
         wikibase_id=WikibaseID(extra_concept_id), preferred_label="Extra Concept"
     )
-    helper_upload_concept_to_s3(
-        mock_s3_client, test_wikibase_to_s3_config.cdn_bucket_name, extra_concept
+    await helper_upload_concept_to_s3(
+        mock_s3_async_client, test_wikibase_to_s3_config.cdn_bucket_name, extra_concept
     )
 
     # Verify it exists in S3
-    s3_concepts_before = list_s3_concepts(config=test_wikibase_to_s3_config)
+    s3_concepts_before = await list_s3_concepts(config=test_wikibase_to_s3_config)
     assert extra_concept_id in s3_concepts_before
-
+    print(f"s3 concepts before: {s3_concepts_before}")
     # Run the flow
     await wikibase_to_s3.fn(config=test_wikibase_to_s3_config)
 
     # Verify the extra concept was removed from S3
-    s3_concepts_after = list_s3_concepts(config=test_wikibase_to_s3_config)
+    s3_concepts_after = await list_s3_concepts(config=test_wikibase_to_s3_config)
+    print(f"s3 concepts after: {s3_concepts_after}")
     assert extra_concept_id not in s3_concepts_after


### PR DESCRIPTION
+ Update `wikibase_to_s3` to be async and update the cdn fixture to include a teardown, replicating steps from mock_async_bucket
+ Update `mock_wandb` fixture to also use async s3 client
+ Scripts have been left as synchronous as not much to gains in speed from moving to async

CLOSES PLA-720