### PR TITLE
fix: Strictly match prefixes in S3

### DIFF
--- a/flows/config.py
+++ b/flows/config.py
@@ -8,10 +8,10 @@ from pydantic import BaseModel, Field, SecretStr
 from knowledge_graph.cloud import AwsEnv, get_prefect_job_variable
 
 # Constant, s3 prefix for the aggregated results
-INFERENCE_RESULTS_PREFIX = "inference_results"
-INFERENCE_DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "embeddings_input"
-INFERENCE_DOCUMENT_TARGET_PREFIX_DEFAULT: str = "labelled_passages"
-AGGREGATE_DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "labelled_passages"
+INFERENCE_RESULTS_PREFIX = "inference_results/"
+INFERENCE_DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "embeddings_input/"
+INFERENCE_DOCUMENT_TARGET_PREFIX_DEFAULT: str = "labelled_passages/"
+AGGREGATE_DOCUMENT_SOURCE_PREFIX_DEFAULT: str = "labelled_passages/"
 
 # SSM
 WIKIBASE_PASSWORD_SSM_NAME = "/Wikibase/Cloud/ServiceAccount/Password"
@@ -50,7 +50,7 @@ class Config(BaseModel):
     )
 
     pipeline_state_prefix: str = Field(
-        default="input",
+        default="input/",
         description="S3 prefix for where new & updated documents from ingestion are located",
     )
 


### PR DESCRIPTION
When trying a test run in sandbox for inference, it failed[^1], as the lax prefix meant that it tried to load `embeddings_input` _and_ `embeddings_input_test`. It shouldn't have tried to load the latter.

By adding a trailing slash, it makes it a stricter match.

You can confirm this with the CLI:

```
$ aws s3 --profile sandbox ls s3://cpr-sandbox-data-pipeline-cache/embeddings_input --recursive
..
2022-12-13 13:17:48       3138 embeddings_input/CCLW.legislative.10379.5058.json
2022-12-13 13:17:48       4551 embeddings_input/CCLW.legislative.1038.0.json
2022-12-13 13:17:48       2615 embeddings_input/CCLW.legislative.10385.5072.json
..
2024-11-14 16:06:31          0 embeddings_input_test/
2024-11-14 16:09:19    2110648 embeddings_input_test/UNFCCC.party.535.0.json
2024-11-14 16:46:19     298964 embeddings_input_test/UNFCCC.party.535.0_short.json
2024-11-14 16:09:20    2029526 embeddings_input_test/UNFCCC.party.535.0_translated_en.json
...
```

```
$ aws s3 --profile sandbox ls s3://cpr-sandbox-data-pipeline-cache/embeddings_input/ --recursive | grep test
```

TOWARDS PLA-831
TOWARDS PLA-893

[^1]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/068dab3e-708d-78fd-8000-9795dae922dc?entity_id=068dab3e-708d-78fd-8000-9795dae922dc&state=cancelled&state=cancelling&state=completed&state=crashed&state=failed&state=paused&state=pending&state=running&state=scheduled&entity=flowRuns&entity=taskRuns&entity=events&entity=logs&entity=artifacts

