### PR TITLE
Flexible matching of spaces dashes and hyphens for keyword classifier

### DIFF
--- a/knowledge_graph/classifier/keyword.py
+++ b/knowledge_graph/classifier/keyword.py
@@ -55,7 +55,14 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
             labels: list[str], case_sensitive: bool = False
         ) -> re.Pattern:
             """Create a regex pattern from a list of labels."""
-            pattern = r"\b(?:" + "|".join(labels) + r")\b" if labels else ""
+
+            # Matches space, hyphen-minus, en-dash, and em-dash interchangeably
+            normalized_labels = [
+                re.escape(label).replace(r"\ ", r"[ \-–—]").replace(r"\-", r"[ \-–—]")
+                for label in labels
+            ]
+
+            pattern = r"\b(?:" + "|".join(normalized_labels) + r")\b" if labels else ""
             flags = re.IGNORECASE if not case_sensitive else 0
             return re.compile(pattern, flags)
 


### PR DESCRIPTION
- Modified create_pattern() to normalize labels for all labels (negative, positive, case sensitive and not)
- Spaces and hyphens now match interchangeably, as do different dashes
- Policy style guide already suggests labels should be created in this way. 