### PR TITLE
attempt to fix modernbert training on prefect

### DIFF
--- a/knowledge_graph/classifier/__init__.py
+++ b/knowledge_graph/classifier/__init__.py
@@ -67,7 +67,7 @@ def __getattr__(name):
         module = importlib.import_module(".autollm", __package__)
         return getattr(module, name)
     else:
-        return globals()[name]
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [


### PR DESCRIPTION
relevant part of [traceback](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069d5299-26bd-7969-8000-8058c732b3a3?preview=true&tab=logs&selected_id=069d5299-26bd-7969-8000-8058c732b3a3&selected_kind=flow-run):

``` text
  File "/app/knowledge_graph/classifier/__init__.py", line 70, in __getattr__
    return globals()[name]
           ~~~~~~~~~^^^^^^
torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
KeyError: 'torch'
```

This _seems_ to be because the pickle serializer is trying to find `torch`, but it's not in the module's global scope. Raising `AttributeError` is handled smoothly by the pickle serializer, according to Claude. And `return globals()[name]` is never useful as `_getattr_` is only called when a module isn't in the global scope

towards SCI-619