### PR TITLE
ci: don't redeploy sandbox

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,23 +11,11 @@ permissions:
   contents: write
 
 jobs:
-  deploy_prefect_sandbox:
+  deploy_prefect_labs:
     if: |
       (github.event.workflow_run.conclusion == 'success' &&
       github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/prefect_deploy.yml
-    with:
-      aws-env: sandbox
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SANDBOX }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SANDBOX }}
-      PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
-      PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
-
-  deploy_prefect_labs:
-    if: github.ref == 'refs/heads/main'
-    needs: [deploy_prefect_sandbox]
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: labs
@@ -38,8 +26,10 @@ jobs:
       PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
 
   deploy_prefect_staging:
-    if: github.ref == 'refs/heads/main'
-    needs: [deploy_prefect_sandbox]
+    if: |
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: staging
@@ -50,8 +40,10 @@ jobs:
       PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
 
   deploy_prefect_prod:
-    if: github.ref == 'refs/heads/main'
-    needs: [deploy_prefect_sandbox]
+    if: |
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: prod


### PR DESCRIPTION
Currently on merge to main, we deploy sandbox, then we redeploy sandbox before deploying everything else. Deploys can take over 5 minutes each so this is pretty painful. Its still a good check that deploys are valid before trying to deploy to other envs so Im just taking out the last deploy to sandbox