### PR TITLE
fix: Include validation errors

### DIFF
--- a/tests/flows/__snapshots__/test_aggregate.ambr
+++ b/tests/flows/__snapshots__/test_aggregate.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: test_process_single_document__value_error
   list([
-    AggregationFailure("CCLW.executive.10061.4515 | exception: The number of passages diverge when appending Q767:mgwutbqx: len(labelled_passages)=2 != len(concepts_for_vespa)=27 | context: ValueError('The number of passages diverge when appending Q767:mgwutbqx: len(labelled_passages)=2 != len(concepts_for_vespa)=27')"),
+    AggregationFailure('CCLW.executive.10061.4515 | exception: The number of passages diverge when appending Q767:mgwutbqx: len(labelled_passages)=2 != len(concepts_for_vespa)=27 | context: '),
   ])
 # ---

--- a/tests/flows/test_aggregate.py
+++ b/tests/flows/test_aggregate.py
@@ -170,8 +170,8 @@ async def test_aggregate_batch_of_documents__with_failures(
     artifact_data = json.loads(summary_artifact.data)
     failure_stems = [f["Failed document Stem"] for f in artifact_data]
     assert set(failure_stems) == set(expect_failure_stems)
-    assert "NoSuchKey" in artifact_data[0]["Context"]
-    assert "NoSuchKey" in artifact_data[1]["Context"]
+    assert "NoSuchKey" in artifact_data[0]["Exception"]
+    assert "NoSuchKey" in artifact_data[1]["Exception"]
 
 
 def test_build_run_output_prefix():


### PR DESCRIPTION
They get truncated. This approach was based on a recommendation by Pydantic[^1] and some examples online[^2].

The context values added no information and made printed representations of the exceptions noisy.

[^1]: https://github.com/pydantic/pydantic/discussions/7733

[^2]: https://github.com/search?q=validation_error.errors+language%3Apython&type=code
