### PR TITLE
refactor: Use our custom logger for retries

### DIFF
--- a/flows/utils.py
+++ b/flows/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import inspect
 import json
-import logging
 import os
 import re
 import textwrap
@@ -55,6 +54,7 @@ from knowledge_graph.cloud import (
     function_to_flow_name,
     generate_deployment_name,
 )
+from knowledge_graph.utils import get_logger
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -865,30 +865,6 @@ async def gather_and_report(
             )
 
     return results
-
-
-LoggingAdapter = logging.LoggerAdapter[logging.Logger]
-
-
-def get_logger() -> logging.Logger | LoggingAdapter:
-    """
-    Get a logger via Prefect.
-
-    You can overwrite the logging level[2]. If not running in a flow
-    or task run context, a logger that doesn't send to the Prefect API
-    is returned.
-
-    > `get_run_logger()` can only be used in the context of a flow or task.
-    > To use a normal Python logger anywhere with your same configuration, use `get_logger()` from `prefect.logging`.
-    > The logger retrieved with `get_logger()` will not send log records to the Prefect API.
-
-    [1]: https://docs.prefect.io/v3/how-to-guides/workflows/add-logging
-    [2]: https://docs.prefect.io/v3/api-ref/settings-ref#logging-level
-    """
-    try:
-        return prefect.logging.get_run_logger()
-    except prefect.exceptions.MissingContextError:
-        return prefect.logging.get_logger()
 
 
 def get_run_name() -> None | str:

--- a/knowledge_graph/utils.py
+++ b/knowledge_graph/utils.py
@@ -1,10 +1,38 @@
 """Utility functions for the knowledge_graph package."""
 
 import json
+import logging
 from collections.abc import Generator, Sequence
 from typing import TypeVar
 
+import prefect
+import prefect.exceptions
+import prefect.logging
 from pydantic import BaseModel, ValidationError
+
+LoggingAdapter = logging.LoggerAdapter[logging.Logger]
+
+
+def get_logger() -> logging.Logger | LoggingAdapter:
+    """
+    Get a logger via Prefect.
+
+    You can overwrite the logging level[2]. If not running in a flow
+    or task run context, a logger that doesn't send to the Prefect API
+    is returned.
+
+    > `get_run_logger()` can only be used in the context of a flow or task.
+    > To use a normal Python logger anywhere with your same configuration, use `get_logger()` from `prefect.logging`.
+    > The logger retrieved with `get_logger()` will not send log records to the Prefect API.
+
+    [1]: https://docs.prefect.io/v3/how-to-guides/workflows/add-logging
+    [2]: https://docs.prefect.io/v3/api-ref/settings-ref#logging-level
+    """
+    try:
+        return prefect.logging.get_run_logger()
+    except prefect.exceptions.MissingContextError:
+        return prefect.logging.get_logger()
+
 
 T = TypeVar("T")
 

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -1,9 +1,9 @@
 import asyncio
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from enum import Enum
-from logging import getLogger
 from typing import Any, NamedTuple, Optional
 
 import dotenv
@@ -18,6 +18,7 @@ from pydantic import (
     ValidationError,
 )
 from tenacity import (
+    before_sleep_log,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
@@ -32,8 +33,9 @@ from knowledge_graph.exceptions import (
     RevisionNotFoundError,
 )
 from knowledge_graph.identifiers import ClassifierID, WikibaseID
+from knowledge_graph.utils import get_logger
 
-logger = getLogger(__name__)
+logger = get_logger()
 dotenv.load_dotenv()
 
 
@@ -124,6 +126,7 @@ class WikibaseSession:
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get the HTTP client, initializing session on first use"""
+        logger = get_logger()
         if self._client is None:
             logger.debug("Initialising Wikibase HTTP client and session")
             self._client = httpx.AsyncClient(timeout=self.DEFAULT_TIMEOUT)
@@ -531,6 +534,7 @@ class WikibaseSession:
         retry=retry_if_exception_type(
             (HTTPStatusError, RequestError, json.JSONDecodeError)
         ),
+        before_sleep=before_sleep_log(get_logger(), logging.WARNING),  # type: ignore[arg-type]
     )
     async def get_concepts_async(
         self,

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -1,5 +1,7 @@
+import logging
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from knowledge_graph.concept import Concept
@@ -64,6 +66,26 @@ def test_wikibase__get_concepts(MockedWikibaseSession):
         "Q1006",
         "Q1005",
     }
+
+
+@pytest.mark.asyncio
+async def test_get_concepts_async__logs_warning_on_retry(MockedWikibaseSession, caplog):
+    """`before_sleep_log` should emit a warning each time `get_concepts_async retries`."""
+    wikibase = MockedWikibaseSession()
+
+    with (
+        patch.object(
+            wikibase,
+            "get_all_concept_ids_async",
+            side_effect=httpx.RequestError("Connection failed"),
+        ),
+        patch("asyncio.sleep"),  # Don't actually wait between retries
+        caplog.at_level(logging.WARNING),  # Don't get too much noise
+    ):
+        with pytest.raises(Exception):
+            await wikibase.get_concepts_async()
+
+    assert any("Retrying" in r.message for r in caplog.records)
 
 
 @pytest.mark.skip(reason="Not implemented")


### PR DESCRIPTION
Not knowing a retry happened can make it harder to debug [1] [2]. This adds a log to when retries happen.

Our custom logger was moved to a place that's _in_ the `knowledge-graph` importable package to facilitate this.

[1]: https://github.com/climatepolicyradar/knowledge-graph/pull/1103
[2]: https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069ca44f-c25d-7470-8000-e39b20365c7f?preview=true&tab=logs

