### PR TITLE
fix: run inference with less concurrency

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -791,7 +791,7 @@ async def _inference_batch_of_documents(
     logger.info(f"Loading classifier {classifier_spec}")
     classifier = await load_classifier(run, config, classifier_spec)
 
-    semaphore = asyncio.Semaphore(200)
+    semaphore = asyncio.Semaphore(100)
 
     session = aioboto3.Session(region_name=config.bucket_region)
     async with session.client("s3") as s3_client:


### PR DESCRIPTION
Tightens the semaphore with the aim of hitting less transient issues accessing s3

TOWARDS PLA-800