### PR TITLE
Use pydantic v2's core schema in identifier classes

### DIFF
--- a/knowledge_graph/identifiers.py
+++ b/knowledge_graph/identifiers.py
@@ -2,8 +2,10 @@ import hashlib
 import re
 from enum import Enum
 from functools import total_ordering
+from typing import Any, Callable
 
 from pydantic import BaseModel, Field
+from pydantic_core import CoreSchema, core_schema
 from typing_extensions import Self
 
 
@@ -11,7 +13,12 @@ from typing_extensions import Self
 class WikibaseID(str):
     """A Wikibase ID, which is a string that starts with a 'Q' followed by a number."""
 
-    regex = r"^Q[1-9]\d*$"
+    regex = r"^Q[1-9][0-9]*$"
+
+    def __new__(cls, value):
+        """Validate the Wikibase ID string and create a new instance."""
+        cls._validate(value)
+        return str.__new__(cls, value)
 
     @property
     def numeric(self) -> int:
@@ -39,21 +46,25 @@ class WikibaseID(str):
         return hash(str(self))
 
     @classmethod
-    def _validate(cls, value: str, field=None) -> str:
-        """Validate that the Wikibase ID is in the correct format"""
-        if not re.match(cls.regex, value):
-            raise ValueError(f"{value} is not a valid Wikibase ID")
-        return value
+    def _validate(
+        cls, __input_value: Any, _info: core_schema.ValidationInfo = None
+    ) -> str:
+        """Validate that the Wikibase ID is in the correct format."""
+        if not isinstance(__input_value, str):
+            raise ValueError(f"Wikibase ID must be a string, got {type(__input_value)}")
+        if not re.match(cls.regex, __input_value):
+            raise ValueError(f"'{__input_value}' is not a valid Wikibase ID")
+        return __input_value
 
     @classmethod
-    def __get_validators__(cls):
-        """Return a generator of validators for the WikibaseID class"""
-        yield cls._validate
-
-    def __new__(cls, value: str) -> "WikibaseID":
-        """Create a new instance of WikibaseID after validation"""
-        validated_value = cls._validate(value)
-        return str.__new__(cls, validated_value)
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[[Any], CoreSchema]
+    ) -> CoreSchema:
+        """Returns a pydantic_core.CoreSchema object for Pydantic V2 compatibility."""
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.str_schema(),
+            python_schema=core_schema.with_info_plain_validator_function(cls._validate),
+        )
 
 
 class VespaSchema(Enum):
@@ -111,6 +122,11 @@ class Identifier(str):
     # as class attributes are resolved at class creation time.
     pattern = re.compile(rf"^[{valid_characters}]{{8}}$")
 
+    def __new__(cls, value):
+        """Validate the Identifier string and create a new instance."""
+        cls._validate(value)
+        return str.__new__(cls, value)
+
     @classmethod
     def generate(cls, *args) -> "Self":
         """Generates a new Identifier from the supplied data."""
@@ -132,7 +148,7 @@ class Identifier(str):
         return cls(identifier)
 
     @classmethod
-    def _validate(cls, value: str, field=None) -> str:
+    def _validate(cls, value: str, _info: core_schema.ValidationInfo = None) -> str:
         """Validate that the Identifier string is in the correct format"""
         if not isinstance(value, str):
             raise TypeError(
@@ -145,19 +161,15 @@ class Identifier(str):
             )
         return value
 
-    def __new__(cls, value_to_become_identifier: str) -> "Identifier":
-        """
-        Create a new Identifier from a string, after validation.
-
-        To generate an Identifier from arbitrary data, use `Identifier.generate(*args)`.
-        """
-        validated_value = cls._validate(value_to_become_identifier)
-        return str.__new__(cls, validated_value)
-
     @classmethod
-    def __get_validators__(cls):
-        """Return a generator of validators for Pydantic compatibility."""
-        yield cls._validate
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[[Any], CoreSchema]
+    ) -> CoreSchema:
+        """Returns a pydantic_core.CoreSchema object for Pydantic V2 compatibility."""
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.str_schema(),
+            python_schema=core_schema.with_info_plain_validator_function(cls._validate),
+        )
 
 
 class ClassifierID(Identifier):

--- a/knowledge_graph/identifiers.py
+++ b/knowledge_graph/identifiers.py
@@ -46,9 +46,7 @@ class WikibaseID(str):
         return hash(str(self))
 
     @classmethod
-    def _validate(
-        cls, __input_value: Any, _info: core_schema.ValidationInfo = None
-    ) -> str:
+    def _validate(cls, __input_value: Any) -> str:
         """Validate that the Wikibase ID is in the correct format."""
         if not isinstance(__input_value, str):
             raise ValueError(f"Wikibase ID must be a string, got {type(__input_value)}")
@@ -58,12 +56,14 @@ class WikibaseID(str):
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: Callable[[Any], CoreSchema]
+        cls,
+        source_type: Any,
+        handler: Callable[[Any], CoreSchema],  # type: ignore
     ) -> CoreSchema:
         """Returns a pydantic_core.CoreSchema object for Pydantic V2 compatibility."""
         return core_schema.json_or_python_schema(
             json_schema=core_schema.str_schema(),
-            python_schema=core_schema.with_info_plain_validator_function(cls._validate),
+            python_schema=core_schema.no_info_plain_validator_function(cls._validate),
         )
 
 
@@ -83,7 +83,8 @@ class VespaID(BaseModel):
 
     def __str__(self) -> str:
         """String representation of a Vespa ID, ready to be used with Vespa queries"""
-        return f"{self.prefix}:{self.kind.value}::{self.id}"
+        kind_value: str = self.kind.value  # type: ignore[attr-defined]
+        return f"{self.prefix}:{kind_value}::{self.id}"
 
 
 class FamilyDocumentID(VespaID):
@@ -148,12 +149,9 @@ class Identifier(str):
         return cls(identifier)
 
     @classmethod
-    def _validate(cls, value: str, _info: core_schema.ValidationInfo = None) -> str:
+    def _validate(cls, value: str) -> str:
         """Validate that the Identifier string is in the correct format"""
-        if not isinstance(value, str):
-            raise TypeError(
-                f"{cls.__name__} value must be a string, received {type(value).__name__}"
-            )
+
         if not cls.pattern.match(value):
             raise ValueError(
                 f"'{value}' is not a valid {cls.__name__}. Must be 8 characters from "
@@ -163,12 +161,14 @@ class Identifier(str):
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: Callable[[Any], CoreSchema]
+        cls,
+        source_type: Any,
+        handler: Callable[[Any], CoreSchema],  # type: ignore
     ) -> CoreSchema:
         """Returns a pydantic_core.CoreSchema object for Pydantic V2 compatibility."""
         return core_schema.json_or_python_schema(
             json_schema=core_schema.str_schema(),
-            python_schema=core_schema.with_info_plain_validator_function(cls._validate),
+            python_schema=core_schema.no_info_plain_validator_function(cls._validate),
         )
 
 
@@ -178,5 +178,3 @@ class ClassifierID(Identifier):
 
     This is intended for typing clarity rather than extending the Identifier class.
     """
-
-    pass


### PR DESCRIPTION
The changes in #677 fail on their own, necessitating an update to the validators on our identifier classes.

In this PR, I've updated the validation methods to use the new pydantic_core structure, and replaced `__get_validators__` with `__get_pydantic_core_schema__`. These changes should enable future development with frameworks which aren't compatible with the older versions of pydantic, without breaking any of our existing code 🤞

More documentation on the pydantic v2 changes here: https://docs.pydantic.dev/latest/internals/architecture/
