### PR TITLE
chore: Update classifier specs. to include keyword classifier fix

### DIFF
--- a/flows/classifier_specs/v2/prod.yaml
+++ b/flows/classifier_specs/v2/prod.yaml
@@ -2,416 +2,510 @@
 - wikibase_id: Q53
   concept_id: kgtd77zy
   classifier_id: r4xsb4ff
-  classifiers_profiles:
-  - primary
-  wandb_registry_version: v4
+  wandb_registry_version: v5
   dont_run_on:
   - sabin
 - wikibase_id: Q57
+  concept_id: 3p2pxgcp
   classifier_id: jq7535b6
-  wandb_registry_version: v0
+  wandb_registry_version: v3
   dont_run_on:
   - sabin
 - wikibase_id: Q68
+  concept_id: ad7tcbph
   classifier_id: kk8dqcrj
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q69
-  classifier_id: bp3wqfwc
-  wandb_registry_version: v0
+  concept_id: swk535mj
+  classifier_id: 5ppa92su
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q123
+  concept_id: f6h7mncv
   classifier_id: 8np4shsw
-  wandb_registry_version: v19
-  dont_run_on:
-  - sabin
-- wikibase_id: Q218
-  classifier_id: 3p7eyng3
   wandb_registry_version: v21
   dont_run_on:
   - sabin
-- wikibase_id: Q223
-  classifier_id: dntrzvg4
+- wikibase_id: Q218
+  concept_id: ygjab2d5
+  classifier_id: 3p7eyng3
+  wandb_registry_version: v23
+  dont_run_on:
+  - sabin
+- wikibase_id: Q221
+  concept_id: s9rbcnjc
+  classifier_id: zahr3y3c
   wandb_registry_version: v14
   dont_run_on:
   - sabin
+- wikibase_id: Q223
+  concept_id: fxx6vsts
+  classifier_id: dntrzvg4
+  wandb_registry_version: v16
+  dont_run_on:
+  - sabin
 - wikibase_id: Q226
+  concept_id: fmp2rf6u
   classifier_id: epdr39n7
-  wandb_registry_version: v13
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q368
+  concept_id: wfcb6jdf
   classifier_id: mfe6wvbv
-  wandb_registry_version: v25
+  wandb_registry_version: v27
   dont_run_on:
   - sabin
 - wikibase_id: Q374
+  concept_id: 5m964t43
   classifier_id: 2dpw38rj
-  wandb_registry_version: v24
+  wandb_registry_version: v26
   dont_run_on:
   - sabin
 - wikibase_id: Q404
+  concept_id: ybg68eaw
   classifier_id: fd5t9bhw
-  wandb_registry_version: v24
+  wandb_registry_version: v26
   dont_run_on:
   - sabin
 - wikibase_id: Q412
+  concept_id: 6muuvqpm
   classifier_id: 9cfzu8vh
-  wandb_registry_version: v28
+  wandb_registry_version: v30
   dont_run_on:
   - sabin
 - wikibase_id: Q572
+  concept_id: jfzuzpcy
   classifier_id: 9x5fdgft
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q601
+  concept_id: c5289g25
   classifier_id: 76fhnpae
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q606
+  concept_id: antdeacg
   classifier_id: pun2by55
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q615
+  concept_id: 8f9ejwsu
   classifier_id: 3wkwmd2t
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q618
+  concept_id: j4gcmr7q
   classifier_id: qp7pt7vc
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q622
+  concept_id: gaghy24b
   classifier_id: gxgdn95e
-  wandb_registry_version: v0
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q639
   concept_id: 9a3aj2vs
   classifier_id: zp9e66p9
-  classifiers_profiles:
-  - primary
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q650
-  classifier_id: 274gekg9
-  wandb_registry_version: v11
-  dont_run_on:
-  - sabin
-- wikibase_id: Q661
-  classifier_id: ty2jvjmp
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q676
-  classifier_id: y3vcj3dm
-  wandb_registry_version: v15
-  dont_run_on:
-  - sabin
-- wikibase_id: Q684
-  classifier_id: 9adt36v3
-  wandb_registry_version: v18
-  dont_run_on:
-  - sabin
-- wikibase_id: Q690
-  classifier_id: eq9x9wsr
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q695
-  classifier_id: am4npkr4
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q701
-  classifier_id: nyutpxgp
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q704
-  classifier_id: y5npmjhs
-  wandb_registry_version: v15
-  dont_run_on:
-  - sabin
-- wikibase_id: Q708
-  classifier_id: x9kfsd8s
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q715
-  classifier_id: hqv67qyk
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q757
-  classifier_id: n4t9ec5y
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q760
-  classifier_id: bbhksdtz
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q761
-  classifier_id: grw5x8ee
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q762
-  classifier_id: qa22cf6s
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q763
-  classifier_id: s3cc4cdt
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q764
-  classifier_id: nxt8v557
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q765
-  classifier_id: mqmq7qz7
-  wandb_registry_version: v24
-  dont_run_on:
-  - sabin
-- wikibase_id: Q766
-  classifier_id: auwqx2qx
-  wandb_registry_version: v24
-  dont_run_on:
-  - sabin
-- wikibase_id: Q767
-  classifier_id: dfk2cka7
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q768
-  classifier_id: pgqzewd7
-  wandb_registry_version: v22
-  dont_run_on:
-  - sabin
-- wikibase_id: Q769
-  classifier_id: 7cgtdjf8
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q774
-  classifier_id: qxa74qvw
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q775
-  classifier_id: aqx9zu2w
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q779
-  classifier_id: y5d5v37k
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q786
-  classifier_id: e6mcjpw5
-  wandb_registry_version: v21
-  dont_run_on:
-  - sabin
-- wikibase_id: Q787
-  classifier_id: esv3cdac
-  wandb_registry_version: v26
-  dont_run_on:
-  - sabin
-- wikibase_id: Q788
-  classifier_id: 9pexe8zd
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q818
-  classifier_id: xtpdyp7t
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q856
-  classifier_id: rqtk7h47
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q857
-  classifier_id: 9hmkcj6h
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q954
-  classifier_id: fyhqe7b6
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q955
-  classifier_id: cfuft4qg
-  wandb_registry_version: v24
-  dont_run_on:
-  - sabin
-- wikibase_id: Q956
-  classifier_id: 7dcdxgfj
-  wandb_registry_version: v26
-  dont_run_on:
-  - sabin
-- wikibase_id: Q973
-  classifier_id: 2nwj5fwh
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q983
-  classifier_id: dsxc3m8e
-  wandb_registry_version: v23
-  dont_run_on:
-  - sabin
-- wikibase_id: Q986
-  classifier_id: mjaupkch
-  wandb_registry_version: v24
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1016
-  classifier_id: 6vn29j93
-  wandb_registry_version: v15
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1167
-  classifier_id: gq529aad
-  wandb_registry_version: v15
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1269
-  classifier_id: ruzvuy9d
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1273
-  classifier_id: 9aezptyn
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1274
-  classifier_id: wk49jsch
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1275
-  classifier_id: bb55gpzc
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1276
-  classifier_id: dp92w33k
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1277
-  classifier_id: smhdpm2v
-  wandb_registry_version: v15
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1278
-  classifier_id: 5b3ndxc3
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1279
-  classifier_id: 2he9rkha
-  wandb_registry_version: v13
-  dont_run_on:
-  - sabin
-- wikibase_id: Q1280
-  classifier_id: bhf4p2mt
   wandb_registry_version: v14
   dont_run_on:
   - sabin
-- wikibase_id: Q1281
-  classifier_id: yvzajyqf
+- wikibase_id: Q650
+  concept_id: tyyhf95y
+  classifier_id: 274gekg9
   wandb_registry_version: v13
+  dont_run_on:
+  - sabin
+- wikibase_id: Q661
+  concept_id: 5j6qb6ve
+  classifier_id: ty2jvjmp
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q676
+  concept_id: mc8gvrpj
+  classifier_id: y3vcj3dm
+  wandb_registry_version: v17
+  dont_run_on:
+  - sabin
+- wikibase_id: Q684
+  concept_id: z6atmpr5
+  classifier_id: 9adt36v3
+  wandb_registry_version: v20
+  dont_run_on:
+  - sabin
+- wikibase_id: Q690
+  concept_id: 3mrsd5tt
+  classifier_id: eq9x9wsr
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q695
+  concept_id: yhrxbe6y
+  classifier_id: am4npkr4
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q701
+  concept_id: ckeffgxk
+  classifier_id: nyutpxgp
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q704
+  concept_id: m6xpbysp
+  classifier_id: y5npmjhs
+  wandb_registry_version: v17
+  dont_run_on:
+  - sabin
+- wikibase_id: Q708
+  concept_id: s5f84ek7
+  classifier_id: x9kfsd8s
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q715
+  concept_id: 2wcgurff
+  classifier_id: hqv67qyk
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q757
+  concept_id: 9tyjwej6
+  classifier_id: n4t9ec5y
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q760
+  concept_id: cc2jt9kj
+  classifier_id: fvdwz7cn
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q761
+  concept_id: 7z86eraa
+  classifier_id: grw5x8ee
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q762
+  concept_id: qmjg8zym
+  classifier_id: qa22cf6s
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q763
+  concept_id: hdndzxpg
+  classifier_id: s3cc4cdt
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q764
+  concept_id: jud4rkgs
+  classifier_id: nxt8v557
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q765
+  concept_id: bh2ju2dy
+  classifier_id: mqmq7qz7
+  wandb_registry_version: v26
+  dont_run_on:
+  - sabin
+- wikibase_id: Q766
+  concept_id: rdnsrw5k
+  classifier_id: auwqx2qx
+  wandb_registry_version: v26
+  dont_run_on:
+  - sabin
+- wikibase_id: Q767
+  concept_id: uyekkhgv
+  classifier_id: dfk2cka7
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q768
+  concept_id: jv274crg
+  classifier_id: pgqzewd7
+  wandb_registry_version: v24
+  dont_run_on:
+  - sabin
+- wikibase_id: Q769
+  concept_id: 3sgfhs46
+  classifier_id: 7cgtdjf8
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q774
+  concept_id: mqnudzra
+  classifier_id: qxa74qvw
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q775
+  concept_id: zt7e7p5z
+  classifier_id: tphrygrm
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q777
+  concept_id: qembqy8s
+  classifier_id: 8fj9pk8h
+  wandb_registry_version: v21
+  dont_run_on:
+  - sabin
+- wikibase_id: Q778
+  concept_id: eum2twbb
+  classifier_id: bgrd72hx
+  wandb_registry_version: v21
+  dont_run_on:
+  - sabin
+- wikibase_id: Q779
+  concept_id: eemkkb45
+  classifier_id: y5d5v37k
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q786
+  concept_id: yxgms8vv
+  classifier_id: 76acyeg6
+  wandb_registry_version: v23
+  dont_run_on:
+  - sabin
+- wikibase_id: Q787
+  concept_id: cggp45vj
+  classifier_id: esv3cdac
+  wandb_registry_version: v28
+  dont_run_on:
+  - sabin
+- wikibase_id: Q788
+  concept_id: dvrpbf8t
+  classifier_id: 9pexe8zd
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q818
+  concept_id: n5nctjxa
+  classifier_id: xtpdyp7t
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q856
+  concept_id: gf4rs7ya
+  classifier_id: rqtk7h47
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q857
+  concept_id: em6j2zn8
+  classifier_id: 9hmkcj6h
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q954
+  concept_id: eaupne6f
+  classifier_id: fyhqe7b6
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q955
+  concept_id: tcczd5sy
+  classifier_id: hx47bkk6
+  wandb_registry_version: v26
+  dont_run_on:
+  - sabin
+- wikibase_id: Q956
+  concept_id: w6nrbsmk
+  classifier_id: 7dcdxgfj
+  wandb_registry_version: v28
+  dont_run_on:
+  - sabin
+- wikibase_id: Q973
+  concept_id: vjsuh5wk
+  classifier_id: 2nwj5fwh
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q983
+  concept_id: yfycqcfb
+  classifier_id: dsxc3m8e
+  wandb_registry_version: v25
+  dont_run_on:
+  - sabin
+- wikibase_id: Q986
+  concept_id: qjz8mphv
+  classifier_id: mjaupkch
+  wandb_registry_version: v26
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1016
+  concept_id: dugfcdzm
+  classifier_id: 6vn29j93
+  wandb_registry_version: v17
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1167
+  concept_id: rhs8xgsy
+  classifier_id: jp8e4k7h
+  wandb_registry_version: v17
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1269
+  concept_id: fxmy2gbs
+  classifier_id: ruzvuy9d
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1273
+  concept_id: rw38g2q8
+  classifier_id: 9aezptyn
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1274
+  concept_id: bjgcfphm
+  classifier_id: 8ya34btw
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1275
+  concept_id: 68w3shve
+  classifier_id: bb55gpzc
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1276
+  concept_id: tqgezuej
+  classifier_id: dp92w33k
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1277
+  concept_id: ns3mswx8
+  classifier_id: smhdpm2v
+  wandb_registry_version: v17
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1278
+  concept_id: ak3eprz2
+  classifier_id: 5b3ndxc3
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1279
+  concept_id: 6bfaxrjh
+  classifier_id: 2he9rkha
+  wandb_registry_version: v15
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1280
+  concept_id: hrd8qz7c
+  classifier_id: bhf4p2mt
+  wandb_registry_version: v16
+  dont_run_on:
+  - sabin
+- wikibase_id: Q1281
+  concept_id: sfrb8bcr
+  classifier_id: yvzajyqf
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q1282
+  concept_id: 8rmuwu8c
   classifier_id: z7cnc9cz
-  wandb_registry_version: v13
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q1284
+  concept_id: p7g5wn8t
   classifier_id: mxfwgjr7
-  wandb_registry_version: v13
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q1285
+  concept_id: 75spmz5a
   classifier_id: 6pm6a6nd
-  wandb_registry_version: v13
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q1286
+  concept_id: rzpp5768
   classifier_id: 5rjgvetv
-  wandb_registry_version: v13
+  wandb_registry_version: v15
   dont_run_on:
   - sabin
 - wikibase_id: Q1343
+  concept_id: nrdhw2ad
   classifier_id: vax7e3n7
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1344
+  concept_id: f3jxb2er
   classifier_id: g8veubg3
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1345
+  concept_id: 3b635c3d
   classifier_id: wy3a2h5x
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1346
+  concept_id: 8m9nendg
   classifier_id: aqrcdtxx
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1362
+  concept_id: ghurfdkk
   classifier_id: bugd7dbt
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1368
+  concept_id: 6bbq9thx
   classifier_id: 9n9xsymu
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1369
+  concept_id: xbfj5vfj
   classifier_id: wyaugrjm
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1370
+  concept_id: qf5rwhnf
   classifier_id: 6dxvusb9
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1371
+  concept_id: u9sz78pv
   classifier_id: v76y24qd
-  wandb_registry_version: v12
+  wandb_registry_version: v14
   dont_run_on:
   - sabin
 - wikibase_id: Q1744
-  classifier_id: ekzukwdz
-  wandb_registry_version: v0
+  concept_id: m2cfkvme
+  classifier_id: 7aeap3ca
+  wandb_registry_version: v2
   dont_run_on:
   - sabin
 - wikibase_id: Q1754
-  classifier_id: 36bb7tcv
-  wandb_registry_version: v0
+  concept_id: xvsvqu5f
+  classifier_id: jakqefy4
+  wandb_registry_version: v2
   dont_run_on:
   - sabin


### PR DESCRIPTION
I used a script to get all models that have `KeywordClassifier` as their `classifier_name` metadata in W&B.

I ran
`AWS_PROFILE=prod just deploy-classifiers prod "Q53 Q57 Q68 Q69
Q123 Q218 Q221 Q223 Q226 Q368 Q374 Q404 Q412 Q572 Q601 Q606 Q615 Q618
Q622 Q639 Q650 Q661 Q676 Q684 Q690 Q695 Q701 Q704 Q708 Q715 Q757 Q760
Q761 Q762 Q763 Q764 Q765 Q766 Q767 Q768 Q769 Q774 Q775 Q777 Q778 Q779
Q786 Q787 Q788 Q818 Q856 Q857 Q954 Q955 Q956 Q973 Q983 Q986 Q1016
Q1167 Q1269 Q1273 Q1274 Q1275 Q1276 Q1277 Q1278 Q1279 Q1280 Q1281
Q1282 Q1284 Q1285 Q1286 Q1343 Q1344 Q1345 Q1346 Q1362 Q1368 Q1369
Q1370 Q1371 Q1744 Q1754"`, then `just update-inference-classifiers --aws-envs prod`, and `just classifier-metadata-entire-env prod --add-dont-run-on sabin`.

Still has https://github.com/climatepolicyradar/knowledge-graph/pull/733 accounted for.

TOWARDS PLA-854

