### PR TITLE
chore: temporarily disable gpus in prod

### DIFF
--- a/flows/classifier_specs/v2/prod.yaml
+++ b/flows/classifier_specs/v2/prod.yaml
@@ -403,22 +403,16 @@
 - wikibase_id: Q1651
   classifier_id: 6rys3abe
   wandb_registry_version: v12
-  compute_environment:
-    gpu: true
   dont_run_on:
   - sabin
 - wikibase_id: Q1652
   classifier_id: 57uwtz45
   wandb_registry_version: v9
-  compute_environment:
-    gpu: true
   dont_run_on:
   - sabin
 - wikibase_id: Q1653
   classifier_id: u86a8p2d
   wandb_registry_version: v9
-  compute_environment:
-    gpu: true
   dont_run_on:
   - sabin
 - wikibase_id: Q1744


### PR DESCRIPTION
It seems there is a credentials bug with gpus in prod, disabling to unblock inference runs until its resolved