### PR TITLE
fix: add logging for `RequestTimeTooSkewed` error

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -281,10 +281,8 @@ def main(
     :type use_coiled_gpu: bool
     """
     if use_coiled_gpu:
-        flow_name = "train_on_gpu"
-        deployment_name = generate_deployment_name(
-            flow_name="train_on_gpu", aws_env=aws_env
-        )
+        flow_name = "train-on-gpu"
+        deployment_name = generate_deployment_name(flow_name=flow_name, aws_env=aws_env)
         qualified_name = f"{flow_name}/{deployment_name}"
 
         flow_run: FlowRun = run_deployment(  # type: ignore[misc]


### PR DESCRIPTION
 Adds some initial, extra logging for these errors, for starters it will tell us how skewed the requests are getting.

Also includes a driveby fix for a typo in the train script — ci feels too painful right now to have a whole run just for it.
