### PR TITLE
fix: add gpu specific limits

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -78,7 +78,8 @@ BLOCKED_BLOCK_TYPES: Final[set[BlockType]] = {
     BlockType.FIGURE,
 }
 
-CLASSIFIER_CONCURRENCY_LIMIT: Final[PositiveInt] = 20
+CLASSIFIER_CPU_CONCURRENCY_LIMIT: Final[PositiveInt] = 20
+CLASSIFIER_GPU_CONCURRENCY_LIMIT: Final[PositiveInt] = 10
 INFERENCE_BATCH_SIZE_DEFAULT: Final[PositiveInt] = 1000
 CLASSIFIER_PREDICT_BATCH_SIZE: Final[PositiveInt] = 32
 AWS_ENV: str = os.environ["AWS_ENV"]
@@ -1267,7 +1268,8 @@ async def inference(
     document_ids_s3_path: str | None = None,
     config: Config | None = None,
     batch_size: int = INFERENCE_BATCH_SIZE_DEFAULT,
-    classifier_concurrency_limit: PositiveInt = CLASSIFIER_CONCURRENCY_LIMIT,
+    classifier_cpu_concurrency_limit: PositiveInt = CLASSIFIER_CPU_CONCURRENCY_LIMIT,
+    classifier_gpu_concurrency_limit: PositiveInt = CLASSIFIER_GPU_CONCURRENCY_LIMIT,
     return_pointer: Literal[False] = False,
 ) -> set[DocumentStem] | Fault: ...
 
@@ -1279,7 +1281,8 @@ async def inference(
     document_ids_s3_path: str | None = None,
     config: Config | None = None,
     batch_size: int = INFERENCE_BATCH_SIZE_DEFAULT,
-    classifier_concurrency_limit: PositiveInt = CLASSIFIER_CONCURRENCY_LIMIT,
+    classifier_cpu_concurrency_limit: PositiveInt = CLASSIFIER_CPU_CONCURRENCY_LIMIT,
+    classifier_gpu_concurrency_limit: PositiveInt = CLASSIFIER_GPU_CONCURRENCY_LIMIT,
     return_pointer: Literal[True] = ...,
 ) -> RunOutputIdentifier | Fault: ...
 
@@ -1294,7 +1297,8 @@ async def inference(
     document_ids_s3_path: str | None = None,
     config: Config | None = None,
     batch_size: int = INFERENCE_BATCH_SIZE_DEFAULT,
-    classifier_concurrency_limit: PositiveInt = CLASSIFIER_CONCURRENCY_LIMIT,
+    classifier_cpu_concurrency_limit: PositiveInt = CLASSIFIER_CPU_CONCURRENCY_LIMIT,
+    classifier_gpu_concurrency_limit: PositiveInt = CLASSIFIER_GPU_CONCURRENCY_LIMIT,
     return_pointer: bool = False,
 ) -> set[DocumentStem] | RunOutputIdentifier | Fault:
     """
@@ -1374,7 +1378,8 @@ async def inference(
 
     # Prepare document batches based on classifier specs
     requested_document_stems: set[DocumentStem] = set()
-    parameterised_batches: Sequence[ParameterisedFlow] = []
+    cpu_batches: list[ParameterisedFlow] = []
+    gpu_batches: list[ParameterisedFlow] = []
     removal_details: dict[ClassifierSpec, int] = {}
     skipped_by_cache: dict[ClassifierSpec, set[DocumentStem]] = {}
     existing_results_count: dict[ClassifierSpec, int] = {}
@@ -1413,11 +1418,17 @@ async def inference(
                 classifier_spec.compute_environment
                 and classifier_spec.compute_environment.gpu
             ):
-                fn = inference_batch_of_documents_gpu
+                gpu_batches.append(
+                    ParameterisedFlow(
+                        fn=inference_batch_of_documents_gpu, params=params
+                    )
+                )
             else:
-                fn = inference_batch_of_documents_cpu
-
-            parameterised_batches.append(ParameterisedFlow(fn=fn, params=params))
+                cpu_batches.append(
+                    ParameterisedFlow(
+                        fn=inference_batch_of_documents_cpu, params=params
+                    )
+                )
 
     await create_dont_run_on_docs_summary_artifact(
         config=config,
@@ -1427,6 +1438,8 @@ async def inference(
         accepted_documents_count=accepted_documents_count,
     )
 
+    parameterised_batches = [*cpu_batches, *gpu_batches]
+
     all_raw_successes: list[BatchInferenceResult] = []
     all_raw_failures: list[BaseException | FlowRun] = []
 
@@ -1434,15 +1447,30 @@ async def inference(
         printer=print,
         name="running classifier inference with map_as_sub_flow",
     ):
-        raw_successes, raw_failures = await map_as_sub_flow(
-            aws_env=config.aws_env,
-            counter=classifier_concurrency_limit,
-            parameterised_batches=parameterised_batches,
-            unwrap_result=True,
-        )
+        coros = []
+        if cpu_batches:
+            coros.append(
+                map_as_sub_flow(
+                    aws_env=config.aws_env,
+                    counter=classifier_cpu_concurrency_limit,
+                    parameterised_batches=cpu_batches,
+                    unwrap_result=True,
+                )
+            )
+        if gpu_batches:
+            coros.append(
+                map_as_sub_flow(
+                    aws_env=config.aws_env,
+                    counter=classifier_gpu_concurrency_limit,
+                    parameterised_batches=gpu_batches,
+                    unwrap_result=True,
+                )
+            )
 
-        all_raw_successes.extend(raw_successes)
-        all_raw_failures.extend(raw_failures)
+        results = await asyncio.gather(*coros)
+        for raw_successes, raw_failures in results:
+            all_raw_successes.extend(raw_successes)
+            all_raw_failures.extend(raw_failures)
 
     # The type of response when running as a sub deployment is:
     #   <class 'inference.BatchInferenceResult'>

--- a/flows/topic_pipeline.py
+++ b/flows/topic_pipeline.py
@@ -25,7 +25,8 @@ from flows.index import (
     index,
 )
 from flows.inference import (
-    CLASSIFIER_CONCURRENCY_LIMIT,
+    CLASSIFIER_CPU_CONCURRENCY_LIMIT,
+    CLASSIFIER_GPU_CONCURRENCY_LIMIT,
     INFERENCE_BATCH_SIZE_DEFAULT,
     inference,
 )
@@ -71,7 +72,8 @@ async def topic_pipeline(
     document_ids: Sequence[DocumentImportId] | None = None,
     document_ids_s3_path: str | None = None,
     inference_batch_size: int = INFERENCE_BATCH_SIZE_DEFAULT,
-    inference_classifier_concurrency_limit: PositiveInt = CLASSIFIER_CONCURRENCY_LIMIT,
+    inference_cpu_concurrency_limit: PositiveInt = CLASSIFIER_CPU_CONCURRENCY_LIMIT,
+    inference_gpu_concurrency_limit: PositiveInt = CLASSIFIER_GPU_CONCURRENCY_LIMIT,
     config: Config | None = None,
     aggregation_n_documents_in_batch: PositiveInt = AGGREGATION_DEFAULT_N_DOCUMENTS_IN_BATCH,
     aggregation_n_batches: PositiveInt = 5,
@@ -95,7 +97,8 @@ async def topic_pipeline(
         document_ids_s3_path: An S3 path string (e.g., "s3://bucket/key") that contains document ids to process.
         config: Configuration for the inference, aggregation and index flows. If None, creates default.
         inference_batch_size: Number of documents to process in each batch.
-        inference_classifier_concurrency_limit: Maximum concurrent classifiers.
+        inference_cpu_concurrency_limit: Maximum concurrent CPU classifier batches.
+        inference_gpu_concurrency_limit: Maximum concurrent GPU classifier batches.
         aggregation_n_documents_in_batch: Number of documents per aggregation batch.
         aggregation_n_batches: Number of aggregation batches to run.
         indexing_batch_size: Number of documents to index in each batch.
@@ -125,7 +128,8 @@ async def topic_pipeline(
         document_ids_s3_path=document_ids_s3_path,
         config=config,
         batch_size=inference_batch_size,
-        classifier_concurrency_limit=inference_classifier_concurrency_limit,
+        classifier_cpu_concurrency_limit=inference_cpu_concurrency_limit,
+        classifier_gpu_concurrency_limit=inference_gpu_concurrency_limit,
         return_pointer=True,
         return_state=True,
     )

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -82,10 +82,16 @@ def mock_deployment():
             self._mock_patch = None
 
         async def mock_awaitable(self, *args, **kwargs):
-            """Generate FlowRun with next state from the iterator"""
+            """
+            Generate FlowRun with next state from the iterator.
+
+            If self.state is callable it is invoked with the same args/kwargs
+            so callers can return different states per call.
+            """
             flow_id = uuid.uuid4()
             flow_name = f"{self.name}-{str(flow_id)[:8]}"
-            return FlowRun(flow_id=flow_id, name=flow_name, state=self.state)
+            state = self.state(*args, **kwargs) if callable(self.state) else self.state
+            return FlowRun(flow_id=flow_id, name=flow_name, state=state)
 
         def __enter__(self):
             self._mock_patch = patch("flows.utils.run_deployment")
@@ -2404,3 +2410,71 @@ def test_get_labelled_passage_from_prediction_without_spans():
     assert result.id == "fish_block"
     # When there are no spans, metadata should be empty
     assert result.metadata == {}
+
+
+@pytest.mark.asyncio
+async def test_inference_with_mixed_cpu_and_gpu_specs(
+    test_config,
+    mock_classifiers_dir,
+    mock_wandb,
+    mock_async_bucket_documents,
+    mock_deployment,
+):
+    """Inference for both CPU and GPU are called & results combined."""
+
+    cpu_spec = ClassifierSpec(
+        wikibase_id=WikibaseID("Q788"),
+        classifier_id=ClassifierID("cpucpu22"),
+        wandb_registry_version="v13",
+    )
+    gpu_spec = ClassifierSpec(
+        wikibase_id=WikibaseID("Q789"),
+        classifier_id=ClassifierID("gpugpu22"),
+        wandb_registry_version="v1",
+        compute_environment=ClassifierSpec.ComputeEnvironment(gpu=True),
+    )
+
+    input_doc_ids = [
+        DocumentImportId(Path(doc_file).stem)
+        for doc_file in mock_async_bucket_documents
+    ]
+    doc_stems = [DocumentStem(d) for d in input_doc_ids]
+    results_by_spec = {
+        str(cpu_spec): BatchInferenceResult(
+            batch_document_stems=doc_stems,
+            successful_document_stems=doc_stems,
+            classifier_spec=cpu_spec,
+            failed=False,
+        ),
+        str(gpu_spec): BatchInferenceResult(
+            batch_document_stems=doc_stems,
+            successful_document_stems=doc_stems,
+            classifier_spec=gpu_spec,
+            failed=False,
+        ),
+    }
+
+    def state_for_call(*args, **kwargs):
+        spec_json = kwargs["parameters"]["classifier_spec_json"]
+        spec = ClassifierSpec.model_validate(spec_json)
+        return Completed(data=results_by_spec[str(spec)])
+
+    with mock_deployment(state_for_call) as mock_rd:
+        inference_result = await inference(
+            classifier_specs=[cpu_spec, gpu_spec],
+            document_ids=input_doc_ids,
+            config=test_config,
+        )
+
+    assert mock_rd.call_count == 2
+    called_names = {call.kwargs["name"] for call in mock_rd.call_args_list}
+    assert (
+        "inference-batch-of-documents-cpu/kg-inference-batch-of-documents-cpu-sandbox"
+        in called_names
+    )
+    assert (
+        "inference-batch-of-documents-gpu/kg-inference-batch-of-documents-gpu-sandbox"
+        in called_names
+    )
+
+    assert inference_result == set(input_doc_ids)

--- a/tests/flows/test_topic_pipeline.py
+++ b/tests/flows/test_topic_pipeline.py
@@ -206,7 +206,8 @@ async def test_topic_pipeline_with_full_config(
                 DocumentImportId("test.doc.2"),
             ],
             inference_batch_size=500,
-            inference_classifier_concurrency_limit=5,
+            inference_cpu_concurrency_limit=5,
+            inference_gpu_concurrency_limit=5,
             aggregation_n_documents_in_batch=50,
             aggregation_n_batches=3,
             indexing_batch_size=200,
@@ -227,7 +228,8 @@ async def test_topic_pipeline_with_full_config(
         )
         assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
-        assert call_args.kwargs["classifier_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_cpu_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_gpu_concurrency_limit"] == 5
 
         mock_aggregate.assert_called_once()
         call_args = mock_aggregate.call_args
@@ -322,7 +324,8 @@ async def test_topic_pipeline_with_inference_failure(
                 classifier_specs=[classifier_spec],
                 document_ids=document_ids,
                 inference_batch_size=500,
-                inference_classifier_concurrency_limit=5,
+                inference_cpu_concurrency_limit=5,
+                inference_gpu_concurrency_limit=5,
                 aggregation_n_documents_in_batch=50,
                 aggregation_n_batches=3,
                 indexing_batch_size=200,
@@ -343,7 +346,8 @@ async def test_topic_pipeline_with_inference_failure(
         )
         assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
-        assert call_args.kwargs["classifier_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_cpu_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_gpu_concurrency_limit"] == 5
 
         mock_aggregate.assert_called_once()
         call_args = mock_aggregate.call_args
@@ -379,7 +383,8 @@ async def test_topic_pipeline_with_inference_failure(
                 classifier_specs=[classifier_spec],
                 document_ids=document_ids,
                 inference_batch_size=500,
-                inference_classifier_concurrency_limit=5,
+                inference_cpu_concurrency_limit=5,
+                inference_gpu_concurrency_limit=5,
                 aggregation_n_documents_in_batch=50,
                 aggregation_n_batches=3,
                 indexing_batch_size=200,
@@ -466,7 +471,8 @@ async def test_topic_pipeline_completes_after_some_docs_fail_inference_and_aggre
                     DocumentImportId("test.doc.2"),
                 ],
                 inference_batch_size=500,
-                inference_classifier_concurrency_limit=5,
+                inference_cpu_concurrency_limit=5,
+                inference_gpu_concurrency_limit=5,
                 aggregation_n_documents_in_batch=50,
                 aggregation_n_batches=3,
                 indexing_batch_size=200,
@@ -487,7 +493,8 @@ async def test_topic_pipeline_completes_after_some_docs_fail_inference_and_aggre
         )
         assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
-        assert call_args.kwargs["classifier_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_cpu_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_gpu_concurrency_limit"] == 5
 
         mock_aggregate.assert_called_once()
         call_args = mock_aggregate.call_args
@@ -610,7 +617,8 @@ async def test_topic_pipeline_with_document_ids_s3_path(
             classifier_specs=[classifier_spec],
             document_ids_s3_path=s3_path,
             inference_batch_size=500,
-            inference_classifier_concurrency_limit=5,
+            inference_cpu_concurrency_limit=5,
+            inference_gpu_concurrency_limit=5,
             aggregation_n_documents_in_batch=50,
             aggregation_n_batches=3,
             indexing_batch_size=200,
@@ -626,7 +634,8 @@ async def test_topic_pipeline_with_document_ids_s3_path(
         assert call_args.kwargs["document_ids_s3_path"] == s3_path
         assert call_args.kwargs["config"] == test_config
         assert call_args.kwargs["batch_size"] == 500
-        assert call_args.kwargs["classifier_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_cpu_concurrency_limit"] == 5
+        assert call_args.kwargs["classifier_gpu_concurrency_limit"] == 5
 
         mock_aggregate.assert_called_once()
         mock_indexing.assert_called_once()


### PR DESCRIPTION
We were getting rate limited by aws previously for gpu instances and experienced crashes. This limits gpu classifier inference & cpu classifier inference independently. There is more that we can do to improve this, especially around distribution. But this is intended as a tactical, time-efficient improvement for starters