### PR TITLE
docs: make it clear where we are deploying in ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   deploy_prefect_labs:
+    name: "Labs"
     if: |
       (github.event.workflow_run.conclusion == 'success' &&
       github.ref == 'refs/heads/main') ||
@@ -26,6 +27,7 @@ jobs:
       PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
 
   deploy_prefect_staging:
+    name: "Staging"
     if: |
       (github.event.workflow_run.conclusion == 'success' &&
       github.ref == 'refs/heads/main') ||
@@ -40,6 +42,7 @@ jobs:
       PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
 
   deploy_prefect_prod:
+    name: "Prod"
     if: |
       (github.event.workflow_run.conclusion == 'success' &&
       github.ref == 'refs/heads/main') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: just test-with-vespa
 
   deploy_prefect_sandbox:
-    name: "Deploy"
+    name: "Sandbox"
     uses: ./.github/workflows/prefect_deploy.yml
     with:
       aws-env: sandbox


### PR DESCRIPTION
Motivated by the fact it is just not clear at the moment:
<img width="329" height="266" alt="image" src="https://github.com/user-attachments/assets/abeb7984-9c9b-46a3-84dd-63690946381b" />

<img width="329" height="266" alt="image" src="https://github.com/user-attachments/assets/178e28dc-e310-40e5-a835-534a322e65a8" />

See current for comparison
