### PR TITLE
Fix Span.from_xml when there are no annotations

### DIFF
--- a/knowledge_graph/span.py
+++ b/knowledge_graph/span.py
@@ -217,6 +217,9 @@ class Span(BaseModel):
 
         tags = re.findall(r"</?concept>", xml)
 
+        if not tags:
+            return
+
         if not (
             tags[0] == "<concept>"
             and len(set(tags)) == 2
@@ -246,6 +249,11 @@ class Span(BaseModel):
         cls._validate_xml(xml)
 
         text_without_tags = xml.replace("<concept>", "").replace("</concept>", "")
+
+        # There were no XML tags, so return empty list of spans
+        if text_without_tags == xml:
+            return []
+
         span_timestamps = [datetime.now()] * len(labellers)
 
         if input_text is not None and input_text != text_without_tags:
@@ -316,7 +324,7 @@ class Span(BaseModel):
 
             if found_indices is None:
                 logger.warning(
-                    f"No spans found matching {span_text} near to character offset {start_index_in_original} in original.\n{xml}"
+                    f"No spans found matching {span_text} near to character offset {start_index_in_original} in original.\nLLM output:\n{xml}\nOriginal text:\n{input_text}"
                 )
             else:
                 start_index, end_index = found_indices

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -413,3 +413,16 @@ def test_span_from_xml_invalid_concept_annotation(xml: str, is_valid: bool):
     else:
         with pytest.raises(SpanXMLConceptFormattingError):
             _ = Span.from_xml(xml, concept_id=WikibaseID("Q123"), labellers=["me"])
+
+
+@pytest.mark.parametrize(
+    "xml",
+    [
+        "",
+        "no concept tags here",
+        "Some <b>bold</b> but no concept tags.",
+    ],
+)
+def test_span_from_xml_empty(xml: str):
+    spans = Span.from_xml(xml, concept_id=WikibaseID("Q1"), labellers=["model"])
+    assert spans == []

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -423,6 +423,6 @@ def test_span_from_xml_invalid_concept_annotation(xml: str, is_valid: bool):
         "Some <b>bold</b> but no concept tags.",
     ],
 )
-def test_span_from_xml_empty(xml: str):
+def test_whether_parsing_text_with_no_concept_tags_returns_an_empty_list(xml: str):
     spans = Span.from_xml(xml, concept_id=WikibaseID("Q1"), labellers=["model"])
     assert spans == []


### PR DESCRIPTION
Small fix for `Span.from_xml` (used by LLM classifiers which return `<concept>` tags) for when no concepts are annotated in the text.