### PR TITLE
feat: add json conversion function

### DIFF
--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from pathlib import Path
 from typing import NewType, Optional, Sequence
@@ -128,3 +129,17 @@ def should_skip_doc(stem: DocumentStem, spec: ClassifierSpec) -> bool:
     """
     source = stem.split(".")[0]
     return DontRunOnEnum(source.lower()) in (spec.dont_run_on or [])
+
+
+def yaml_spec_to_json(aws_env: AwsEnv):
+    """
+    Print classifier specs as json.
+
+    Can be used ad hoc to get a json representation of the yaml files. This can be
+    useful in creating prefect parameters.
+    """
+    file_path = determine_spec_file_path(aws_env)
+    with open(file_path, "r") as file:
+        contents = yaml.load(file, Loader=yaml.FullLoader)
+
+    print(json.dumps(contents, indent=2))


### PR DESCRIPTION
It's often useful to generate a json version of the specs, I've found myself doing this on occasions when wanting this as a parameter for prefect.

I'm resisting adding this as a script, it just seems like overkill. But the function can be imported in a terminal python session and run when needed and I think thats sufficient for now.