### PR TITLE
Feat: otel/prefect spike and example usage

### DIFF
--- a/flows/repo_info.py
+++ b/flows/repo_info.py
@@ -1,17 +1,39 @@
+import os
+
 import httpx
+from opentelemetry import metrics, trace
 from prefect import flow
+
+run_counter = None
 
 
 @flow(log_prints=True)
 def get_repo_info(repo_name: str = "PrefectHQ/prefect"):
+    global run_counter
+    if run_counter is None:
+        run_counter = metrics.get_meter("knowledge-graph-flows").create_counter(
+            "repo_info_runs",
+            description="The number of times the repo_info flow has been run",
+        )
+
+    print(f"Tracer: {trace.get_tracer_provider()}")
+    print(f"OTEL_EXPORTER_OTLP_ENDPOINT: {os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT')}")
+    print(f"OTEL_EXPORT_OTLP_PROTOCOL: {os.getenv('OTEL_EXPORT_OTLP_PROTOCOL')}")
+    print(f"OTEL_SERVICE_NAME: {os.getenv('OTEL_SERVICE_NAME')}")
+    print(f"OTEL_RESOURCE_ATTRIBUTES: {os.getenv('OTEL_RESOURCE_ATTRIBUTES')}")
     url = f"https://api.github.com/repos/{repo_name}"
+
     response = httpx.get(url)
     response.raise_for_status()
     repo = response.json()
+
+    run_counter.add(1)
+
     print(f"{repo_name} repository statistics 🤓:")
     print(f"Stars 🌠 : {repo['stargazers_count']}")
     print(f"Forks 🍴 : {repo['forks_count']}")
 
 
 if __name__ == "__main__":
-    get_repo_info.serve(name="my-first-deployment")  # type: ignore
+    # get_repo_info.serve(name="my-first-deployment")  # type: ignore
+    get_repo_info()

--- a/telemetry/otel_setup.py
+++ b/telemetry/otel_setup.py
@@ -1,0 +1,47 @@
+# Requires: opentelemetry-sdk, opentelemetry-exporter-otlp
+
+import os
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Set resource attributes; add your own org/team identifiers
+resource = Resource.create(
+    {
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "knowledge-graph-flows"),
+        "service.namespace": "knowledge-graph",
+        "service.instance.id": "knowledge-graph-flows-1",
+        "environment": "local",
+    }
+)
+
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = (
+    "https://otel.staging.climatepolicyradar.org"
+)
+os.environ["OTEL_EXPORT_OTLP_PROTOCOL"] = "http/protobuf"
+os.environ["OTEL_SERVICE_NAME"] = "knowledge-graph-flows"
+os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.namespace=knowledge-graph"
+
+base_endpoint = os.getenv(
+    "OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.staging.climatepolicyradar.org"
+)
+
+# Tracing
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{base_endpoint}/v1/traces"))
+)
+trace.set_tracer_provider(tracer_provider)
+
+# Metrics
+metric_reader = PeriodicExportingMetricReader(
+    OTLPMetricExporter(endpoint=f"{base_endpoint}/v1/metrics")
+)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)


### PR DESCRIPTION
It's intended to be illustrative code only so just demonstrating it working. 

The meter can be seen [here](https://climatepolicyradar.grafana.net/a/grafana-metricsdrilldown-app/drilldown?var-filters=&layout=grid&filters-rule=&filters-prefix=&filters-suffix=&search_txt=&var-labelsWingman=%28none%29&var-metrics-reducer-sort-by=default&var-other_metric_filters=&from-2=now-5m&to-2=now&timezone-2=browser&metric=repo_info_runs_total&actionView=breakdown&var-groupby=$__all&breakdownLayout=grid&from=now-1h&to=now&timezone=browser)

Traces [here](https://climatepolicyradar.grafana.net/a/grafana-exploretraces-app/explore?from=now-30m&to=now&timezone=browser&var-ds=grafanacloud-traces&var-primarySignal=nestedSetParent%3C0&var-filters=resource.service.name%7C%3D%7Cknowledge-graph-flows&var-metric=rate&var-groupBy=resource.service.namespace&var-spanListColumns=&var-latencyThreshold=&var-partialLatencyThreshold=&actionView=breakdown)

Recommend having a look at the better quality integration code we've written for telemetry in navi-backend, please steal as appropriate :) https://github.com/climatepolicyradar/navigator-backend/blob/main/backend-api/app/telemetry.py and https://github.com/climatepolicyradar/navigator-backend/blob/main/backend-api/app/telemetry_config.py

Our initial service mapping for service and namespace names is [here](https://www.notion.so/climatepolicyradar/Architecture-Service-mappings-1d59109609a48028877ae392eae9a773?pvs=26&qid=&origin=). it needs refining and im happy for everyone to use best judgement on good names but [otel semantic conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/) & grafana both require service.name at least. I would recommend using all the fields we have in the navi-backend integration for standardisation. 