### PR TITLE
Run deploy in parallel with lint and test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
 
   deploy_prefect_sandbox:
     name: "Deploy"
-    needs: [lint, test]
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: sandbox


### PR DESCRIPTION
This Pull Request: 
---
Attempts to work towards a reduction in deploy times via a potential quick win by running steps in parallel (flow code storage spike to come after). We could half our deployment times by simply running the deploy flow in parallel rather than in series with the test and linting actions. 

_I don't personally have any worries with running them in parallel - what's the worst case scenario; some code that fails unit tests get's pushed to sandbox?_ 

<img width="608" height="223" alt="image" src="https://github.com/user-attachments/assets/45474233-3ee1-4969-b170-ae9210965142" />
