### PR TITLE
feat: Include concept ID in classifier specs.

### DIFF
--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, field_serializer
 
 from flows.utils import DocumentStem
 from knowledge_graph.cloud import AwsEnv
-from knowledge_graph.identifiers import ClassifierID, WikibaseID
+from knowledge_graph.identifiers import ClassifierID, ConceptID, WikibaseID
 from knowledge_graph.version import Version
 
 type SpecStr = str
@@ -43,6 +43,10 @@ class ClassifierSpec(BaseModel):
             default=False,
         )
 
+    concept_id: ConceptID | None = Field(
+        default=None,
+        description=("The Concept ID for the associated concept being classified."),
+    )
     wikibase_id: WikibaseID = Field(
         description=(
             "The Wikibase ID for the underlying concept being classified. e.g. 'Q992'"

--- a/flows/classifier_specs/v2/sandbox.yaml
+++ b/flows/classifier_specs/v2/sandbox.yaml
@@ -1,4 +1,8 @@
 ---
+- concept_id: du5mvcjb
+  wikibase_id: Q53
+  classifier_id: yt874y4h
+  wandb_registry_version: v2
 - wikibase_id: Q368
   classifier_id: 58br2fy7
   wandb_registry_version: v22

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,7 @@ just train "Q123" --track --upload --aws-env sandbox
 Then we promote:
 
 ```shell
-just promote "Q123" --classifier_id abcd2345 --aws-env sandbox --primary
+just promote "Q123" --classifier-id abcd2345 --aws-env sandbox --primary
 ```
 
 You can also achieve the above directly with:

--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -86,6 +86,9 @@ def refresh_all_available_classifiers(aws_envs: list[AwsEnv] | None = None) -> N
         if compute_environment := art.metadata.get("compute_environment"):
             spec_data["compute_environment"] = compute_environment
 
+        if concept_id := art.metadata.get("concept_id"):
+            spec_data["concept_id"] = concept_id
+
         spec = ClassifierSpec(**spec_data)
         specs[env].append(spec)
 

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -71,7 +71,8 @@ def test_classifier_spec_creation(spec_dict, expectation):
 
 def test_load_classifier_specs():
     """Test loading classifier specs from a YAML file."""
-    sample_data = textwrap.dedent("""
+    sample_data = textwrap.dedent(
+        """
         ---
         - wikibase_id: Q368
           classifier_id: abcd2345
@@ -88,7 +89,8 @@ def test_load_classifier_specs():
           dont_run_on:
             - sabin
             - cpr
-    """).lstrip()
+    """
+    ).lstrip()
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_spec_dir = Path(temp_dir)

--- a/tests/scripts/test_update_classifier_spec.py
+++ b/tests/scripts/test_update_classifier_spec.py
@@ -24,8 +24,17 @@ def mock_wandb_api():
         # Create mock classifier artifacts
         mock_artifacts = []
         for model_data in [
-            {"name": "Q111:v1", "env": "sandbox", "id": "abcd2345"},
-            {"name": "Q444:v2", "env": "labs", "id": "efgh6789"},
+            {
+                "name": "Q111:v1",
+                "env": "sandbox",
+                "id": "abcd2345",
+                "concept_id": "du5mvcjb",
+            },
+            {
+                "name": "Q444:v2",
+                "env": "labs",
+                "id": "efgh6789",
+            },
             {
                 "name": "Q222:v1",
                 "env": "sandbox",
@@ -45,6 +54,9 @@ def mock_wandb_api():
 
             if compute_environment := model_data.get("compute_environment"):
                 mock_artifact.metadata["compute_environment"] = compute_environment
+
+            if concept_id := model_data.get("concept_id"):
+                mock_artifact.metadata["concept_id"] = concept_id
 
             mock_artifact.source_name = f"{model_data['id']}:v1"
             mock_artifacts.append(mock_artifact)
@@ -71,9 +83,11 @@ def test_refresh_all_available_classifiers(mock_wandb_api):
             with open(output_path, "r") as file:
                 results = file.read()
 
-            expected = textwrap.dedent("""
+            expected = textwrap.dedent(
+                """
                 ---
-                - wikibase_id: Q111
+                - concept_id: du5mvcjb
+                  wikibase_id: Q111
                   classifier_id: abcd2345
                   wandb_registry_version: v1
                 - wikibase_id: Q222
@@ -83,7 +97,8 @@ def test_refresh_all_available_classifiers(mock_wandb_api):
                     gpu: true
                   dont_run_on:
                   - sabin
-                """).lstrip()
+                """
+            ).lstrip()
 
             assert results == expected
 


### PR DESCRIPTION
This makes it available for our pipelines to use, and, eventually get into
Vespa.

Ideally it's not optional. We can migrate to it being required later.

_Test_

```
USE_AWS_PROFILES=true just promote "Q53" --classifier-id yt874y4h --aws-env sandbox --primary
uv run promote --wikibase-id Q53 --classifier-id yt874y4h --aws-env sandbox --primary
..
wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at: ./data/wandb/wandb/run-20250916_194720-q04xk9xw/logs
```

```
just update-inference-classifiers --aws-envs sandbox
```

This shows the new concept ID.

FIXES PLA-821

