### PR TITLE
drive-by classifier training fixes

### DIFF
--- a/knowledge_graph/classifier/autollm.py
+++ b/knowledge_graph/classifier/autollm.py
@@ -102,7 +102,7 @@ class AutoLLMClassifier(LLMClassifier):
         self,
         labelled_passages: list | None = None,
         meta_prompt: str | None = None,
-        optimiser_model_name: str = "openrouter:google/gemini-3-pro-preview",
+        optimiser_model_name: str = "openrouter:google/gemini-3.1-pro-preview",
         final_classifier_model_name: str | None = None,
         n_trials: int = 3,
         beta: float = 1.0,
@@ -299,7 +299,7 @@ if __name__ == "__main__":
 
     clf.fit(
         optimiser_model_name="openrouter:google/gemini-3-flash-preview",
-        final_classifier_model_name="openrouter:google/gemini-3-pro-preview",
+        final_classifier_model_name="openrouter:google/gemini-3.1-pro-preview",
         n_trials=5,
         beta=0.5,
     )

--- a/knowledge_graph/classifier/large_language_model.py
+++ b/knowledge_graph/classifier/large_language_model.py
@@ -267,7 +267,7 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
                     marked_up_text=response.output,
                     reasoning=None,
                 )
-        except UnexpectedModelBehavior as e:
+        except (UnexpectedModelBehavior, ValidationError) as e:
             logger.warning(
                 f"LLM failed to produce valid response after retries: {e}. "
                 f"Text (truncated): {text[:100]}..."
@@ -336,7 +336,7 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
         for text, response in zip(texts, responses):
             # Handle exceptions that occurred during async execution
             if isinstance(response, Exception):
-                if isinstance(response, UnexpectedModelBehavior):
+                if isinstance(response, (UnexpectedModelBehavior, ValidationError)):
                     logger.warning(
                         f"LLM failed to produce valid response after retries: {response}. "
                         f"Text (truncated): {text[:100]}..."

--- a/knowledge_graph/classifier/large_language_model.py
+++ b/knowledge_graph/classifier/large_language_model.py
@@ -260,7 +260,9 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
         try:
             response: AgentRunResult[LLMResponse | str] = self.agent.run_sync(  # type: ignore[assignment]
                 text,
-                model_settings=ModelSettings(seed=self.random_seed or 42),  # type: ignore[arg-type]
+                model_settings=ModelSettings(
+                    seed=self.random_seed or 42, temperature=0
+                ),  # type: ignore[arg-type]
             )
             if isinstance(response.output, str):
                 response.output = LLMResponse(  # type: ignore[assignment]
@@ -306,7 +308,9 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
             async_responses = [
                 self.agent.run(
                     text,
-                    model_settings=ModelSettings(seed=self.random_seed or 42),  # type: ignore[arg-type]
+                    model_settings=ModelSettings(
+                        seed=self.random_seed or 42, temperature=0
+                    ),  # type: ignore[arg-type]
                 )
                 for text in texts
             ]

--- a/scripts/custom_concept_training/q32_train_llm.py
+++ b/scripts/custom_concept_training/q32_train_llm.py
@@ -28,7 +28,7 @@ app = typer.Typer()
 console = Console()
 
 WIKIBASE_ID = WikibaseID("Q32")
-MODEL_NAME = "openrouter:google/gemini-3-pro-preview"
+MODEL_NAME = "openrouter:google/gemini-3.1-pro-preview"
 
 CONCEPT_DEFINITION = "Justice is the ethical and political framework that addresses fairness, including issues of responsibility, rights, and structural inequity."
 

--- a/scripts/custom_concept_training/q911_train_llm.py
+++ b/scripts/custom_concept_training/q911_train_llm.py
@@ -28,7 +28,7 @@ app = typer.Typer()
 console = Console()
 
 WIKIBASE_ID = WikibaseID("Q911")
-MODEL_NAME = "openrouter:google/gemini-3-pro-preview"
+MODEL_NAME = "openrouter:google/gemini-3.1-pro-preview"
 
 CONCEPT_DEFINITION = """Distributive justice is the fair allocation of the benefits, burdens, and risks, focusing on those most responsible and those most vulnerable. It includes ethical and political arguments, as well as concrete actions."""
 

--- a/scripts/custom_concept_training/q912_train_llm.py
+++ b/scripts/custom_concept_training/q912_train_llm.py
@@ -25,7 +25,7 @@ app = typer.Typer()
 console = Console()
 
 WIKIBASE_ID = WikibaseID("Q912")
-MODEL_NAME = "openrouter:google/gemini-3-pro-preview"
+MODEL_NAME = "openrouter:google/gemini-3.1-pro-preview"
 
 CONCEPT_DEFINITION = """Procedural justice means ensuring that decision making is fair and inclusive, emphasizing the agency and influence of vulnerable groups and those, giving them power to change processes that affect their lives."""
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from collections import defaultdict
 from datetime import datetime
@@ -36,6 +37,7 @@ from knowledge_graph.wandb_helpers import load_classifier_from_wandb
 from scripts.get_concept import get_concept_async
 
 console = Console()
+logger = logging.getLogger(__name__)
 
 
 def load_concept(wikibase_id: WikibaseID) -> Concept:
@@ -225,8 +227,9 @@ def group_passages_by_equity_strata(
     if missing_equity_strata := [
         name for name, values in equity_strata_values.items() if values == {None}
     ]:
-        print(
-            f"WARNING: Equity columns provided to evaluate don't have values in the human labelled passages: {missing_equity_strata}."
+        logger.warning(
+            "Equity columns provided to evaluate don't have values in the human labelled passages: %s.",
+            missing_equity_strata,
         )
 
         return groups

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -225,9 +225,11 @@ def group_passages_by_equity_strata(
     if missing_equity_strata := [
         name for name, values in equity_strata_values.items() if values == {None}
     ]:
-        raise ValueError(
-            f"Equity columns provided to evaluate don't have values in the human labelled passages: {missing_equity_strata}."
+        print(
+            f"WARNING: Equity columns provided to evaluate don't have values in the human labelled passages: {missing_equity_strata}."
         )
+
+        return groups
 
     # group the passages according to their values
     for equity_stratum, values in equity_strata_values.items():

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -137,8 +137,10 @@ def test_log_metrics(metrics_df: pd.DataFrame):
         assert any(["performance" in log_call[0][0] for log_call in log_calls])
 
 
-def test_group_passages_by_equity_strata_raises_when_equity_column_missing_from_metadata():
-    """Test that ValueError is raised when equity strata columns have no values in passages."""
+def test_group_passages_by_equity_strata_logs_warning_when_equity_column_missing_from_metadata(
+    caplog,
+):
+    """Test that a warning is logged and only the 'all' group is returned when equity strata columns have no values."""
     human_passages = [
         LabelledPassage(text="passage 1", spans=[], metadata={"other_field": "value1"}),
         LabelledPassage(text="passage 2", spans=[], metadata={"other_field": "value2"}),
@@ -148,14 +150,16 @@ def test_group_passages_by_equity_strata_raises_when_equity_column_missing_from_
         LabelledPassage(text="passage 2", spans=[], metadata={"other_field": "value2"}),
     ]
 
-    with pytest.raises(ValueError) as exc_info:
-        group_passages_by_equity_strata(
+    with caplog.at_level("WARNING", logger="scripts.evaluate"):
+        result = group_passages_by_equity_strata(
             human_labelled_passages=human_passages,
             model_labelled_passages=model_passages,
             equity_strata=["missing_column"],
         )
 
-    assert "missing_column" in str(exc_info.value)
+    assert "missing_column" in caplog.text
+    assert len(result) == 1
+    assert result[0][0] == "all"
 
 
 def test_calculate_std_by_equity_strata(metrics_df: pd.DataFrame):


### PR DESCRIPTION
some fixes found when training Q912's LLMClassifier

- log rather than raise when equity strata columns not found
- handle model output `ValidationError` cleanly
- use gemini 3.1 pro due to [gemini 3 pro deprecation](https://ai.google.dev/gemini-api/docs/deprecations#:~:text=gemini%2D3%2Dpro%2Dpreview)
- set temperature of 0 for LLMClassifier