### PR TITLE
fix: move retry handling to lowest levels & increase timeouts

### DIFF
--- a/.github/workflows/prefect_deploy.yml
+++ b/.github/workflows/prefect_deploy.yml
@@ -39,9 +39,9 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         with:
-          just-version: 1.36.0
+          just-version: 1.46.0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -17,7 +17,6 @@ from prefect.cache_policies import NONE
 from prefect.context import FlowRunContext, get_run_context
 from prefect_slack.credentials import AsyncWebClient
 from pydantic import AnyHttpUrl, SecretStr, ValidationError
-from tenacity import RetryError
 from vespa.application import VespaAsync
 from vespa.io import VespaResponse
 
@@ -288,19 +287,7 @@ async def load_concepts(
         logger.info(f"loaded {len(concepts)} concepts from cache")
     else:
         logger.info("getting concepts from Wikibase")
-
-        try:
-            concepts = await wikibase.get_concepts_async(limit=None)
-        except RetryError as e:
-            # RetryError contains unpicklable objects (Future, Lock).
-            # Prefect's JSON serialiser does work with it, but I
-            # decided to handle it here, this way.
-            #
-            # Extract the underlying exception and re-raise with a
-            # clean message.
-            underlying_error = e.last_attempt.exception() if e.last_attempt else None
-            error_msg = f"Failed to fetch concepts from Wikibase after retries: {underlying_error}"
-            raise RuntimeError(error_msg) from underlying_error
+        concepts = await wikibase.get_concepts_async(limit=None)
 
         logger.info(f"got {len(concepts)} concepts")
 

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -18,6 +18,7 @@ from pydantic import (
     ValidationError,
 )
 from tenacity import (
+    AsyncRetrying,
     before_sleep_log,
     retry,
     retry_if_exception_type,
@@ -210,11 +211,6 @@ class WikibaseSession:
             )
         return self._redirects.get(wikibase_id, wikibase_id)
 
-    @retry(
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_exponential_jitter(initial=RETRY_INITIAL_WAIT, max=RETRY_MAX_WAIT),
-        retry=retry_if_exception_type((HTTPStatusError, ReadTimeout)),
-    )
     async def _get_all_redirects(
         self, batch_size: Optional[int] = None
     ) -> dict[WikibaseID, WikibaseID]:
@@ -231,17 +227,33 @@ class WikibaseSession:
             ids_to_fetch = [
                 page["title"].removeprefix(self.ITEM_PREFIX) for page in batch
             ]
+            response: httpx.Response | None = None
 
-            response = await client.get(
-                url=self.api_url,
-                params={
-                    "action": "wbgetentities",
-                    "format": "json",
-                    "ids": "|".join(ids_to_fetch),
-                    "props": "info",
-                },
-                timeout=self.DEFAULT_TIMEOUT,
-            )
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(MAX_RETRIES),
+                wait=wait_exponential_jitter(
+                    initial=RETRY_INITIAL_WAIT, max=RETRY_MAX_WAIT
+                ),
+                retry=retry_if_exception_type((HTTPStatusError, ReadTimeout)),
+                before_sleep=before_sleep_log(get_logger(), logging.WARNING),  # type: ignore[arg-type]
+                reraise=True,
+            ):
+                with attempt:
+                    response = await client.get(
+                        url=self.api_url,
+                        params={
+                            "action": "wbgetentities",
+                            "format": "json",
+                            "ids": "|".join(ids_to_fetch),
+                            "props": "info",
+                        },
+                        timeout=self.DEFAULT_TIMEOUT,
+                    )
+
+            if response is None:
+                raise RuntimeError(
+                    "Redirect batch request completed without a response"
+                )
             response.raise_for_status()
             data = response.json()
 
@@ -535,6 +547,7 @@ class WikibaseSession:
             (HTTPStatusError, RequestError, json.JSONDecodeError)
         ),
         before_sleep=before_sleep_log(get_logger(), logging.WARNING),  # type: ignore[arg-type]
+        reraise=True,
     )
     async def get_concepts_async(
         self,

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -66,6 +66,7 @@ class WikibaseSession:
 
     # Magic numbers
     DEFAULT_TIMEOUT = 30
+    REDIRECT_REQUEST_TIMEOUT = 90
     DEFAULT_BATCH_SIZE = 50
     PAGE_REQUEST_SIZE = 500
     MAX_PAGE_REQUESTS = 2000  # Suitable up to 1M pages (500*2000)
@@ -247,7 +248,7 @@ class WikibaseSession:
                             "ids": "|".join(ids_to_fetch),
                             "props": "info",
                         },
-                        timeout=self.DEFAULT_TIMEOUT,
+                        timeout=self.REDIRECT_REQUEST_TIMEOUT,
                     )
 
             if response is None:


### PR DESCRIPTION
This seems to be flakey in production suggesting its a heavier path, trying a more generous timeout

Additionally, three levels of abstraction in the trace, each level has retry logic. This simplifies by just putting it on the low level calls, this should improve the resilience because we are retrying per call rather than across a batch of calls, it also means we should have better interpretability, in that we had a lot of code trying to unwrap the error previously but can now just reraise instead.