### PR TITLE
token-based BERT classifier

### DIFF
--- a/knowledge_graph/classifier/__init__.py
+++ b/knowledge_graph/classifier/__init__.py
@@ -53,6 +53,9 @@ def __getattr__(name):
     elif name == "BertBasedClassifier":
         module = importlib.import_module(".bert_based", __package__)
         return getattr(module, name)
+    elif name == "BertTokenClassifier":
+        module = importlib.import_module(".bert_token_classifier", __package__)
+        return getattr(module, name)
     elif name in (
         "EmissionsReductionTargetClassifier",
         "NetZeroTargetClassifier",
@@ -78,6 +81,7 @@ __all__ = [
     "NetZeroTargetClassifier",  # type: ignore
     "TargetClassifier",  # type: ignore
     "BertBasedClassifier",  # type: ignore
+    "BertTokenClassifier",  # type: ignore
     "LLMClassifier",  # type: ignore
     "LocalLLMClassifier",  # type: ignore
     "AutoLLMClassifier",  # type: ignore

--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -587,6 +587,8 @@ class BertTokenClassifier(
             for name, _ in self.model.named_parameters():
                 if match := re.search(r"layers?\.(\d+)\.", name):
                     layer_indices.add(int(match.group(1)))
+                else:
+                    logger.warning(f"No layers found in the model with name {name}")
             if layer_indices:
                 max_layer = max(layer_indices)
                 unfrozen_layer_indices = {

--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -278,7 +278,7 @@ class BertTokenClassifier(
         concept: Concept,
         model_name: str = "answerdotai/ModernBERT-base",
         download_pretrained_model_on_init: bool = True,
-        unfreeze_layers: int = 0,
+        unfreeze_layers: int = 2,
     ):
         super().__init__(concept)
         self.model_name = model_name

--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -1,0 +1,734 @@
+import logging
+import os
+import random
+import re
+import tempfile
+from collections.abc import Sequence
+from contextlib import contextmanager
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import torch
+from datasets import Dataset
+from rich.logging import RichHandler
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+from sklearn.utils.class_weight import compute_class_weight
+from transformers import (
+    AutoModelForTokenClassification,
+    AutoTokenizer,
+    EarlyStoppingCallback,
+    EvalPrediction,
+    PreTrainedModel,
+    PreTrainedTokenizer,
+)
+from transformers.trainer import Trainer
+from transformers.training_args import TrainingArguments
+from typing_extensions import Self
+
+from knowledge_graph.classifier.classifier import (
+    Classifier,
+    GPUBoundClassifier,
+    ProbabilityCapableClassifier,
+    VariantEnabledClassifier,
+)
+from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import ClassifierID, WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.span import Span
+
+logging.basicConfig(handlers=[RichHandler()])
+logger = logging.getLogger(__name__)
+
+# BIO label scheme
+O_LABEL = 0
+B_LABEL = 1
+I_LABEL = 2
+IGNORE_LABEL = -100
+NUM_LABELS = 3
+
+ID2LABEL = {O_LABEL: "O", B_LABEL: "B-CONCEPT", I_LABEL: "I-CONCEPT"}
+LABEL2ID = {v: k for k, v in ID2LABEL.items()}
+
+
+def _align_labels_with_tokens(
+    offset_mapping: list[tuple[int, int]],
+    spans: list[Span],
+    concept_id: WikibaseID | None,
+) -> list[int]:
+    """
+    Align character-level span annotations to subword token positions using BIO tagging.
+
+    For each token, determines whether it falls inside a gold span for the given concept,
+    and assigns a BIO label accordingly.
+
+    :param offset_mapping: List of (start_char, end_char) tuples from the tokenizer,
+        one per token. Special tokens have (0, 0).
+    :param spans: Gold span annotations for this passage.
+    :param concept_id: The concept ID to filter spans by.
+    :returns: List of integer labels, one per token.
+    """
+    # Filter to spans for this concept
+    concept_spans = [s for s in spans if s.concept_id == concept_id]
+
+    # Sort spans by start_index so we can track B vs I correctly
+    concept_spans.sort(key=lambda s: s.start_index)
+
+    labels = []
+    prev_span_idx: int | None = None  # which span the previous real token was in
+
+    for tok_start, tok_end in offset_mapping:
+        # Special tokens (CLS, SEP, PAD) have (0, 0) offset
+        if tok_start == 0 and tok_end == 0:
+            labels.append(IGNORE_LABEL)
+            prev_span_idx = None
+            continue
+
+        # Find which span this token overlaps with (if any)
+        current_span_idx = None
+        for i, span in enumerate(concept_spans):
+            if tok_start < span.end_index and tok_end > span.start_index:
+                current_span_idx = i
+                break
+
+        if current_span_idx is not None:
+            if current_span_idx == prev_span_idx:
+                labels.append(I_LABEL)
+            else:
+                labels.append(B_LABEL)
+            prev_span_idx = current_span_idx
+        else:
+            labels.append(O_LABEL)
+            prev_span_idx = None
+
+    return labels
+
+
+def _reconstruct_spans_from_predictions(
+    token_labels: list[int],
+    token_probs: list[float],
+    offset_mapping: list[tuple[int, int]],
+    text: str,
+    concept_id: WikibaseID | None,
+    labeller: str,
+    min_span_chars: int = 2,
+) -> list[Span]:
+    """
+    Convert BIO token predictions back to character-level Span objects.
+
+    Merges consecutive B/I tokens into contiguous spans and averages their
+    probabilities.
+
+    :param token_labels: Predicted BIO label per token.
+    :param token_probs: Probability of the predicted label per token.
+    :param offset_mapping: (start_char, end_char) per token from the tokenizer.
+    :param text: The original text.
+    :param concept_id: Concept ID to assign to spans.
+    :param labeller: Labeller string for the spans.
+    :param min_span_chars: Minimum span length in characters; shorter spans are dropped.
+    :returns: List of reconstructed Span objects.
+    """
+    spans: list[Span] = []
+    now = datetime.now()
+
+    current_start: int | None = None
+    current_end: int | None = None
+    current_probs: list[float] = []
+
+    def _finalise_span():
+        nonlocal current_start, current_end, current_probs
+        if current_start is not None and current_end is not None:
+            if current_end - current_start >= min_span_chars:
+                spans.append(
+                    Span(
+                        text=text,
+                        start_index=current_start,
+                        end_index=current_end,
+                        concept_id=concept_id,
+                        prediction_probability=float(np.mean(current_probs)),
+                        labellers=[labeller],
+                        timestamps=[now],
+                    )
+                )
+        current_start = None
+        current_end = None
+        current_probs = []
+
+    for label, prob, (tok_start, tok_end) in zip(
+        token_labels, token_probs, offset_mapping
+    ):
+        # Skip special tokens
+        if tok_start == 0 and tok_end == 0:
+            continue
+
+        if label == B_LABEL:
+            # Finalise any open span before starting a new one
+            _finalise_span()
+            current_start = tok_start
+            current_end = tok_end
+            current_probs = [prob]
+        elif label == I_LABEL and current_start is not None:
+            # Extend current span
+            current_end = tok_end
+            current_probs.append(prob)
+        else:
+            # O label or orphaned I label: finalise any open span
+            _finalise_span()
+
+    # Finalise any span still open at end of sequence
+    _finalise_span()
+
+    return spans
+
+
+def _count_bio_labels(label_sequences: list[list[int]]) -> dict[int, int]:
+    """Count occurrences of each BIO label across all sequences."""
+    counts: dict[int, int] = {O_LABEL: 0, B_LABEL: 0, I_LABEL: 0}
+    for seq in label_sequences:
+        for label in seq:
+            if label in counts:
+                counts[label] += 1
+    return counts
+
+
+def _compute_token_metrics(eval_pred: EvalPrediction) -> dict[str, float]:
+    """
+    Compute token-level metrics from token predictions.
+
+    Note: precision/recall/F1 here are token-level, not span-level. A 5-token
+    entity counts as 5 positives. This is used for early stopping during
+    training; the production quality signal is the span-level Jaccard metric
+    computed by evaluate_classifier.
+    """
+    predictions = np.argmax(eval_pred.predictions, axis=2)  # [batch, seq_len]
+    labels = eval_pred.label_ids  # [batch, seq_len]
+
+    # Flatten, ignoring positions with IGNORE_LABEL
+    mask = labels != IGNORE_LABEL
+    flat_preds = predictions[mask]
+    flat_labels = labels[mask]
+
+    accuracy = accuracy_score(flat_labels, flat_preds)
+
+    # Token-level positives: any non-O token
+    pred_positive = flat_preds != O_LABEL
+    gold_positive = flat_labels != O_LABEL
+
+    tp = int(np.sum(pred_positive & gold_positive))
+    fp = int(np.sum(pred_positive & ~gold_positive))
+    fn = int(np.sum(~pred_positive & gold_positive))
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1 = (
+        2 * precision * recall / (precision + recall)
+        if (precision + recall) > 0
+        else 0.0
+    )
+
+    return {"accuracy": accuracy, "f1": f1, "precision": precision, "recall": recall}
+
+
+class WeightedTokenTrainer(Trainer):
+    """Trainer that applies class weights to token-level cross-entropy loss."""
+
+    def __init__(self, *args, class_weights=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.class_weights = class_weights
+
+    def compute_loss(
+        self, model, inputs, return_outputs=False, num_items_in_batch=None
+    ):
+        """Compute weighted token-level cross-entropy loss"""
+        labels = inputs.pop("labels")
+        outputs = model(**inputs)
+        logits = outputs.get("logits")
+
+        if self.class_weights is not None:
+            loss_fct = torch.nn.CrossEntropyLoss(
+                weight=self.class_weights, ignore_index=IGNORE_LABEL
+            )
+        else:
+            loss_fct = torch.nn.CrossEntropyLoss(ignore_index=IGNORE_LABEL)
+
+        # Reshape: [batch, seq_len, num_labels] -> [batch*seq_len, num_labels]
+        loss = loss_fct(logits.view(-1, NUM_LABELS), labels.view(-1))
+
+        return (loss, outputs) if return_outputs else loss
+
+
+class BertTokenClassifier(
+    Classifier,
+    GPUBoundClassifier,
+    VariantEnabledClassifier,
+    ProbabilityCapableClassifier,
+):
+    """
+    Token-level BERT classifier.
+
+    Performs BIO (beginning-inside-outside) token classification to identify precisely
+    which tokens mention the concept.
+
+    https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)
+    """
+
+    def __init__(
+        self,
+        concept: Concept,
+        model_name: str = "answerdotai/ModernBERT-base",
+        download_pretrained_model_on_init: bool = True,
+        unfreeze_layers: int = 0,
+    ):
+        super().__init__(concept)
+        self.model_name = model_name
+        self.unfreeze_layers = unfreeze_layers
+
+        self._use_dropout_during_inference = False
+        self._variant_seed = False
+        self._variant_dropout_rate = False
+        self._random_id_component: str = ""
+
+        self.device = self._resolve_device()
+
+        if download_pretrained_model_on_init:
+            self.download_model_and_tokenizer()
+
+    def _resolve_device(self) -> torch.device:
+        if torch.backends.mps.is_available():
+            return torch.device("mps")
+        elif torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
+    def move_model_to_device(self, device: torch.device | None = None) -> None:
+        """Move a model to a chosen device"""
+        device = device or self._resolve_device()
+        if hasattr(self.model, "to"):
+            self.model.to(device)  # type: ignore[arg-type]
+        self.device = device
+
+    def download_model_and_tokenizer(self) -> None:
+        """Download pretrained base model and tokenizer"""
+        self.model: PreTrainedModel = AutoModelForTokenClassification.from_pretrained(
+            self.model_name,
+            num_labels=NUM_LABELS,
+            id2label=ID2LABEL,
+            label2id=LABEL2ID,
+        )
+        self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
+            self.model_name
+        )
+
+        if not self.tokenizer.is_fast:
+            raise ValueError(
+                f"Tokenizer for {self.model_name} is not a fast tokenizer. "
+                "A fast tokenizer is required for offset_mapping support."
+            )
+
+        self.model.to(self.device)  # type: ignore[arg-type]
+
+    @property
+    def id(self) -> ClassifierID:
+        """Classifier ID"""
+        return ClassifierID.generate(
+            self.name,
+            self.concept.id,
+            self.model_name,
+            self.prediction_threshold,
+            self.unfreeze_layers,
+            self._random_id_component,
+        )
+
+    @contextmanager
+    def _dropout_enabled(self):
+        was_training = self.model.training
+
+        dropout_layers = [
+            m for m in self.model.modules() if isinstance(m, torch.nn.Dropout)
+        ]
+
+        if not hasattr(self, "_dropout_logged"):
+            if not dropout_layers:
+                logger.warning(
+                    "No dropout layers found in model %s. "
+                    "Ensemble variants may produce identical predictions.",
+                    self.model_name,
+                )
+            else:
+                original_rates = {layer.p for layer in dropout_layers}
+                logger.info(
+                    "Found %d dropout layers with original rates: %s",
+                    len(dropout_layers),
+                    original_rates,
+                )
+            self._dropout_logged = True
+
+        original_dropout_rates = [layer.p for layer in dropout_layers]
+
+        if self._variant_dropout_rate is not None and dropout_layers:
+            for layer in dropout_layers:
+                layer.p = self._variant_dropout_rate
+
+        if self._variant_seed is not None:
+            torch.manual_seed(self._variant_seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(self._variant_seed)
+            if torch.backends.mps.is_available():
+                torch.mps.manual_seed(self._variant_seed)
+
+        self.model.train()
+        try:
+            yield
+        finally:
+            for layer, original_rate in zip(dropout_layers, original_dropout_rates):
+                layer.p = original_rate
+            self.model.train(was_training)
+
+    def get_variant(
+        self, random_seed: int | None = None, dropout_rate: float = 0.1
+    ) -> Self:
+        """Get a variant of the classifier for Monte Carlo dropout estimation."""
+        variant = self.__class__(
+            concept=self.concept,
+            model_name=self.model_name,
+            download_pretrained_model_on_init=True,
+            unfreeze_layers=self.unfreeze_layers,
+        )
+        variant.model.load_state_dict(self.model.state_dict())
+        variant.tokenizer = self.tokenizer
+        variant.device = self.device
+
+        variant._variant_seed = random_seed
+        variant._variant_dropout_rate = dropout_rate
+        variant._use_dropout_during_inference = True
+        variant.is_fitted = self.is_fitted
+
+        return variant
+
+    def _prepare_dataset(self, labelled_passages: list[LabelledPassage]) -> Dataset:
+        texts = [passage.text for passage in labelled_passages]
+
+        tokenized = self.tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors=None,
+            return_offsets_mapping=True,
+        )
+
+        all_labels = []
+        for i, passage in enumerate(labelled_passages):
+            offset_mapping = tokenized["offset_mapping"][i]  # type: ignore[index]
+            labels = _align_labels_with_tokens(
+                offset_mapping=offset_mapping,
+                spans=passage.spans,
+                concept_id=self.concept.wikibase_id,
+            )
+            all_labels.append(labels)
+
+        # Remove offset_mapping before creating the dataset (model doesn't need it)
+        tokenized.pop("offset_mapping")
+
+        return Dataset.from_dict({**tokenized, "labels": all_labels})
+
+    def _predict(self, text: str, threshold: float | None = None) -> list[Span]:
+        return self._predict_batch([text], threshold=threshold)[0]
+
+    def _predict_batch(
+        self, texts: Sequence[str], threshold: float | None = None
+    ) -> list[list[Span]]:
+        if self._use_dropout_during_inference:
+            with self._dropout_enabled():
+                with torch.no_grad():
+                    batch_labels, batch_probs, batch_offsets = self._forward(texts)
+        else:
+            self.model.eval()
+            with torch.no_grad():
+                batch_labels, batch_probs, batch_offsets = self._forward(texts)
+
+        effective_threshold = (
+            threshold if threshold is not None else self.prediction_threshold
+        )
+
+        labeller = str(self)
+        results = []
+        for text, token_labels, token_probs, offsets in zip(
+            texts, batch_labels, batch_probs, batch_offsets
+        ):
+            spans = _reconstruct_spans_from_predictions(
+                token_labels=token_labels,
+                token_probs=token_probs,
+                offset_mapping=offsets,
+                text=text,
+                concept_id=self.concept.wikibase_id,
+                labeller=labeller,
+            )
+
+            if effective_threshold is not None:
+                spans = [
+                    s
+                    for s in spans
+                    if s.prediction_probability is not None
+                    and s.prediction_probability >= effective_threshold
+                ]
+
+            results.append(spans)
+
+        return results
+
+    def _forward(
+        self, texts: Sequence[str]
+    ) -> tuple[list[list[int]], list[list[float]], list[list[tuple[int, int]]]]:
+        """
+        Run a batched forward pass for token classification.
+
+        :returns: Tuple of (batch_labels, batch_probs, batch_offsets) where each
+            is a list-per-text of per-token values.
+        """
+        device = self.device
+        tokenized = self.tokenizer(
+            list(texts),
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="pt",
+            return_offsets_mapping=True,
+        )
+
+        # offset_mapping is not a model input
+        offset_mapping = tokenized.pop("offset_mapping").tolist()
+
+        inputs = {k: v.to(device) for k, v in tokenized.items()}
+        logits = self.model(**inputs).logits  # [batch, seq_len, num_labels]
+
+        probs = torch.softmax(logits, dim=-1)
+        predicted_classes = torch.argmax(probs, dim=-1)  # [batch, seq_len]
+
+        # Get the probability of the predicted class for each token
+        batch_size, seq_len, _ = probs.shape
+        predicted_probs = probs[
+            torch.arange(batch_size).unsqueeze(1),
+            torch.arange(seq_len).unsqueeze(0),
+            predicted_classes,
+        ]
+
+        batch_labels = predicted_classes.tolist()
+        batch_probs = predicted_probs.tolist()
+
+        return batch_labels, batch_probs, offset_mapping
+
+    def fit(
+        self,
+        labelled_passages: list[LabelledPassage],
+        validation_size: float = 0.2,
+        enable_wandb: bool = False,
+        **kwargs,
+    ) -> "BertTokenClassifier":
+        """
+        Fine tune the base model on some labelled passages.
+
+        :param labelled_passages: Training data.
+        :param validation_size: The proportion of labelled passages to use for validation.
+        :param bool enable_wandb: Whether to enable W&B logging for training metrics and model checkpoints.
+        :return BertTokenClassifier: The trained classifier.
+        """
+        if len(labelled_passages) < 10:
+            raise ValueError(
+                f"Not enough labelled passages to train a {self.name} for "
+                f"{self.concept.wikibase_id}. At least 10 are required."
+            )
+
+        # Passage-level labels for stratified splitting
+        labels = [
+            1
+            if any(
+                (span.concept_id == self.concept.wikibase_id)
+                and (span.prediction_probability != 0)
+                for span in p.spans
+            )
+            else 0
+            for p in labelled_passages
+        ]
+
+        train_passages, val_passages, _, _ = train_test_split(
+            labelled_passages,
+            labels,
+            test_size=validation_size,
+            random_state=42,
+            stratify=labels,
+        )
+
+        logger.info("Preparing datasets...")
+        train_dataset = self._prepare_dataset(train_passages)
+        validation_dataset = self._prepare_dataset(val_passages)
+
+        # Dataset statistics
+        train_label_counts = _count_bio_labels(train_dataset["labels"])
+        val_label_counts = _count_bio_labels(validation_dataset["labels"])
+
+        stats_df = pd.DataFrame(
+            {
+                "Split": ["Training", "Validation"],
+                "Passages": [len(train_dataset), len(validation_dataset)],
+                "B tokens": [train_label_counts[B_LABEL], val_label_counts[B_LABEL]],
+                "I tokens": [train_label_counts[I_LABEL], val_label_counts[I_LABEL]],
+                "O tokens": [train_label_counts[O_LABEL], val_label_counts[O_LABEL]],
+            }
+        )
+
+        logger.info(stats_df.to_markdown(index=False, tablefmt="rounded_grid"))
+
+        # Determine which transformer layers to unfreeze (if any)
+        unfrozen_layer_indices: set[int] = set()
+        if self.unfreeze_layers > 0:
+            layer_indices = set()
+            for name, _ in self.model.named_parameters():
+                if match := re.search(r"layers?\.(\d+)\.", name):
+                    layer_indices.add(int(match.group(1)))
+            if layer_indices:
+                max_layer = max(layer_indices)
+                unfrozen_layer_indices = {
+                    i
+                    for i in layer_indices
+                    if i >= max_layer - self.unfreeze_layers + 1
+                }
+
+        if unfrozen_layer_indices:
+            logger.info(
+                "Unfreezing transformer layers %s (plus classification head).",
+                sorted(unfrozen_layer_indices),
+            )
+        else:
+            logger.info(
+                "Freezing base model. The token classification head will be trained."
+            )
+
+        for name, param in self.model.named_parameters():
+            if "classifier" in name or "head" in name:
+                param.requires_grad = True
+            elif unfrozen_layer_indices:
+                match = re.search(r"layers?\.(\d+)\.", name)
+                if match and int(match.group(1)) in unfrozen_layer_indices:
+                    param.requires_grad = True
+                else:
+                    param.requires_grad = False
+            else:
+                param.requires_grad = False
+
+        trainable_params = sum(
+            p.numel() for p in self.model.parameters() if p.requires_grad
+        )
+        total_params = sum(p.numel() for p in self.model.parameters())
+
+        logger.info("  Trainable parameters: %s", f"{trainable_params:,}")
+        logger.info("  Frozen parameters: %s", f"{total_params - trainable_params:,}")
+        logger.info(
+            "  Training %s%% of model",
+            f"{trainable_params / total_params * 100:.2f}",
+        )
+
+        # Compute token-level class weights
+        all_train_labels = [
+            label
+            for seq in train_dataset["labels"]
+            for label in seq
+            if label != IGNORE_LABEL
+        ]
+        unique_labels = sorted(set(all_train_labels))
+        class_weights = compute_class_weight(
+            class_weight="balanced",
+            classes=np.array(unique_labels),
+            y=np.array(all_train_labels),
+        )
+
+        # Build full weight tensor for all NUM_LABELS classes
+        weight_tensor = torch.ones(NUM_LABELS, dtype=torch.float32)
+        for label, weight in zip(unique_labels, class_weights):
+            weight_tensor[label] = weight
+        weight_tensor = weight_tensor.to(self.device)
+        logger.info("Class weights (O, B, I): %s", weight_tensor.cpu().numpy())
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            training_args = TrainingArguments(
+                output_dir=os.path.join(temp_dir, "results"),
+                num_train_epochs=10,
+                per_device_train_batch_size=min(32, max(8, len(train_dataset) // 10)),
+                per_device_eval_batch_size=32,
+                max_grad_norm=1.0,
+                learning_rate=2e-4,
+                weight_decay=0.01,
+                warmup_ratio=0.1,
+                lr_scheduler_type="cosine",
+                optim="adamw_torch_fused",
+                fp16=False,
+                dataloader_pin_memory=False,
+                logging_dir=os.path.join(temp_dir, "logs"),
+                logging_steps=10,
+                eval_strategy="epoch",
+                save_strategy="epoch",
+                save_total_limit=2,
+                load_best_model_at_end=True,
+                metric_for_best_model="eval_f1",
+                greater_is_better=True,
+                dataloader_num_workers=2,
+                report_to=["wandb"] if enable_wandb else [],
+                disable_tqdm=True,
+                run_name=(f"{self.concept.id}_{self.name}" if enable_wandb else None),
+                log_level="info" if enable_wandb else "warning",
+            )
+
+            trainer = WeightedTokenTrainer(
+                model=self.model,
+                args=training_args,
+                train_dataset=train_dataset,
+                eval_dataset=validation_dataset,
+                compute_metrics=_compute_token_metrics,
+                class_weights=weight_tensor,
+                callbacks=[
+                    EarlyStoppingCallback(
+                        early_stopping_patience=2, early_stopping_threshold=0
+                    )
+                ],
+            )
+
+            logger.info("Starting training...")
+            trainer.train()
+
+            if enable_wandb:
+                import wandb as _wandb
+
+                if _wandb.run is not None:
+                    _wandb.config.update(
+                        {"unfreeze_layers": self.unfreeze_layers}, allow_val_change=True
+                    )
+
+            logger.info("Evaluating on validation set...")
+            eval_results = trainer.evaluate(eval_dataset=validation_dataset)  # type: ignore[arg-type]
+
+            results_df = pd.DataFrame(
+                {
+                    "Metric": ["F1 Score", "Accuracy", "Precision", "Recall"],
+                    "Value": [
+                        eval_results.get("eval_f1", 0),
+                        eval_results.get("eval_accuracy", 0),
+                        eval_results.get("eval_precision", 0),
+                        eval_results.get("eval_recall", 0),
+                    ],
+                }
+            )
+            logger.info("Final Validation Results")
+            logger.info(
+                results_df.round(4).to_markdown(index=False, tablefmt="rounded_grid")
+            )
+
+            final_f1 = eval_results.get("eval_f1", 0)
+            logger.info("Final F1 score: %.4f", final_f1)
+
+        logger.info("Training complete for concept %s!", self.concept.id)
+
+        self.is_fitted = True
+        self._random_id_component = str(random.getrandbits(128))
+
+        return self

--- a/knowledge_graph/classifier/classifier.py
+++ b/knowledge_graph/classifier/classifier.py
@@ -277,9 +277,10 @@ class Classifier(ABC):
 
         # Avoids circular import
         from knowledge_graph.classifier.bert_based import BertBasedClassifier  # noqa: I001
+        from knowledge_graph.classifier.bert_token_classifier import BertTokenClassifier  # noqa: I001
 
-        if isinstance(classifier, BertBasedClassifier):
-            new_classifier = BertBasedClassifier(
+        if isinstance(classifier, (BertBasedClassifier, BertTokenClassifier)):
+            new_classifier = classifier.__class__(
                 concept=classifier.concept,
                 model_name=classifier.model_name,
                 download_pretrained_model_on_init=False,

--- a/scripts/benchmarks/token_vs_sequence_bert.py
+++ b/scripts/benchmarks/token_vs_sequence_bert.py
@@ -1,0 +1,199 @@
+"""
+Benchmark BERT sequence-based classifiers against:
+
+- a token-based classifier, with no layers unfrozen
+- a token-based classifier with two layers unfrozen
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+import pandas as pd
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from knowledge_graph.classifier import BertBasedClassifier, BertTokenClassifier
+from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.wandb_helpers import load_labelled_passages_from_wandb
+from scripts.evaluate import evaluate_classifier
+from scripts.get_concept import get_concept_async
+from scripts.train import deduplicate_training_data
+
+console = Console()
+app = typer.Typer()
+
+
+async def fetch_concept(wikibase_id: WikibaseID) -> Concept:
+    concept = await get_concept_async(
+        wikibase_id=wikibase_id,
+        include_recursive_has_subconcept=True,
+        include_labels_from_subconcepts=True,
+    )
+    if not concept.labelled_passages:
+        console.log(f"{wikibase_id} has no labelled passages for evaluation")
+        raise typer.Exit(1)
+    return concept
+
+
+def run_benchmark_for_concept(
+    concept: Concept,
+    training_passages: list[LabelledPassage],
+    enable_wandb: bool = False,
+) -> pd.DataFrame | None:
+    """Train and evaluate both classifiers on a single concept."""
+    console.rule(f"{concept.wikibase_id} ({concept.preferred_label})")
+
+    # Evaluation data comes from the concept's labelled passages (Argilla)
+    eval_passages = concept.labelled_passages
+
+    # Deduplicate training data against evaluation set
+    train_passages = deduplicate_training_data(
+        training_data=training_passages,
+        evaluation_data=eval_passages,
+    )
+
+    console.log(f"Train: {len(train_passages)}, Eval: {len(eval_passages)}")
+
+    if len(train_passages) < 10:
+        console.log(
+            "Not enough training passages after deduplication (need >= 10). Skipping."
+        )
+        return None
+
+    results = []
+
+    classifiers_to_run = [
+        (
+            "BertBasedClassifier (sequence)",
+            lambda: BertBasedClassifier(concept=concept),
+        ),
+        ("BertTokenClassifier (token)", lambda: BertTokenClassifier(concept=concept)),
+        (
+            "BertTokenClassifier (token, 2 layers unfrozen)",
+            lambda: BertTokenClassifier(concept=concept, unfreeze_layers=2),
+        ),
+    ]
+
+    for name, make_classifier in classifiers_to_run:
+        console.log(f"\nTraining {name}...")
+        classifier = make_classifier()
+        classifier.fit(train_passages, enable_wandb=enable_wandb)
+
+        console.log(f"Evaluating {name}...")
+        metrics_df, _, _ = evaluate_classifier(
+            classifier=classifier,
+            labelled_passages=eval_passages,
+        )
+
+        metrics_df["classifier"] = name
+        metrics_df["concept_id"] = str(concept.wikibase_id)
+        results.append(metrics_df)
+
+    if results:
+        return pd.concat(results, ignore_index=True)
+    return None
+
+
+def print_comparison_table(df: pd.DataFrame) -> None:
+    """Print a side-by-side comparison of classifier metrics."""
+    table = Table(title="Classifier Comparison", show_lines=True)
+    table.add_column("Metric")
+    table.add_column("Jaccard threshold")
+
+    classifiers = df["classifier"].unique()
+    for c in classifiers:
+        table.add_column(c, justify="right")
+
+    # Group by metric and agreement level
+    metric_cols = [
+        c for c in df.columns if c not in ("classifier", "concept_id", "group")
+    ]
+
+    for col in metric_cols:
+        if col in ("agreement",):
+            continue
+        for agreement in (
+            df["agreement"].unique() if "agreement" in df.columns else [""]
+        ):
+            row = [col, str(agreement)]
+            for c in classifiers:
+                mask = df["classifier"] == c
+                if "agreement" in df.columns and agreement:
+                    mask = mask & (df["agreement"] == agreement)
+                vals = df.loc[mask, col]
+                if not vals.empty and pd.api.types.is_numeric_dtype(vals):
+                    row.append(f"{vals.mean():.4f}")
+                else:
+                    row.append("-")
+            if any(v not in ("-", col, str(agreement)) for v in row[2:]):
+                table.add_row(*row)
+
+    console.print(table)
+
+
+@app.command()
+def main(
+    concept: Annotated[
+        str,
+        typer.Option(
+            "--concept",
+            help="Wikibase ID to evaluate (e.g., 'Q1016')",
+        ),
+    ],
+    training_data_wandb_path: Annotated[
+        str,
+        typer.Option(
+            "--training-data-wandb-path",
+            help="W&B artifact path for training data (e.g., 'climatepolicyradar/Q1016/training-data:latest')",
+        ),
+    ],
+    wandb: Annotated[
+        bool,
+        typer.Option("--wandb", help="Enable W&B logging during training"),
+    ] = False,
+):
+    """
+    Benchmark token-level vs sequence-level BERT classifiers.
+
+    Trains both classifiers on the same training data (from W&B) for a
+    concept, evaluates against the concept's labelled passages from Argilla,
+    and compares span-level and passage-level metrics.
+    """
+    console.log("Token vs Sequence BERT Classifier Benchmark")
+
+    concept_id = WikibaseID(concept)
+
+    # Load training data from W&B
+    console.log(f"Loading training data from W&B: {training_data_wandb_path}")
+    training_passages = load_labelled_passages_from_wandb(
+        wandb_path=training_data_wandb_path
+    )
+    console.log(f"Loaded {len(training_passages)} training passages from W&B")
+
+    # Fetch concept (evaluation data comes from Argilla via concept)
+    fetched_concept = asyncio.run(fetch_concept(concept_id))
+
+    # Run benchmark
+    result = run_benchmark_for_concept(
+        fetched_concept,
+        training_passages=training_passages,
+        enable_wandb=wandb,
+    )
+
+    if result is not None:
+        print_comparison_table(result)
+
+        # Save raw results
+        output_path = Path(__file__).parent / "token_vs_sequence_results.csv"
+        result.to_csv(output_path, index=False)
+        console.log(f"Results saved to {output_path}")
+    else:
+        console.log("No results to compare.")
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -176,8 +176,10 @@ def move_model_to_cpu(classifier: Classifier) -> None:
 
     console = Console()
 
-    if isinstance(classifier, BertBasedClassifier):
-        classifier.move_model_to_device(torch.device("cpu"))
+    if isinstance(classifier, BertBasedClassifier) or hasattr(
+        classifier, "move_model_to_device"
+    ):
+        classifier.move_model_to_device(torch.device("cpu"))  # type: ignore[attr-defined]
         console.log("Moved model to CPU")
 
 

--- a/tests/test_bert_token_classifier.py
+++ b/tests/test_bert_token_classifier.py
@@ -1,0 +1,338 @@
+"""Tests for BertTokenClassifier alignment and span reconstruction utilities."""
+
+import numpy as np
+import pytest
+from transformers import EvalPrediction
+
+from knowledge_graph.classifier.bert_token_classifier import (
+    B_LABEL,
+    I_LABEL,
+    IGNORE_LABEL,
+    O_LABEL,
+    _align_labels_with_tokens,
+    _compute_token_metrics,
+    _reconstruct_spans_from_predictions,
+)
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.span import Span
+
+
+@pytest.fixture
+def concept_id():
+    return WikibaseID("Q42")
+
+
+@pytest.fixture
+def sample_text():
+    return "Climate change affects biodiversity in many regions."
+
+
+def _make_span(text: str, start: int, end: int, concept_id: WikibaseID) -> Span:
+    return Span(
+        text=text,
+        start_index=start,
+        end_index=end,
+        concept_id=concept_id,
+    )
+
+
+class TestAlignLabelsWithTokens:
+    """Tests for _align_labels_with_tokens"""
+
+    def test_no_spans_all_outside(self, concept_id):
+        """All real tokens should be O when there are no gold spans."""
+        offset_mapping = [(0, 0), (0, 7), (8, 14), (0, 0)]  # CLS, 2 tokens, SEP
+        labels = _align_labels_with_tokens(offset_mapping, [], concept_id)
+        assert labels == [IGNORE_LABEL, O_LABEL, O_LABEL, IGNORE_LABEL]
+
+    def test_single_span_bio_labels(self, sample_text, concept_id):
+        """A span covering multiple tokens should produce B then I labels."""
+        span = _make_span(sample_text, 0, 14, concept_id)  # "Climate change"
+
+        # Simulated tokens: [CLS] "Climate" " change" " affects" [SEP]
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (14, 22), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span], concept_id)
+        assert labels == [IGNORE_LABEL, B_LABEL, I_LABEL, O_LABEL, IGNORE_LABEL]
+
+    def test_single_token_span(self, sample_text, concept_id):
+        """A span covering exactly one token should produce just B."""
+
+        span = _make_span(sample_text, 0, 7, concept_id)  # "Climate"
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span], concept_id)
+        assert labels == [IGNORE_LABEL, B_LABEL, O_LABEL, IGNORE_LABEL]
+
+    def test_multiple_separate_spans(self, concept_id):
+        """Two separate spans should each start with B."""
+
+        text = "Climate change affects biodiversity and ecosystems."
+        span1 = _make_span(text, 0, 14, concept_id)  # "Climate change"
+        span2 = _make_span(text, 23, 36, concept_id)  # "biodiversity"
+
+        # [CLS] "Climate" " change" " affects" " biodiversity" " and" [SEP]
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (14, 23), (23, 36), (36, 40), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span1, span2], concept_id)
+        assert labels == [
+            IGNORE_LABEL,
+            B_LABEL,
+            I_LABEL,
+            O_LABEL,
+            B_LABEL,
+            O_LABEL,
+            IGNORE_LABEL,
+        ]
+
+    def test_adjacent_spans_get_separate_b_labels(self, concept_id):
+        """Two adjacent spans should each start with B (BIO separates them)."""
+
+        text = "AB"
+        span1 = _make_span(text, 0, 1, concept_id)  # "A"
+        span2 = _make_span(text, 1, 2, concept_id)  # "B"
+        offset_mapping = [(0, 0), (0, 1), (1, 2), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span1, span2], concept_id)
+        assert labels == [IGNORE_LABEL, B_LABEL, B_LABEL, IGNORE_LABEL]
+
+    def test_partial_token_overlap(self, concept_id):
+        """A token partially overlapping a span should still be labelled."""
+
+        text = "abcdefghij"
+        span = _make_span(text, 2, 5, concept_id)  # "cde"
+        # Token covers chars 1-6, overlapping the span
+        offset_mapping = [(0, 0), (0, 2), (2, 6), (6, 10), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span], concept_id)
+        assert labels == [IGNORE_LABEL, O_LABEL, B_LABEL, O_LABEL, IGNORE_LABEL]
+
+    def test_different_concept_id_ignored(self, concept_id):
+        """Spans with a different concept_id should be ignored."""
+
+        text = "Climate change"
+        other_concept = WikibaseID("Q999")
+        span = _make_span(text, 0, 7, other_concept)
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (0, 0)]
+        labels = _align_labels_with_tokens(offset_mapping, [span], concept_id)
+        assert labels == [IGNORE_LABEL, O_LABEL, O_LABEL, IGNORE_LABEL]
+
+    def test_empty_offset_mapping(self, concept_id):
+        """Empty offset mapping should return empty labels."""
+
+        labels = _align_labels_with_tokens([], [], concept_id)
+        assert labels == []
+
+
+class TestReconstructSpans:
+    """Tests for _reconstruct_spans_from_predictions"""
+
+    def test_no_positive_predictions(self, sample_text, concept_id):
+        """All O predictions should produce no spans."""
+
+        token_labels = [O_LABEL, O_LABEL, O_LABEL]
+        token_probs = [0.95, 0.92, 0.90]
+        offset_mapping = [(0, 0), (0, 7), (7, 14)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            sample_text,
+            concept_id,
+            "test",
+        )
+        assert spans == []
+
+    def test_single_b_token_span(self, sample_text, concept_id):
+        """A single B token should create a span."""
+
+        token_labels = [O_LABEL, B_LABEL, O_LABEL]
+        token_probs = [0.95, 0.85, 0.90]
+        offset_mapping = [(0, 0), (0, 7), (7, 14)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            sample_text,
+            concept_id,
+            "test",
+        )
+        assert len(spans) == 1
+        assert spans[0].start_index == 0
+        assert spans[0].end_index == 7
+        assert spans[0].labelled_text == "Climate"
+
+    def test_b_then_i_merged(self, sample_text, concept_id):
+        """B followed by I tokens should merge into one span."""
+
+        # [CLS] "Climate" " change" " affects" [SEP]
+        token_labels = [O_LABEL, B_LABEL, I_LABEL, O_LABEL, O_LABEL]
+        token_probs = [0.9, 0.85, 0.80, 0.95, 0.9]
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (14, 22), (0, 0)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            sample_text,
+            concept_id,
+            "test",
+        )
+        assert len(spans) == 1
+        assert spans[0].start_index == 0
+        assert spans[0].end_index == 14
+        assert spans[0].labelled_text == "Climate change"
+        assert spans[0].prediction_probability == pytest.approx(0.825)
+
+    def test_two_separate_spans(self, concept_id):
+        """Two B tokens separated by O should produce two spans."""
+
+        text = "Climate change affects biodiversity significantly."
+        # [CLS] "Climate" " change" " affects" " biodiversity" " significantly" [SEP]
+        token_labels = [O_LABEL, B_LABEL, I_LABEL, O_LABEL, B_LABEL, O_LABEL, O_LABEL]
+        token_probs = [0.9, 0.85, 0.80, 0.95, 0.90, 0.88, 0.9]
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (14, 23), (23, 37), (37, 51), (0, 0)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            text,
+            concept_id,
+            "test",
+        )
+        assert len(spans) == 2
+        assert spans[0].labelled_text == "Climate change"
+        assert spans[1].start_index == 23
+
+    def test_orphaned_i_label_ignored(self, sample_text, concept_id):
+        """An I label not preceded by B should not create a span."""
+
+        token_labels = [O_LABEL, O_LABEL, I_LABEL, O_LABEL]
+        token_probs = [0.9, 0.95, 0.80, 0.90]
+        offset_mapping = [(0, 0), (0, 7), (7, 14), (14, 22)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            sample_text,
+            concept_id,
+            "test",
+        )
+        assert spans == []
+
+    def test_short_spans_filtered(self, concept_id):
+        """Spans shorter than min_span_chars should be filtered out."""
+
+        text = "A B C D"
+        token_labels = [B_LABEL, O_LABEL]
+        token_probs = [0.85, 0.90]
+        offset_mapping = [(0, 1), (1, 3)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            text,
+            concept_id,
+            "test",
+            min_span_chars=2,
+        )
+        assert spans == []
+
+    def test_span_at_end_of_sequence(self, concept_id):
+        """A span at the end of the sequence should finish at the appropriate place."""
+
+        text = "affects biodiversity"
+        token_labels = [O_LABEL, B_LABEL]
+        token_probs = [0.90, 0.85]
+        offset_mapping = [(0, 7), (8, 20)]
+        spans = _reconstruct_spans_from_predictions(
+            token_labels,
+            token_probs,
+            offset_mapping,
+            text,
+            concept_id,
+            "test",
+        )
+        assert len(spans) == 1
+        assert spans[0].start_index == 8
+        assert spans[0].end_index == 20
+
+    def test_empty_inputs(self, concept_id):
+        """Empty inputs should produce no spans."""
+
+        spans = _reconstruct_spans_from_predictions(
+            [],
+            [],
+            [],
+            "some text",
+            concept_id,
+            "test",
+        )
+        assert spans == []
+
+
+def _make_eval_prediction(
+    predictions: list[list[list[float]]], labels: list[list[int]]
+) -> EvalPrediction:
+    """Helper: build an EvalPrediction from raw logits and label IDs."""
+    return EvalPrediction(
+        predictions=np.array(predictions, dtype=np.float32),
+        label_ids=np.array(labels, dtype=np.int64),
+    )
+
+
+class TestComputeTokenMetrics:
+    """Tests for _compute_token_metrics"""
+
+    def test_perfect_predictions(self):
+        """All correct predictions should give F1=1, accuracy=1."""
+        # 1 sequence: [O, B, I] with matching gold labels
+        preds = [
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        ]
+        labels = [[O_LABEL, B_LABEL, I_LABEL]]
+        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        assert result["accuracy"] == pytest.approx(1.0)
+        assert result["f1"] == pytest.approx(1.0)
+        assert result["precision"] == pytest.approx(1.0)
+        assert result["recall"] == pytest.approx(1.0)
+
+    def test_all_wrong_predictions(self):
+        """Predicting all O when gold has B/I should give recall=0, F1=0."""
+        preds = [
+            [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        ]
+        labels = [[O_LABEL, B_LABEL, I_LABEL]]
+        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        assert result["recall"] == pytest.approx(0.0)
+        assert result["f1"] == pytest.approx(0.0)
+
+    def test_ignore_label_positions_excluded(self):
+        """IGNORE_LABEL positions (CLS/SEP/PAD) should not affect metrics."""
+        # IGNORE_LABEL at position 0 and 3 (CLS/SEP), real tokens at 1 and 2
+        preds = [
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
+        ]
+        labels = [[IGNORE_LABEL, B_LABEL, I_LABEL, IGNORE_LABEL]]
+        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        # Only positions 1 and 2 count: both predicted correctly
+        assert result["accuracy"] == pytest.approx(1.0)
+        assert result["f1"] == pytest.approx(1.0)
+
+    def test_token_level_not_span_level(self):
+        """A 3-token entity contributes 3 TPs, not 1 (token-level semantics)."""
+        # Gold: B I I (one 3-token entity). Predict: B I I (perfect).
+        preds = [
+            [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
+        ]
+        labels = [[B_LABEL, I_LABEL, I_LABEL]]
+        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        # 3 TP, 0 FP, 0 FN → precision=1, recall=1, f1=1
+        assert result["precision"] == pytest.approx(1.0)
+        assert result["recall"] == pytest.approx(1.0)
+
+    def test_partial_overlap(self):
+        """Predicting only part of an entity: precision=1, recall=0.5."""
+        # Gold: B I. Predict: B O (miss the I token).
+        preds = [
+            [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]],
+        ]
+        labels = [[B_LABEL, I_LABEL]]
+        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        assert result["precision"] == pytest.approx(1.0)
+        assert result["recall"] == pytest.approx(0.5)
+        assert result["f1"] == pytest.approx(2 / 3)


### PR DESCRIPTION
[BIO](https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging))-based BERT classifier + benchmark script

Tested on _Q1829 finance flow_, this scored a passage-level F1 score on par with the [best passage-based BERT model for the concept](https://wandb.ai/climatepolicyradar/Q1829/runs/cgscfdfs?nw=nwuserkdutia). Some layers had to be unfrozen for it to perform as well as it did.

It's natural that it'd perform worse than the passage-level classifier at span level as the passage-level classifier labels _everything_, but I'm not sure why it performs so badly. Either way, I think it's worth merging so we can do a fully-W&B-instrumented training run to compare some predictions. 


``` text
    Group   Agreement at        Precision   Recall   Accuracy   F1 score   Support                                                                                                                  
────────────────────────────────────────────────────────────────────────────────                                                                                                                 
    all     Passage level       0.78        0.87     0.83       0.82       644                                                                                                                      
    all     Span level (0)      0.60        0.76     0.67       0.67       827                                                                                                                      
    all     Span level (0.5)    0.38        0.48     0.51       0.42       855                                                                                                                      
    all     Span level (0.9)    0.23        0.27     0.42       0.25       862                                                                                                                      
    all     Span level (0.99)   0.09        0.11     0.36       0.10       881                                                                                                                      


# comparable results for passage level classifier

all   Passage level       0.75        0.91     0.82       0.82       644
all   Span level (0.5)    0.41        0.49     0.54       0.45       762

```