### PR TITLE
chore: once again temporarily disable targets

### DIFF
--- a/flows/classifier_specs/v2/prod.yaml
+++ b/flows/classifier_specs/v2/prod.yaml
@@ -405,21 +405,6 @@
   wandb_registry_version: v12
   dont_run_on:
   - sabin
-- wikibase_id: Q1651
-  classifier_id: 6rys3abe
-  wandb_registry_version: v12
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1652
-  classifier_id: 57uwtz45
-  wandb_registry_version: v9
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1653
-  classifier_id: u86a8p2d
-  wandb_registry_version: v9
-  dont_run_on:
-  - sabin
 - wikibase_id: Q1744
   classifier_id: ekzukwdz
   wandb_registry_version: v0


### PR DESCRIPTION
To get new classsifiers live quickly we then plan to follow up with targets afterwards. For reference:

https://climate-policy-radar.slack.com/archives/C078K2QNU0L/p1758289642269079

![berne-targets](https://github.com/user-attachments/assets/d0902287-a11c-4e29-81e4-8cb6bab40d3f)
