### PR TITLE
Revert "Update classifier specs (automated)"

### DIFF
--- a/flows/classifier_specs/v2/production.yaml
+++ b/flows/classifier_specs/v2/production.yaml
@@ -469,9 +469,9 @@
   wandb_registry_version: v3
 - wikibase_id: Q1829
   concept_id: d2sckcja
-  classifier_id: 7n27za9e
+  classifier_id: fuqmphf9
   classifiers_profile: primary
-  wandb_registry_version: v1
+  wandb_registry_version: v0
   compute_environment:
     gpu: true
 - wikibase_id: Q1830


### PR DESCRIPTION
This reverts commit 1234ed0e464c58a00ca607ca3b79bc472e945636.

The model failed in inference, reverting to unblock other work:
```
Executing flow 'inference-batch-of-documents-gpu' for flow run 'pristine-loon'...
Loading classifier Q1829:7n27za9e:v1
Encountered exception during execution: RuntimeError('torch.UntypedStorage(): Storage device not recognized: mps')
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.13/site-packages/torch/storage.py", line 268, in mps
    return torch.UntypedStorage(self.size(), device="mps").copy_(self, False)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: torch.UntypedStorage(): Storage device not recognized: mps
pristine-loon transitioned from Running → Failed
Finished in state Failed('Flow run encountered an exception: RuntimeError: torch.UntypedStorage(): Storage device not recognized: mps')
```