### PR TITLE
fix: don't train redirects

### DIFF
--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Annotated, Optional
 
 import typer
@@ -70,7 +71,7 @@ async def get_concept_async(
 
 
 @app.command()
-async def main(
+def main(
     wikibase_id: Annotated[
         WikibaseID,
         typer.Option(
@@ -81,11 +82,13 @@ async def main(
     include_labels_from_subconcepts=True,
     wikibase_config: Optional[WikibaseConfig] = None,
 ):
-    concept = await get_concept_async(
-        wikibase_id=wikibase_id,
-        include_recursive_has_subconcept=include_recursive_has_subconcept,
-        include_labels_from_subconcepts=include_labels_from_subconcepts,
-        wikibase_config=wikibase_config,
+    concept = asyncio.run(
+        get_concept_async(
+            wikibase_id=wikibase_id,
+            include_recursive_has_subconcept=include_recursive_has_subconcept,
+            include_labels_from_subconcepts=include_labels_from_subconcepts,
+            wikibase_config=wikibase_config,
+        )
     )
 
     return concept

--- a/scripts/get_concept.py
+++ b/scripts/get_concept.py
@@ -43,7 +43,11 @@ async def get_concept_async(
         include_labels_from_subconcepts=include_labels_from_subconcepts,
     )
     # To handle redirects where the wikibase_id is overwritten
-    concept.wikibase_id = wikibase_id
+    if concept.wikibase_id != wikibase_id:
+        raise typer.BadParameter(
+            f"{wikibase_id} is a redirect to {concept.wikibase_id}, run with "
+            f"{concept.wikibase_id} instead."
+        )
     # Ensure concept data can be serialised and rebuilt without failing validations
     concept.model_validate_json(concept.model_dump_json())
 

--- a/scripts/scripts.just
+++ b/scripts/scripts.just
@@ -4,8 +4,11 @@ build-dataset n="10000":
     poetry run python scripts/build_dataset.py --n {{n}}
 
 # fetch metadata and labelled passages for a specific wikibase ID
-get-concept id:
-    uv run python scripts/get_concept.py --wikibase-id {{id}}
+# Optionally ad a wikibase_config as a string, if omitted this will rely on env variables instead:
+# just get-concept <id> "<url> <username> <password>"
+get-concept id wikibase_config="":
+    uv run python scripts/get_concept.py --wikibase-id {{id}} \
+        {{if wikibase_config != "" { "--wikibase-config \"" + wikibase_config + "\"" } else { "" } }}
 
 # train a model for a specific wikibase ID
 train id +OPTS="":


### PR DESCRIPTION
Downstream in app land, redirects are not currently handled. Letting them
in to the pipeline means we find out at the point of deployment that they
cannot go live, as we saw with Q57/Q58. This changes the get_concept
behaviour to prevent the use of redirects, wether when used directly or
when this script is used by the train or deploy commands.

Drive by fixes, see commits for details:

- fix: Type not yet supported error
- fix: coroutine 'main' was never awaited
    