### PR TITLE
fix(train): Don't implicitly promote in train

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -155,8 +155,8 @@ def create_and_link_model_artifact(
     )
     artifact.add_reference(uri=uri, checksum=True)
 
-    # Log the artifact to W&B, creating it within a wandb project
-    artifact = run.log_artifact(artifact, aliases=[storage_link.aws_env.value])
+    # Log the artifact to W&B, creating it within a W&B project
+    artifact = run.log_artifact(artifact, aliases=[])
     artifact = artifact.wait()
 
     return artifact

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -215,7 +215,7 @@ def test_create_and_link_model_artifact():
         # Then the artifact was logged in W&B
         mock_run.log_artifact.assert_called_once_with(
             mock_artifact_instance,
-            aliases=[aws_env.value],
+            aliases=[],
         )
 
         # Then the artifact was waited for


### PR DESCRIPTION
Having an AWS environment as an _alias_ means that that version has been
_promoted_. This shouldn't be implicitly done here. It should be explicitly done
in promotion.

The AWS environment is included in the metadata at training.

This means that all models trained since August 2025 have been implicitly
promoted, when they shouldn't have been.

TWOARDS PLA-838

