### PR TITLE
chore: retrain Q53

### DIFF
--- a/flows/classifier_specs/v2/prod.yaml
+++ b/flows/classifier_specs/v2/prod.yaml
@@ -1,7 +1,8 @@
-
-- wikibase_id: Q53
+---
+- concept_id: du5mvcjb
+  wikibase_id: Q53
   classifier_id: yt874y4h
-  wandb_registry_version: v0
+  wandb_registry_version: v3
   dont_run_on:
   - sabin
 - wikibase_id: Q57


### PR DESCRIPTION
The kg pipeline saw an error on the labelled passages from this classifier after investigating we found overlap between the concepts alternative_labels & negative_labels. Reviewing hte concept store now and this issue seems to no longer be present so retraining should fix it.

I've also updated the metadata in wandb to reflect the dontrunon & gpu requirements as these where in the specs but missing from wandb.