### PR TITLE
fix: Allow no classifiers profiles

### DIFF
--- a/justfile
+++ b/justfile
@@ -167,7 +167,7 @@ deploy-classifiers aws_env ids:
       ids_args="$ids_args --wikibase-id $id"
     done
 
-    uv run python scripts/deploy.py new \
+    uv run deploy new \
         --aws-env {{aws_env}} \
         $ids_args \
         --train \
@@ -208,7 +208,7 @@ audit-s3-vespa-alignment +OPTS="":
 
 # Update the metadata for a classifier
 classifier-metadata wikibase_id classifier_id aws_env +OPTS="":
-    uv run python -m scripts.classifier_metadata update \
+    uv run classifier-metadata update \
         --wikibase-id {{wikibase_id}} \
         --classifier-id {{classifier_id}} \
         --aws-env {{aws_env}} \
@@ -216,7 +216,7 @@ classifier-metadata wikibase_id classifier_id aws_env +OPTS="":
 
 # Update the same metadata for multiple classifiers in one aws env
 classifier-metadata-entire-env aws_env +OPTS="":
-    uv run python -m scripts.classifier_metadata update-entire-env \
+    uv run classifier-metadata update-entire-env \
         --aws-env {{aws_env}} \
         {{OPTS}}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ demote = "scripts.demote:app"
 evaluate = "scripts.evaluate:app"
 infer = "scripts.infer:app"
 update-inference-classifiers = "scripts.update_classifier_spec:app"
+classifier-metadata = "scripts.classifier_metadata:app"
 deploy = "scripts.deploy:app"
 
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -148,7 +148,7 @@ aws s3 ls
 Execute the training pipeline using the deploy script:
 
 ```bash
-python scripts/deploy.py new \
+uv run deploy new \
   --aws-env prod \
   --train \
   --promote \

--- a/scripts/classifier_metadata.py
+++ b/scripts/classifier_metadata.py
@@ -6,7 +6,6 @@ from typing import Annotated
 
 import typer
 import wandb
-import wandb.apis.public.api
 from rich.console import Console
 
 from flows.classifier_specs.spec_interface import DontRunOnEnum, load_classifier_specs

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -178,7 +178,7 @@ def main(
         # Check that classifiers profiles are defined
         classifiers_profiles = artifact.metadata.get("classifiers_profiles", [])
         if not classifiers_profiles:
-            raise typer.BadParameter(
+            log.warning(
                 "Artifact must have at least one classifiers profile in metadata. "
                 "Use the classifier-metadata script to add profiles before promoting."
             )


### PR DESCRIPTION
As is, the _deploy_ script doesn't take this in, so when it tries to promote,
the value isn't set.

