### PR TITLE
build: Don't install deps in runtime layer

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -76,7 +76,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          load: true
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.get_version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /bin/uv /bin/uvx /bin/
 
 # Copy the project into the image
-COPY pyproject.toml README.md ./
+COPY pyproject.toml uv.lock README.md ./
 COPY knowledge_graph ./knowledge_graph/
 COPY flows ./flows/
 COPY scripts ./scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
     && apt-get install -y gh \
-    && rm -rf /var/lib/apt/lists/*
-RUN git lfs install
+    && rm -rf /var/lib/apt/lists/* \
+    && git lfs install
 
 # Copy Python packages from builder stage
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY static_sites ./static_sites/
 COPY vibe-checker ./vibe-checker/
 
 # Install the project
-RUN uv pip install --system -e .
+RUN uv pip install --system --no-deps -e .
 
 # Set PYTHONPATH to ensure modules can be found for distributed tasks
 # This is a workaround for when running on coiled when functions are serialised 


### PR DESCRIPTION
They're already installed in the build layer, and then copied over.

Help the package installation know the dependencies needed, and thus to avoid trying to reinstall, by coping over `uv.lock`.

This is to help avoid the sometimes really slow builds, due to downloading and reinstall large dependencies.