### PR TITLE
fix: Align classifiers profiles across scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,6 +68,35 @@ promote id +OPTS="":
 demote id aws_env:
     uv run demote --wikibase-id {{id}} --aws-env {{aws_env}}
 
+# Deploy (Get, train & deploy) new model to primary for the given AWS environment.
+# Example: just deploy-classifiers sandbox Q123
+deploy-classifier id aws_env +OPTS="":
+    uv run deploy new \
+        {{id}} \
+        --aws-env {{aws_env}} \
+        --train \
+        --promote \
+        {{OPTS}}
+
+# Deploy (Get, train & deploy) new models to primary for the given AWS environment.
+# Example: just deploy-classifiers sandbox 'Q123 Q368 Q374 Q404 Q412'
+deploy-classifiers ids aws_env +OPTS="":
+    #!/bin/bash
+    set -e
+
+    # Convert the ids argument to a list of --wikibase-id arguments
+    ids_args=""
+    for id in {{ids}}; do
+      ids_args="$ids_args --wikibase-id $id"
+    done
+
+    uv run deploy new \
+        --aws-env {{aws_env}} \
+        $ids_args \
+        --train \
+        --promote \
+        {{OPTS}}
+
 # run a model for a specific wikibase ID on a supplied string
 label id string:
     uv run python scripts/label.py --wikibase-id {{id}} --input-string {{string}}
@@ -154,24 +183,6 @@ serve-static-site tool:
 # Generate a static site
 generate-static-site tool:
     uv run python -m static_sites.{{tool}}
-
-# Deploy (Get, train & deploy) new models to primary for the given AWS environment.
-# Example: just deploy-classifiers sandbox 'Q123 Q368 Q374 Q404 Q412'
-deploy-classifiers aws_env ids:
-    #!/bin/bash
-    set -e
-
-    # Convert the ids argument to a list of --wikibase-id arguments
-    ids_args=""
-    for id in {{ids}}; do
-      ids_args="$ids_args --wikibase-id $id"
-    done
-
-    uv run deploy new \
-        --aws-env {{aws_env}} \
-        $ids_args \
-        --train \
-        --promote
 
 # Does inference have results for accepted classifiers?
 # Set STAGING_CACHE_BUCKET, or pass as argument:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,13 +27,13 @@ just promote "Q123" --classifier-id abcd2345 --aws-env sandbox --primary
 You can also achieve the above directly with:
 
 ```shell
-just deploy-classifiers sandbox Q374
+just deploy-classifier Q374 sandbox
 ```
 
 Or run a batch sequentially with:
 
 ```shell
-just deploy-classifiers sandbox "Q374 Q473"
+just deploy-classifiers "Q374 Q473" sandbox
 ```
 
 This is useful when you are already resolved that the trained model will become the new primary.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -115,6 +115,7 @@ def create_and_link_model_artifact(
     run: Run,
     classifier: Classifier,
     storage_link: StorageLink,
+    add_classifiers_profiles: list[str] | None = None,
 ) -> wandb.Artifact:
     """
     Links a model artifact, stored in S3, to a Weights & Biases run.
@@ -135,6 +136,8 @@ def create_and_link_model_artifact(
         "concept_id": classifier.concept.id,
         "concept_wikibase_revision": classifier.concept.wikibase_revision,
     }
+    if add_classifiers_profiles:
+        metadata["classifiers_profiles"] = list(add_classifiers_profiles)
     if isinstance(classifier, GPUBoundClassifier):
         Console().log("Adding GPU requirement to metadata")
         compute_environment: ComputeEnvironment = {"gpu": True}
@@ -267,7 +270,7 @@ def main(
         typer.Option(
             ...,
             help=(
-                "Run on coiled with a gpu. This uses prefect to start a coiled cluster. "
+                "Run on Coiled with a GPU. This uses prefect to start a Coiled cluster. "
                 "Note, that the classifier won't be available locally after training."
             ),
         ),
@@ -291,6 +294,10 @@ def main(
             help="Classifier kwargs in key=value format. Can be specified multiple times.",
         ),
     ] = None,
+    add_classifiers_profiles: Annotated[
+        list[str] | None,
+        typer.Option(help="Adds 1 or more classifiers profiles."),
+    ] = None,
 ) -> Classifier | None:
     """
     Main function to train the model and optionally upload the artifact.
@@ -311,7 +318,6 @@ def main(
     :param classifier_kwarg: List of classifier kwargs in key=value format
     :type classifier_kwarg: Optional[list[str]]
     """
-
     classifier_kwargs = parse_classifier_kwargs(classifier_kwarg)
 
     if use_coiled_gpu:
@@ -328,6 +334,7 @@ def main(
                 "evaluate": evaluate,
                 "classifier_type": classifier_type,
                 "classifier_kwargs": classifier_kwargs,
+                "add_classifiers_profiles": add_classifiers_profiles,
             },
             timeout=0,  # Don't wait for the flow to finish before continuing
         )
@@ -345,6 +352,7 @@ def main(
                 evaluate=evaluate,
                 classifier_type=classifier_type,
                 classifier_kwargs=classifier_kwargs,
+                add_classifiers_profiles=add_classifiers_profiles,
             )
         )
 
@@ -358,6 +366,7 @@ async def run_training(
     evaluate: bool = True,
     classifier_type: Optional[str] = None,
     classifier_kwargs: Optional[dict[str, Any]] = None,
+    add_classifiers_profiles: list[str] | None = None,
 ) -> Classifier:
     """Train the model and optionally track the run, uploading the model."""
     # Create console locally to avoid serialization issues
@@ -455,10 +464,11 @@ async def run_training(
                 aws_env=aws_env,
             )
 
-            create_and_link_model_artifact(
+            _ = create_and_link_model_artifact(
                 run,  # type: ignore
                 classifier,
                 storage_link,
+                add_classifiers_profiles,
             )
 
         if evaluate:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -222,6 +222,50 @@ def test_create_and_link_model_artifact():
         mock_run.log_artifact.return_value.wait.assert_called_once()
 
 
+def test_create_and_link_model_artifact_with_classifier_profiles():
+    """Test that classifier profiles are added to artifact metadata."""
+    mock_run = Mock()
+    mock_classifier = Mock()
+    mock_classifier.name = "test_classifier"
+    mock_classifier.concept = Mock()
+    mock_classifier.concept.id = "5d4xcy5g"
+    mock_classifier.concept.wikibase_revision = 12300
+    bucket = "cpr-labs-models"
+    key = "Q123/v4prnc54/v3/model.pickle"
+    aws_env = AwsEnv.labs
+
+    storage_link = StorageLink(
+        bucket=bucket,
+        key=key,
+        aws_env=aws_env,
+    )
+
+    # When it's linked from S3 to a W&B artifact with classifier profiles
+    with patch("wandb.Artifact") as mock_artifact_class:
+        mock_artifact_instance = Mock()
+        mock_artifact_class.return_value = mock_artifact_instance
+
+        create_and_link_model_artifact(
+            mock_run,
+            mock_classifier,
+            storage_link,
+            add_classifiers_profiles=["profile1", "profile2"],
+        )
+
+        # Then the artifact was created with classifier profiles in metadata
+        mock_artifact_class.assert_called_once_with(
+            name=mock_classifier.id,
+            type="model",
+            metadata={
+                "aws_env": aws_env.value,
+                "classifier_name": "test_classifier",
+                "concept_id": "5d4xcy5g",
+                "concept_wikibase_revision": 12300,
+                "classifiers_profiles": ["profile1", "profile2"],
+            },
+        )
+
+
 @patch("wandb.Api")
 def test_get_next_version_with_existing(mock_api):
     mock_artifact = Mock()


### PR DESCRIPTION
This was causing us grief. There's still more work to be done, for other
metadata to be in similar places.

I've also aligned other things, like additional options and options ordering.

