### PR TITLE
ci: allow concurrent sandbox deploys in prs

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -17,7 +17,7 @@ on:
         required: true
 
 concurrency:
-  group: deploy-${{ inputs.aws-env }}
+  group: deploy-${{ inputs.aws-env }}${{ inputs.aws-env == 'sandbox' && format('-{0}', github.ref_name) || '' }}
   cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
Because these are safe to deploy and currently there is a bottleneck merging code. The intended behaviour is to make the concurrency group branch specific if the env is sandbox.