### PR TITLE
refactor: Use tags instead of aliases for promotion

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -91,7 +91,6 @@ def existing(
                     wikibase_id=WikibaseID(spec.name),
                     classifier_id=classifier.id,
                     aws_env=to_aws_env,
-                    primary=True,
                     add_classifiers_profiles=add_classifiers_profiles,
                     remove_classifiers_profiles=remove_classifiers_profiles,
                 )
@@ -147,7 +146,6 @@ def new(
                         wikibase_id=wikibase_id,
                         classifier_id=classifier.id,
                         aws_env=aws_env,
-                        primary=True,
                         add_classifiers_profiles=add_classifiers_profiles,
                     )
         except AttributeError as e:

--- a/scripts/update_classifier_spec.py
+++ b/scripts/update_classifier_spec.py
@@ -64,7 +64,7 @@ def refresh_all_available_classifiers(aws_envs: list[AwsEnv] | None = None) -> N
 
     collection_filters = {"name": {"$regex": WikibaseID.regex}}
 
-    version_filters = {"$or": [{"alias": env} for env in aws_envs]}
+    version_filters = {"$or": [{"tag": env.value} for env in aws_envs]}
 
     artifacts = (
         api.registries(filter=registry_filters)

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -4,16 +4,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 import typer
-from click.exceptions import BadParameter
 from moto import mock_aws
 
 from knowledge_graph.cloud import AwsEnv
-from knowledge_graph.identifiers import ClassifierID
-from scripts.promote import (
-    check_existing_artifact_aliases,
-    find_artifact_in_registry,
-    main,
-)
+from scripts.promote import main
 
 
 @pytest.mark.parametrize(
@@ -24,17 +18,15 @@ from scripts.promote import (
                 "wikibase_id": "Q123",
                 "classifier_id": "abcd2345",
                 "aws_env": AwsEnv.labs,
-                "primary": False,
             },
             True,
             None,
         ),
         (
-            {  # Staging environment, logged in, primary
+            {  # Staging environment, logged in
                 "wikibase_id": "Q456",
                 "classifier_id": "abcd2345",
                 "aws_env": AwsEnv.staging,
-                "primary": True,
             },
             True,
             None,
@@ -44,7 +36,6 @@ from scripts.promote import (
                 "wikibase_id": "Q789",
                 "classifier_id": "abcd2345",
                 "aws_env": AwsEnv.labs,
-                "primary": False,
             },
             True,
             None,
@@ -54,7 +45,6 @@ from scripts.promote import (
                 "wikibase_id": "Q789",
                 "classifier_id": "abcd2345",
                 "aws_env": AwsEnv.labs,
-                "primary": False,
             },
             False,
             typer.BadParameter,
@@ -71,6 +61,8 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
     artifact_mock = Mock()
     artifact_mock.version = "v1"
     artifact_mock.metadata = {"classifiers_profiles": ["test_profile"]}
+    artifact_mock.tags = []
+    artifact_mock.save = Mock()
 
     run_mock = Mock()
     run_mock.use_artifact.return_value = artifact_mock
@@ -90,270 +82,5 @@ def test_main(test_case, logged_in, expected_exception, monkeypatch):
                 main(**test_case)
         else:
             main(**test_case)
-
-
-@mock_aws
-def test_main_missing_classifier_profiles(monkeypatch):
-    os.environ["USE_AWS_PROFILES"] = "false"
-    os.environ["WANDB_API_KEY"] = "test_wandb_api_key"
-
-    # Create artifact mock without classifier profiles
-    artifact_mock = Mock()
-    artifact_mock.version = "v1"
-    artifact_mock.metadata = {}  # No classifiers_profiles
-
-    run_mock = Mock()
-    run_mock.use_artifact.return_value = artifact_mock
-    run_mock.link_artifact = Mock()
-
-    init_mock = Mock(return_value=nullcontext(run_mock))
-    monkeypatch.setattr("wandb.init", init_mock)
-    monkeypatch.setattr("os.environ.__setitem__", lambda *args: None)
-
-    test_case = {
-        "wikibase_id": "Q123",
-        "classifier_id": "abcd2345",
-        "aws_env": AwsEnv.labs,
-        "primary": False,
-    }
-
-    with patch("scripts.promote.is_logged_in", return_value=True):
-        with pytest.raises(
-            BadParameter,
-            match="Artifact must have at least one classifiers profile in metadata, or you must specify at least 1 to add",
-        ):
-            main(**test_case)
-
-
-@pytest.mark.parametrize(
-    "collection_exists,artifact_aliases,classifier_id,aws_env,target_path,expected_error",
-    [
-        # Collection doesn't exist
-        (
-            False,
-            [],
-            ClassifierID("abcd2345"),
-            AwsEnv.labs,
-            "test/path",
-            None,
-        ),
-        # Artifact exists with no conflicting aliases
-        (
-            True,
-            ["labs"],
-            ClassifierID("abcd2345"),
-            AwsEnv.labs,
-            "test/path",
-            None,
-        ),
-        # Artifact exists with conflicting alias
-        (
-            True,
-            ["staging", "labs"],
-            ClassifierID("abcd2345"),
-            AwsEnv.labs,
-            "test/path",
-            "Something has gone wrong with the source artifact",
-        ),
-    ],
-)
-def test_check_existing_artifact_aliases(
-    collection_exists,
-    artifact_aliases,
-    classifier_id,
-    aws_env,
-    target_path,
-    expected_error,
-):
-    """Test checking for existing artifacts with conflicting aliases."""
-    mock_api = Mock()
-    mock_api.artifact_collection_exists.return_value = collection_exists
-
-    if collection_exists:
-        other_mock_artifact = Mock(
-            aliases=[],
-            source_name="abcd2345:v2",
-        )
-        mock_artifact = Mock(
-            aliases=artifact_aliases,
-            source_name=f"{classifier_id}:v1",
-        )
-        mock_collection = Mock()
-        mock_collection.artifacts.return_value = [other_mock_artifact, mock_artifact]
-        mock_api.artifact_collection.return_value = mock_collection
-
-    if expected_error:
-        with pytest.raises(typer.BadParameter, match=expected_error):
-            check_existing_artifact_aliases(
-                mock_api,
-                target_path,
-                classifier_id,
-                aws_env,
-            )
-    else:
-        check_existing_artifact_aliases(
-            mock_api,
-            target_path,
-            classifier_id,
-            aws_env,
-        )
-
-
-@pytest.mark.parametrize(
-    "artifacts,aws_env,expected",
-    [
-        # No artifacts
-        ([], AwsEnv.labs, None),
-        # One matching artifact
-        (
-            [Mock(source_name="abcd2345:v1", aliases=["prod"])],
-            AwsEnv.production,
-            "snapshot1",
-        ),
-        # Multiple artifacts, one match
-        (
-            [
-                Mock(source_name="abcd2345:v1", aliases=["prod"]),
-                Mock(source_name="abcd2345:v2", aliases=["staging"]),
-            ],
-            AwsEnv.production,
-            "snapshot1",
-        ),
-        # Multiple artifacts, no match
-        (
-            [
-                Mock(source_name="abcd2345:v1", aliases=["prod"]),
-                Mock(source_name="abcd2345:v2", aliases=["staging"]),
-            ],
-            AwsEnv.sandbox,
-            None,
-        ),
-    ],
-)
-def test_find_artifact_in_registry(artifacts, aws_env, expected):
-    """Test finding artifacts by aws_env."""
-    mock_collection = Mock()
-    mock_collection.artifacts.return_value = artifacts
-
-    result = find_artifact_in_registry(
-        mock_collection, ClassifierID("abcd2345"), aws_env
-    )
-
-    if expected is None:
-        assert result is None
-    else:
-        assert result
-
-
-@mock_aws
-def test_main_with_classifier_profiles_addition(monkeypatch):
-    """Test promote with adding classifier profiles to existing ones."""
-
-    os.environ["USE_AWS_PROFILES"] = "false"
-    os.environ["WANDB_API_KEY"] = "test_wandb_api_key"
-
-    # Create artifact mock with existing classifier profiles
-    artifact_mock = Mock()
-    artifact_mock.version = "v1"
-    artifact_mock.metadata = {"classifiers_profiles": ["existing1", "existing2"]}
-
-    run_mock = Mock()
-    run_mock.use_artifact.return_value = artifact_mock
-    run_mock.link_artifact = Mock()
-
-    init_mock = Mock(return_value=nullcontext(run_mock))
-    monkeypatch.setattr("wandb.init", init_mock)
-    monkeypatch.setattr("os.environ.__setitem__", lambda *args: None)
-
-    test_case = {
-        "wikibase_id": "Q123",
-        "classifier_id": "abcd2345",
-        "aws_env": AwsEnv.labs,
-        "primary": False,
-        "add_classifiers_profiles": ["new1", "new2"],
-    }
-
-    with patch("scripts.promote.is_logged_in", return_value=True):
-        main(**test_case)
-
-    # Check that profiles were merged correctly
-    assert artifact_mock.metadata["classifiers_profiles"] == {
-        "existing1",
-        "existing2",
-        "new1",
-        "new2",
-    }
-
-
-@mock_aws
-def test_main_with_classifier_profiles_removal(monkeypatch):
-    """Test promote with removing classifier profiles."""
-
-    os.environ["USE_AWS_PROFILES"] = "false"
-    os.environ["WANDB_API_KEY"] = "test_wandb_api_key"
-
-    # Create artifact mock with existing classifier profiles
-    artifact_mock = Mock()
-    artifact_mock.version = "v1"
-    artifact_mock.metadata = {
-        "classifiers_profiles": ["profile1", "profile2", "profile3"]
-    }
-
-    run_mock = Mock()
-    run_mock.use_artifact.return_value = artifact_mock
-    run_mock.link_artifact = Mock()
-
-    init_mock = Mock(return_value=nullcontext(run_mock))
-    monkeypatch.setattr("wandb.init", init_mock)
-    monkeypatch.setattr("os.environ.__setitem__", lambda *args: None)
-
-    test_case = {
-        "wikibase_id": "Q123",
-        "classifier_id": "abcd2345",
-        "aws_env": AwsEnv.labs,
-        "primary": False,
-        "remove_classifiers_profiles": ["profile2"],
-    }
-
-    with patch("scripts.promote.is_logged_in", return_value=True):
-        main(**test_case)
-
-    # Check that profile was removed correctly
-    assert artifact_mock.metadata["classifiers_profiles"] == {"profile1", "profile3"}
-
-
-@mock_aws
-def test_main_remove_all_classifier_profiles_deletes_key(monkeypatch):
-    os.environ["USE_AWS_PROFILES"] = "false"
-    os.environ["WANDB_API_KEY"] = "test_wandb_api_key"
-
-    # Create artifact mock with classifier profiles
-    artifact_mock = Mock()
-    artifact_mock.version = "v1"
-    artifact_mock.metadata = {
-        "classifiers_profiles": ["profile1"],
-        "other_key": "value",
-    }
-
-    run_mock = Mock()
-    run_mock.use_artifact.return_value = artifact_mock
-    run_mock.link_artifact = Mock()
-
-    init_mock = Mock(return_value=nullcontext(run_mock))
-    monkeypatch.setattr("wandb.init", init_mock)
-    monkeypatch.setattr("os.environ.__setitem__", lambda *args: None)
-
-    test_case = {
-        "wikibase_id": "Q123",
-        "classifier_id": "abcd2345",
-        "aws_env": AwsEnv.labs,
-        "primary": False,
-        "remove_classifiers_profiles": ["profile1"],
-    }
-
-    with patch("scripts.promote.is_logged_in", return_value=True):
-        main(**test_case)
-
-    # Check that classifiers_profiles key was deleted but other keys remain
-    assert "classifiers_profiles" not in artifact_mock.metadata
-    assert artifact_mock.metadata["other_key"] == "value"
+            assert test_case["aws_env"].value in artifact_mock.tags
+            artifact_mock.save.assert_called()


### PR DESCRIPTION
Since we're now allowing more than 1 version of a classifier per environment, the aliases are too strict. Instead, use tags.

The classifier specs. collections will now be able to return multiple classifiers per environment.

**Test**

There's a migration skip included to go from aliases to tags. Here's some sample output from a dry run:

```
$ uv run python scripts/migrate_aliases_to_tags.py --dry-run --wikibase-id Q221
[11:28:46] Processing Q221:v14...                                                       migrate_aliases_to_tags.py:42
             Found alias: prod                                                          migrate_aliases_to_tags.py:51
             [DRY RUN] Would add tag: production                                        migrate_aliases_to_tags.py:69
             [DRY RUN] Would remove alias: prod                                         migrate_aliases_to_tags.py:70
           Processing Q221:v15...                                                       migrate_aliases_to_tags.py:42
             Found alias: staging                                                       migrate_aliases_to_tags.py:51
             [DRY RUN] Would add tag: staging                                           migrate_aliases_to_tags.py:69
             [DRY RUN] Would remove alias: staging                                      migrate_aliases_to_tags.py:70
                                                                                        migrate_aliases_to_tags.py:74
           [DRY RUN] Migrated 2 artifacts
           Run with --no-dry-run to apply changes                                       migrate_aliases_to_tags.py:78
```

Did a promotion:

`$ USE_AWS_PROFILES=true just promote Q221 --classifier-id zahr3y3c --aws-env staging`

<img width="1393" height="790" alt="CleanShot 2025-10-01 at 11 24 21" src="https://github.com/user-attachments/assets/ef0bf23e-a804-4420-8495-af405b0a3883" />

Used the migration script for just that concept, and it worked flawlessly:

```
$ uv run python scripts/migrate_aliases_to_tags.py --no-dry-run --wikibase-id Q221
[11:29:15] Processing Q221:v14...                                                       migrate_aliases_to_tags.py:42
             Found alias: prod                                                          migrate_aliases_to_tags.py:51
wandb: WARNING Editing tags will apply the changes to the source artifact and all linked artifacts associated with it.
[11:29:16]   ✓ Added tag: production                                                    migrate_aliases_to_tags.py:62
[11:29:17]   ✓ Removed alias: prod                                                      migrate_aliases_to_tags.py:67
           Processing Q221:v15...                                                       migrate_aliases_to_tags.py:42
             Found alias: staging                                                       migrate_aliases_to_tags.py:51
wandb: WARNING Editing tags will apply the changes to the source artifact and all linked artifacts associated with it.
             ✓ Added tag: staging                                                       migrate_aliases_to_tags.py:62
[11:29:18]   ✓ Removed alias: staging                                                   migrate_aliases_to_tags.py:67
                                                                                        migrate_aliases_to_tags.py:74
           Migrated 2 artifacts
```

<img width="553" height="406" alt="CleanShot 2025-10-01 at 11 29 45" src="https://github.com/user-attachments/assets/f54a9150-5c2b-4d3d-876b-e5ada1074234" />

It can be rerun safely:

```
uv run python scripts/migrate_aliases_to_tags.py --dry-run --wikibase-id Q221
[11:33:31]                                                                             migrate_aliases_to_tags.py:100
           [DRY RUN] Migrated 0 artifacts
           Run with --no-dry-run to apply changes                                      migrate_aliases_to_tags.py:104
```

TOWARDS PLA-838