### PR TITLE
refactor: Add function to get logger with fallback

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import inspect
 import json
+import logging
 import os
 import re
 import textwrap
@@ -25,6 +26,8 @@ from typing import (
 from uuid import UUID
 
 import aioboto3
+import prefect.exceptions
+import prefect.logging
 from botocore.exceptions import ClientError
 from prefect.artifacts import (
     create_progress_artifact,
@@ -768,3 +771,27 @@ async def gather_and_report(
             )
 
     return results
+
+
+LoggingAdapter = logging.LoggerAdapter[logging.Logger]
+
+
+def get_logger() -> logging.Logger | LoggingAdapter:
+    """
+    Get a logger via Prefect.
+
+    You can overwrite the logging level[2]. If not running in a flow
+    or task run context, a logger that doesn't send to the Prefect API
+    is returned.
+
+    > `get_run_logger()` can only be used in the context of a flow or task.
+    > To use a normal Python logger anywhere with your same configuration, use `get_logger()` from `prefect.logging`.
+    > The logger retrieved with `get_logger()` will not send log records to the Prefect API.
+
+    [1]: https://docs.prefect.io/v3/how-to-guides/workflows/add-logging
+    [2]: https://docs.prefect.io/v3/api-ref/settings-ref#logging-level
+    """
+    try:
+        return prefect.logging.get_run_logger()
+    except prefect.exceptions.MissingContextError:
+        return prefect.logging.get_logger()


### PR DESCRIPTION
`get_logger` returns a standard Python logger[^3].

The intent is to give someone a function that they can call from code running on Prefect via ECS or Prefect via Coiled or literally anywhere.

> Get a prefect logger. These loggers are intended for internal use within the prefect package.[^4]

Prefect's documentation does say this. A _Prefect logger_ is one that is named as `prefect`[^5]. I think we still want this, despite the internal use mention, since in ECS they currently show up as a Prefect logger, so why not have it show up with the same name, even when not in a flow or task run context? **Update:** I don't feel strongly about this at all actually. As long as the fallback is a Python logger, I don't mind which one it is. Maybe we don't actually want it to be a Prefect one, so there's no confusion with internal logs.

**Update:** I've found some places in `boundary.py` where people are using the Prefect internal `get_logger`.

**Test**

```
Python 3.13.7 (main, Aug 16 2025, 11:35:35) [Clang 17.0.0 (clang-1700.0.13.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from flows.utils import get_logger
>>> logger = get_logger()
>>> logger.debug("debug1")
>>> logger.error("error1")
error1
```

TOWARDS PLA-861

[^1]: https://docs.prefect.io/v3/how-to-guides/workflows/add-logging

[^2]: https://docs.prefect.io/v3/api-ref/settings-ref#logging-level

[^3]: https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L64

[^4]: https://docs.prefect.io/v3/api-ref/python/prefect-logging-loggers#get-logger

[^5]: https://github.com/PrefectHQ/prefect/blob/main/src/prefect/logging/loggers.py#L72C21-L72C49
