### PR TITLE
fix: Reset client if login fails

### DIFF
--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -125,9 +125,23 @@ class WikibaseSession:
     async def _get_client(self) -> httpx.AsyncClient:
         """Get the HTTP client, initializing session on first use"""
         if self._client is None:
+            logger.debug("Initialising Wikibase HTTP client and session")
             self._client = httpx.AsyncClient(timeout=self.DEFAULT_TIMEOUT)
-            await self._login()
-            self._redirects = await self._get_all_redirects()
+            try:
+                await self._login()
+                logger.debug("Wikibase login successful, fetching redirects")
+                self._redirects = await self._get_all_redirects()
+                logger.debug(
+                    "Session initialized with %d redirects", len(self._redirects)
+                )
+            except Exception as e:
+                logger.warning(
+                    "Wikibase session initialisation failed, resetting client: %s", e
+                )
+                # Reset the client, since something went wrong in
+                # initialisation.
+                self._client = None
+                raise
 
         if self._semaphore is None:
             self._semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_REQUESTS)


### PR DESCRIPTION
`get_concepts_async` failed with `Session not initialized - call a method that initializes the session first`[1].

My hunch is that setting up the Wikibase session failed, and there was a silent retry. On the 2nd attempt of the top-level function, it tried to use the client, it saw that `self._client` was _not_ `None`, and tried to use it.

Instead, if logging in, or getting all the redirects, fails, it resets the client back to `None`.

[1]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069ca44f-c25d-7470-8000-e39b20365c7f?preview=true&tab=logs

