### PR TITLE
fix: Remove duplicate entries

### DIFF
--- a/flows/classifier_specs/v2/production.yaml
+++ b/flows/classifier_specs/v2/production.yaml
@@ -430,33 +430,12 @@
   concept_id: anhcmh9a
   classifier_id: 72tmt7zm
   classifiers_profile: primary
-  wandb_registry_version: v15
-  compute_environment:
-    gpu: true
-- wikibase_id: Q1651
-  concept_id: anhcmh9a
-  classifier_id: 72tmt7zm
-  classifiers_profile: primary
   wandb_registry_version: v16
   compute_environment:
     gpu: true
 - wikibase_id: Q1652
   concept_id: z9k6f9ps
   classifier_id: t2gvekg3
-  classifiers_profile: primary
-  wandb_registry_version: v12
-  compute_environment:
-    gpu: true
-- wikibase_id: Q1652
-  concept_id: z9k6f9ps
-  classifier_id: t2gvekg3
-  classifiers_profile: primary
-  wandb_registry_version: v13
-  compute_environment:
-    gpu: true
-- wikibase_id: Q1653
-  concept_id: set8cyd3
-  classifier_id: 2h5qv7ee
   classifiers_profile: primary
   wandb_registry_version: v13
   compute_environment:


### PR DESCRIPTION
The models were retrained last week. The changes to the models though weren’t accounted for in the ID generation, so there was a new W&B version, but not a new canonical ID. The classifier ID in the Concept Store therefore wasn’t changed, since it was the same. This was why there was no update operations, and only the W&B model registry changes.

This removes the dupe entry, and gets it back to a good state.

I had to manually remove the `production` label from the old entries, in W&B. I ran `just update-inference-classifiers --aws-envs prod` to confirm that they weren't re-added, and that there are no changes.

TOWARDS PLA-1284
