### PR TITLE
fix: Add better data validation at training time

### DIFF
--- a/knowledge_graph/concept.py
+++ b/knowledge_graph/concept.py
@@ -112,11 +112,16 @@ class Concept(BaseModel):
     @classmethod
     def _ensure_negative_labels_are_not_in_positive_labels(cls, values: Dict) -> Dict:
         """Raise a ValueError if a negative label is also a positive label"""
-        if any(
-            label in values["alternative_labels"] for label in values["negative_labels"]
-        ):
+        overlapping_labels = []
+        for label in values["negative_labels"]:
+            if label in values["alternative_labels"]:
+                overlapping_labels.append(label)
+        if overlapping_labels:
+            wikibase_id = values.get("wikibase_id")
+            preferred_label = values.get("preferred_label")
             raise ValueError(
-                "A negative label should not be the same as a positive label"
+                f"{wikibase_id} ({preferred_label}): A negative label should not be "
+                f"the same as a positive label. Found in both: {overlapping_labels}"
             )
         return values
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -349,6 +349,8 @@ async def run_training(
         )
         # To handle redirects where the wikibase_id is overwritten
         concept.wikibase_id = wikibase_id
+        # Ensure concept data can be serialised and rebuilt without failing validations
+        concept.model_validate_json(concept.model_dump_json())
         # Create and train a classifier instance
         classifier = ClassifierFactory.create(concept=concept)
         classifier.fit()


### PR DESCRIPTION
Previously some concepts snuck through to aggregate before the issue was discovered, likely meaning models where not behaving correctly at inference which would explain why we saw so many `AllSkippedFailure`'s. This also extends the error message we were seeing to make it actually useful.