### PR TITLE
ci: Log version used for Prefect and correctly run deployments

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -105,7 +105,6 @@ jobs:
           AWS_REGION: eu-west-1
           DOCKER_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           DOCKER_REPOSITORY: ${{ github.event.repository.name }}
-          DOCKER_TAG: ${{ steps.get_version.outputs.docker_tag }}
           PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
         run: uv run python -m deployments
@@ -116,7 +115,6 @@ jobs:
           AWS_REGION: eu-west-1
           DOCKER_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           DOCKER_REPOSITORY: ${{ github.event.repository.name }}
-          DOCKER_TAG: ${{ steps.get_version.outputs.docker_tag }}
           PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
         run: uv run python -m automations

--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Confirm package availability
         run: docker run --rm -e AWS_ENV=${{ inputs.aws-env }} ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }} python -c "import flows.inference; print('flows.inference imported successfully')"
 
-      - name: Deploy to Prefect
+      - name: "Deploy to Prefect: Deployments"
         env:
           AWS_ENV: ${{ inputs.aws-env }}
           AWS_REGION: eu-west-1
@@ -108,6 +108,15 @@ jobs:
           DOCKER_TAG: ${{ steps.get_version.outputs.docker_tag }}
           PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
-        run: |
-          uv run python -m deployments
-          uv run python -m automations
+        run: uv run python -m deployments
+
+      - name: "Deploy to Prefect: Automations"
+        env:
+          AWS_ENV: ${{ inputs.aws-env }}
+          AWS_REGION: eu-west-1
+          DOCKER_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          DOCKER_REPOSITORY: ${{ github.event.repository.name }}
+          DOCKER_TAG: ${{ steps.get_version.outputs.docker_tag }}
+          PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
+          PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
+        run: uv run python -m automations

--- a/deployments.py
+++ b/deployments.py
@@ -176,7 +176,7 @@ def _version() -> str:
     return importlib.metadata.version(PROJECT_NAME)
 
 
-if __name__ == "__name__":
+if __name__ == "__main__":
     logger.info(f"using version: {_version()}")
 
     # Train

--- a/deployments.py
+++ b/deployments.py
@@ -6,6 +6,7 @@ See: https://docs-2.prefect.io/latest/concepts/deployments/
 """
 
 import importlib.metadata
+import logging
 import os
 import subprocess
 from typing import Any, ParamSpec, TypeVar
@@ -38,6 +39,17 @@ DEFAULT_FLOW_VARIABLES = {
     "ephemeralStorage": {"sizeInGiB": 50},
     "match_latest_revision_in_family": True,
 }
+
+# Create logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Create console handler and set level
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+# Add ch to logger
+logger.addHandler(ch)
 
 
 def get_schedule_for_env(
@@ -81,7 +93,7 @@ def create_deployment(
     logger = get_logger()
 
     aws_env = AwsEnv(os.environ["AWS_ENV"])
-    version = importlib.metadata.version(PROJECT_NAME)
+    version = _version()
     flow_name = flow.name
     docker_registry = os.environ["DOCKER_REGISTRY"]
     docker_repository = os.getenv("DOCKER_REPOSITORY", PROJECT_NAME)
@@ -160,7 +172,13 @@ def create_deployment(
     )
 
 
+def _version() -> str:
+    return importlib.metadata.version(PROJECT_NAME)
+
+
 if __name__ == "__name__":
+    logger.info(f"using version: {_version()}")
+
     # Train
     create_deployment(
         flow=train_on_gpu,

--- a/justfile
+++ b/justfile
@@ -66,16 +66,16 @@ export-env-vars:
 prefect-login: export-env-vars
 	prefect cloud login -k ${PREFECT_API_KEY}
 
-deploy: prefect-login
+deploy:
     just deploy-deployments
     just deploy-automations
 
-deploy-deployments: prefect-login
-	aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
-	python -m deployments
+deploy-deployments:
+    aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
+    uv run python -m deployments
 
-deploy-automations: prefect-login
-	python -m automations
+deploy-automations:
+    uv run python -m automations
 
 # Run a static site locally
 serve-static-site tool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "knowledge-graph"
-version = "0.14.0"
+version = "0.14.1"
 description = ""
 authors = [
     {name = "CPR Data Science", email = "dsci@climatepolicyradar.org"}

--- a/uv.lock
+++ b/uv.lock
@@ -2227,7 +2227,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-graph"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "aioboto3" },


### PR DESCRIPTION
This uses the same logging approach as in the automation script.

Originally I did this so I could get insight into what was being deployed, as I noticed our deployments are on an old version. I then found a bug in the script, which is now fixed.

I separated deployments and automations so it's easier to separate in CD on GitHub.

**Test**

```
$ AWS_ENV=sandbox uv run python -m deployments
      Built knowledge-graph @ file:///Users/jesse/src/github.com/climatepolicyradar/knowledge-graph
Uninstalled 1 package in 3ms
Installed 1 package in 3ms
using version: 0.8.0
15:24:38.654 | INFO    | __main__ - using version: 0.8.0
Successfully created/updated all deployments!

                        Deployments
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Name                                 ┃ Status  ┃ Details ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ train-on-gpu/kg-train-on-gpu-sandbox │ applied │         │
└──────────────────────────────────────┴─────────┴─────────┘

To schedule a run for this deployment, use the following command:

        $ prefect deployment run 'train-on-gpu/kg-train-on-gpu-sandbox'


You can also run your flow via the Prefect UI: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/deployments/deployment/99548d7e-9679-4f22-90b9-4a10f3c94b45

...
```

<img width="475" height="39" alt="CleanShot 2025-10-08 at 15 28 55" src="https://github.com/user-attachments/assets/2d360946-e4fb-47c6-8ed2-2a8c3a048c9a" />

<img width="188" height="142" alt="CleanShot 2025-10-08 at 15 45 46" src="https://github.com/user-attachments/assets/0f806a8b-61a4-401e-a2a1-6c339f6db9c3" />
