### PR TITLE
chore(train metadata): include BERT model config

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -243,6 +243,11 @@ def create_and_link_model_artifact(
         Console().log("Adding GPU requirement to metadata")
         compute_environment: ComputeEnvironment = {"gpu": True}
         metadata["compute_environment"] = compute_environment
+    if getattr(classifier, "pipeline", None):  # is a transformer model
+        if model := getattr(classifier, "model", None):
+            Console().log("Adding BERT model config to metadata")
+            metadata["model_config"] = model.config.to_dict()
+            # Note: some details are also viewable on the associated wandb run
 
     artifact = wandb.Artifact(
         name=classifier.id,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -97,6 +97,9 @@ async def test_run_training(
     mock_classifier.version = None
     # Set model_name to a non-OpenRouter model to avoid pricing lookups
     mock_classifier.model_name = "gpt-4"
+    mock_classifier.pipeline = Mock()
+    mock_classifier.model = Mock()
+    mock_classifier.model.config.to_dict.return_value = {"config_data": 768}
 
     mock_concept = Mock()
     mock_concept.id = "5d4xcy5g"
@@ -163,6 +166,7 @@ async def test_run_training(
             "classifier_name": mock_classifier.name,
             "concept_id": mock_classifier.concept.id,
             "concept_wikibase_revision": mock_classifier.concept.wikibase_revision,
+            "model_config": {"config_data": 768},
             **extra_metadata,
         }
 
@@ -181,6 +185,9 @@ def test_create_and_link_model_artifact():
     mock_run = Mock()
     mock_classifier = Mock()
     mock_classifier.name = "test_classifier"
+    mock_classifier.pipeline = Mock()
+    mock_classifier.model = Mock()
+    mock_classifier.model.config.to_dict.return_value = {"config_data": 768}
     mock_classifier.concept = Mock()
     mock_classifier.concept.id = "5d4xcy5g"
     mock_classifier.concept.wikibase_revision = 12300
@@ -214,6 +221,7 @@ def test_create_and_link_model_artifact():
                 "classifier_name": "test_classifier",
                 "concept_id": "5d4xcy5g",
                 "concept_wikibase_revision": 12300,
+                "model_config": {"config_data": 768},
             },
         )
 


### PR DESCRIPTION
When a model is a bert model its useful having the config to hand. For example we would have benefited from this today while debugging a dependency drift issue. including this in the wandb metadata means we can look this up when we need to for future trained models.