### PR TITLE
disable torch.compile when training modernBERT models

### DIFF
--- a/knowledge_graph/classifier/bert_based.py
+++ b/knowledge_graph/classifier/bert_based.py
@@ -164,8 +164,11 @@ class BertBasedClassifier(
         Uses the class's `model_name` property.
         """
 
-        self.model: PreTrainedModel = (
-            AutoModelForSequenceClassification.from_pretrained(self.model_name)
+        self.model: PreTrainedModel = AutoModelForSequenceClassification.from_pretrained(
+            self.model_name,
+            # `reference_compile=False` disables ModernBERT's torch.compile path, which
+            # would otherwise require a C compiler at runtime (absent from our slim image)
+            reference_compile=False,
         )
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
             self.model_name


### PR DESCRIPTION
Attempt number 2 to fix training on prefect. [A run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069e10bc-b0df-7838-8000-3e541bfd9e80?g_range={%22type%22:%22span%22,%22seconds%22:-2592000}&preview=true&tab=logs) after the previous fix (#1112) throws a `RuntimeError: Failed to find C compiler`.

Relevant part of transcript from Claude below. And [here's a link to the relevant part of the modernBERT code](https://github.com/huggingface/transformers/blob/8cb5963cc22174954e7dca2c0a3320b7dc2f4edc/src/transformers/models/modernbert/configuration_modernbert.py#L107-L111).

> ⏺ Here's the relevant reference, pinned to the transformers==4.57.1 version in pyproject.toml.
> 
>   Official docstring
> 
>   From configuration_modernbert.py L107-111 (v4.57.1):
> 
>   ▎ reference_compile (bool, optional): Whether to compile the layers of the model which were compiled during pretraining. If None, then
>   ▎ parts of the model will be compiled if 1) triton is installed, 2) the model is not on MPS, 3) the model is not shared between devices,
>   ▎ and 4) the model is not resized after initialization. If True, then the model may be faster in some scenarios.
> 
>   Default in the config constructor is reference_compile=None (L170).
> 
>   What it actually controls
> 
>   From modeling_modernbert.py (v4.57.1) — the line numbers below match your traceback:
> 
>   - L207-L209: embeddings wrapped in @torch.compile(dynamic=True) as compiled_embeddings.
>   - L217-L220: forward picks compiled_embeddings(...) if config.reference_compile, else the plain path. This is the exact line (218) in your
>    crash.
>   - L552-L555: each block's MLP also runs through compiled_mlp under the same flag.
>   - L1077: MLM head uses compiled_head under the same flag.
> 
>   Auto-disable logic (_maybe_set_compile, L647-L676)
> 
>   It sets reference_compile=False automatically when:
>   - Model is split across devices (hf_device_map > 1)
>   - Device is mps
>   - Device is cpu
> 
>   Then, if still None, it resolves to is_triton_available() (L675-L676). Triton is installed in your runtime image (it's a torch dependency
>   on CUDA), so the default silently becomes True on your coiled GPU worker → Inductor → Triton JIT → cc lookup fails.
> 
>   How to apply it
> 
>   Pass it through from_pretrained — it gets forwarded to the config:
> 
>   AutoModelForSequenceClassification.from_pretrained(
>       self.model_name,
>       reference_compile=False,
>   )
> 
>   Relevant HF doc on overriding config kwargs via from_pretrained: PretrainedConfig.from_pretrained — kwargs — "The values in kwargs of any
>   keys which are configuration attributes will be used to override the loaded values."