### PR TITLE
Better bert based model training

### DIFF
--- a/knowledge_graph/classifier/bert_based.py
+++ b/knowledge_graph/classifier/bert_based.py
@@ -1,18 +1,28 @@
+import logging
 import os
 import tempfile
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 
-import torch  # type: ignore[import-untyped]
+import numpy as np
+import pandas as pd
+import torch
 from datasets import Dataset
-from transformers import (  # type: ignore[import-untyped]
+from rich.logging import RichHandler
+from sklearn.metrics import accuracy_score, precision_recall_fscore_support
+from sklearn.model_selection import train_test_split
+from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
+    EarlyStoppingCallback,
+    EvalPrediction,
+    PreTrainedModel,
+    PreTrainedTokenizer,
 )
-from transformers.pipelines import pipeline  # type: ignore[import-untyped]
-from transformers.trainer import Trainer  # type: ignore[import-untyped]
-from transformers.training_args import TrainingArguments  # type: ignore[import-untyped]
+from transformers.pipelines import pipeline
+from transformers.trainer import Trainer
+from transformers.training_args import TrainingArguments
 from typing_extensions import Self
 
 from knowledge_graph.classifier.classifier import Classifier, GPUBoundClassifier
@@ -21,6 +31,27 @@ from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import ClassifierID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.span import Span
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+    handler = RichHandler(rich_tracebacks=True)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+
+
+def compute_metrics(eval_pred: EvalPrediction) -> dict[str, float]:
+    """Compute metrics for model evaluation"""
+    predictions, labels = eval_pred.predictions, eval_pred.label_ids
+    predictions = np.argmax(predictions, axis=1)
+
+    precision, recall, f1, _ = precision_recall_fscore_support(
+        labels, predictions, average="binary"
+    )
+    accuracy = accuracy_score(labels, predictions)
+
+    return {"accuracy": accuracy, "f1": f1, "precision": precision, "recall": recall}
 
 
 class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
@@ -40,7 +71,7 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
     def __init__(
         self,
         concept: Concept,
-        base_model: str = "climatebert/distilroberta-base-climate-f",
+        base_model: str = "answerdotai/ModernBERT-base",
     ):
         super().__init__(concept)
         self.base_model = base_model
@@ -55,23 +86,23 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
             self.training_device = torch.device("cpu")
 
         # Initialize model and tokenizer
-        self.model: AutoModelForSequenceClassification = (
+        self.model: PreTrainedModel = (
             AutoModelForSequenceClassification.from_pretrained(base_model)
         )
-        self.tokenizer: AutoTokenizer = AutoTokenizer.from_pretrained(base_model)
+        self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(base_model)
 
         # Always use CPU for inference, to ensure consistency across different deployment
         # environments. Models may be developed on machines with GPU/MPS but need to run
         # reliably on CPU in production pipelines.
         self.pipeline = pipeline(
             "text-classification",
-            model=self.model,  # type: ignore[arg-type]
-            tokenizer=self.tokenizer,  # type: ignore[arg-type]
+            model=self.model,
+            tokenizer=self.tokenizer,
             device=self.training_device,
         )
 
         # Move model to training device (only used during training)
-        self.model.to(self.training_device)  # type: ignore[attr-defined]
+        self.model.to(self.training_device)  # type: ignore
 
     @property
     def id(self) -> ClassifierID:
@@ -135,7 +166,7 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
     def get_variant_sub_classifier(self) -> Self:
         """Get a variant of the classifier for Monte Carlo dropout estimation."""
         variant = deepcopy(self)
-        variant._use_dropout_during_inference = True
+        variant._use_dropout_during_inference = True  # noqa: SLF001
         return variant
 
     def _prepare_dataset(self, labelled_passages: list[LabelledPassage]) -> Dataset:
@@ -148,38 +179,59 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
         Returns:
             Dataset: A HuggingFace dataset ready for training
         """
-        texts = []
-        labels = []
-
-        for passage in labelled_passages:
-            contains_concept = any(
+        texts = [passage.text for passage in labelled_passages]
+        labels = [
+            1
+            if any(
                 span.concept_id == self.concept.wikibase_id for span in passage.spans
             )
-            texts.append(passage.text)
-            labels.append(1 if contains_concept else 0)
+            else 0
+            for passage in labelled_passages
+        ]
 
         tokenized_inputs = self.tokenizer(  # type: ignore[operator]
-            texts, padding="max_length", truncation=True, return_tensors="pt"
+            texts, padding=True, truncation=True, max_length=512, return_tensors=None
         )
 
         return Dataset.from_dict({**tokenized_inputs, "labels": labels})
 
     def fit(
         self,
-        *,
-        use_wandb: bool = False,
+        validation_size: float = 0.2,
         **kwargs,
     ) -> "BertBasedClassifier":
         """
         Fine tune the base model using the labelled passages of the supplied concept.
 
-        The model will be trained to predict whether a supplied text contains an
-        instance of the concept.
+        The model is fine-tuned using several techniques for faster and more stable
+        training:
+
+        - We use a pre-trained model as the base model. By default, we use the
+            ModernBERT model from AnswerDotAI, which includes a bunch of smart tricks
+            to make it more performant and robust. See https://huggingface.co/blog/modernbert
+            for more detail.
+        - We freeze the weights of the model's backbone (where most of its fundamental
+            language understanding smarts come from) and only adjust the parameters in
+            themodel's task-specific classification head during training - with the
+            default model, that means we're only changing ~0.4% of the total model
+            weights! This dramatically reduces the training time and memory usage, while
+            still producing a performant classifier.
+        - Because we're only training the head, we can use a relatively high learning
+            rate (5e-4) and batch size (64), even on modest hardware.
+        - We use a cosine learning rate scheduler, giving us a smooth learning rate
+            decay over each epoch.
+        - We set a warmup period for the first 6% of the run to stabilise the weights
+            in the early stages of training.
+        - We set up an early stopping callback to end the training run as soon as we see
+            the model's performance improvements slowing down, or beginning to overfit.
+        - We set weight decay of 0.1. By adding a small penalty to the weights during
+            training, we discourages them from growing too large. Penalising the large
+            weights incentiveses the model to learn simpler, more generalisable patterns
+            from the training data, making the final model less spiky and more reliable.
 
         Args:
-            use_wandb: Whether to use Weights & Biases for logging
+            validation_size: The proportion of labelled passages to use for validation.
             **kwargs: Additional keyword arguments passed to the base class
-
         Returns:
             BertBasedClassifier: The trained classifier
         """
@@ -187,32 +239,146 @@ class BertBasedClassifier(Classifier, GPUBoundClassifier, UncertaintyMixin):
 
         if len(self.concept.labelled_passages) < 10:
             raise ValueError(
-                f"Not enough labelled passages to train a {self.name} for {self.concept.wikibase_id}"
+                f"Not enough labelled passages to train a {self.name} for "
+                f"{self.concept.wikibase_id}. At least 10 are required."
             )
 
-        tokenized_dataset = self._prepare_dataset(self.concept.labelled_passages)
+        passages = self.concept.labelled_passages
+        labels = [
+            1
+            if any(span.concept_id == self.concept.wikibase_id for span in p.spans)
+            else 0
+            for p in passages
+        ]
+
+        # Split passages into training and validation sets. Stratify to maintain the
+        # distribution of positive and negative passages.
+        train_passages, val_passages, _, _ = train_test_split(
+            passages,
+            labels,
+            test_size=validation_size,
+            random_state=42,
+            stratify=labels,
+        )
+
+        logger.info("Preparing datasets...")
+        train_dataset = self._prepare_dataset(train_passages)
+        validation_dataset = self._prepare_dataset(val_passages)
+
+        # Create a summary DataFrame for dataset statistics
+        stats_df = pd.DataFrame(
+            {
+                "Split": ["Training", "Validation"],
+                "Rows": [
+                    len(train_dataset),
+                    len(validation_dataset),
+                ],
+                "Positive %": [
+                    (sum(train_dataset["labels"]) / len(train_dataset)) * 100,
+                    (sum(validation_dataset["labels"]) / len(validation_dataset)) * 100,
+                ],
+            }
+        )
+
+        logger.info(
+            pd.DataFrame(stats_df)
+            .round(2)
+            .to_markdown(index=False, tablefmt="rounded_grid")
+        )
+
+        logger.info(
+            "Freezing base model. The model's prediction head and classifier will be trained."
+        )
+        # More efficient parameter freezing - single pass through parameters
+        for name, param in self.model.named_parameters():
+            if "classifier" in name or "head" in name:
+                param.requires_grad = True
+            else:
+                param.requires_grad = False
+
+        # Count the number of trainable parameters and display the percentage of the model
+        # that is trainable after freezing the backbone
+        trainable_params = sum(
+            p.numel() for p in self.model.parameters() if p.requires_grad
+        )
+        total_params = sum(p.numel() for p in self.model.parameters())
+
+        logger.info("  Trainable parameters: %s", f"{trainable_params:,}")
+        logger.info("  Frozen parameters: %s", f"{total_params - trainable_params:,}")
+        logger.info(
+            "  Training %s%% of model",
+            f"{trainable_params / total_params * 100:.2f}",
+        )
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            # N.B. These training arguments should probably be configurable. Deliberately
-            # keeping them frozen for the time being while developing the overall flow.
             training_args = TrainingArguments(
                 output_dir=os.path.join(temp_dir, "results"),
                 num_train_epochs=3,
-                per_device_train_batch_size=8,
-                learning_rate=5e-5,
+                per_device_train_batch_size=64,
+                per_device_eval_batch_size=64,
+                learning_rate=5e-4,
+                weight_decay=0.01,
+                warmup_ratio=0.06,
                 lr_scheduler_type="cosine",
-                warmup_ratio=0.1,
+                optim="adamw_torch_fused",
+                fp16=False,
+                dataloader_pin_memory=False,
                 logging_dir=os.path.join(temp_dir, "logs"),
                 logging_steps=10,
-                report_to="wandb" if use_wandb else "none",
+                eval_strategy="steps",
+                eval_steps=100,
+                save_steps=200,
+                save_total_limit=2,
+                load_best_model_at_end=True,
+                metric_for_best_model="eval_f1",
+                greater_is_better=True,
+                dataloader_num_workers=2,
+                report_to=[],
                 disable_tqdm=True,
             )
 
             trainer = Trainer(
-                model=self.model,  # type: ignore[arg-type]
+                model=self.model,
                 args=training_args,
-                train_dataset=tokenized_dataset,
+                train_dataset=train_dataset,
+                eval_dataset=validation_dataset,
+                compute_metrics=compute_metrics,
+                callbacks=[
+                    EarlyStoppingCallback(
+                        early_stopping_patience=3, early_stopping_threshold=0.001
+                    )
+                ],
             )
+
+            logger.info("🚀 Starting training...")
             trainer.train()
 
+            logger.info("🎯 Evaluating on validation set...")
+            eval_results = trainer.evaluate(eval_dataset=validation_dataset)  # type: ignore
+
+            results_df = pd.DataFrame(
+                {
+                    "Metric": [
+                        "F1 Score",
+                        "Accuracy",
+                        "Precision",
+                        "Recall",
+                    ],
+                    "Value": [
+                        eval_results.get("eval_f1", 0),
+                        eval_results.get("eval_accuracy", 0),
+                        eval_results.get("eval_precision", 0),
+                        eval_results.get("eval_recall", 0),
+                    ],
+                }
+            )
+            logger.info("Final Validation Results")
+            logger.info(
+                results_df.round(4).to_markdown(index=False, tablefmt="rounded_grid")
+            )
+
+            final_f1 = eval_results.get("eval_f1", 0)
+            logger.info("📊 Final F1 score: %.4f", final_f1)
+
+        logger.info("✅ Training complete for concept %s!", self.concept.id)
         return self


### PR DESCRIPTION
We learned lots of lessons about model training in the [policy-mentions-classifier](https://github.com/climatepolicyradar/policy-mentions-classifier) project. As a result, the last training run was very fast, and produced a fairly solid passage-level classifier.

While this probably isn't the _perfect_ set of config/params/whatever for future BERT-based model training, it's almost definitely an improvement on what was here before, and it gives us a more modern template to start working from. Loads of improvements still to be made, loads of lessons still to incorporate from [targets classifier training](https://github.com/climatepolicyradar/classifier-training), etc, but I thought this was worth migrating now.

The highest priority in my mind is coming up with a method for reliably splitting a concept's labelled data into training vs eval sets... probably follow the targets methodology and use k-folds? not sure...