### PR TITLE
ci: Prioritise trunk deployments

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: deploy-${{ inputs.aws-env }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
I was trying to start a full pipeline run, but couldn't get the new classifiers
in the updated classifiers specs. deployed.

This means that if the branch trying to start the runk is trunk (`main`) then
_do_ cancel any in progress runs, to give it priority of them.

What I'm unsure about from the documentation[^1], is what happens to the queue.

TOWARDS PLA-854

[^1]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-only-cancel-in-progress-jobs-on-specific-branches
