### PR TITLE
fix logging when running model building scripts on prefect

### DIFF
--- a/knowledge_graph/utils.py
+++ b/knowledge_graph/utils.py
@@ -31,14 +31,7 @@ def get_logger() -> logging.Logger | LoggingAdapter:
     try:
         return prefect.logging.get_run_logger()
     except prefect.exceptions.MissingContextError:
-        logger = prefect.logging.get_logger()
-        if not logger.handlers:
-            handler = logging.StreamHandler()
-            handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-            logger.addHandler(handler)
-            logger.setLevel(logging.INFO)
-            logger.propagate = False
-        return logger
+        return logging.getLogger("knowledge_graph")
 
 
 T = TypeVar("T")

--- a/knowledge_graph/utils.py
+++ b/knowledge_graph/utils.py
@@ -31,7 +31,14 @@ def get_logger() -> logging.Logger | LoggingAdapter:
     try:
         return prefect.logging.get_run_logger()
     except prefect.exceptions.MissingContextError:
-        return prefect.logging.get_logger()
+        logger = prefect.logging.get_logger()
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+            logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+            logger.propagate = False
+        return logger
 
 
 T = TypeVar("T")

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional
 import typer
 import wandb
 from dotenv import load_dotenv
-from rich.console import Console
 
 from knowledge_graph.cloud import AwsEnv, get_s3_client
 from knowledge_graph.config import WANDB_ENTITY, predictions_dir
@@ -15,6 +14,7 @@ from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.labelling import label_passages_with_classifier
 from knowledge_graph.utils import (
     deserialise_pydantic_list_with_fallback,
+    get_logger,
     serialise_pydantic_list_as_jsonl,
 )
 from knowledge_graph.wandb_helpers import (
@@ -23,8 +23,6 @@ from knowledge_graph.wandb_helpers import (
     load_labelled_passages_from_wandb,
     log_labelled_passages_artifact_to_wandb_run,
 )
-
-console = Console()
 
 app = typer.Typer()
 
@@ -129,6 +127,8 @@ def main(
     if `track_and_upload` is set.
     """
 
+    logger = get_logger()
+
     wandb_config = {
         "batch_size": batch_size,
         "limit": limit,
@@ -178,7 +178,7 @@ def main(
 
         already_predicted_passages: list[LabelledPassage] = []
         if restart_from_wandb_run:
-            console.print(
+            logger.info(
                 f"Loading already-predicted passages from {restart_from_wandb_run} to skip..."
             )
             try:
@@ -186,8 +186,8 @@ def main(
                 already_predicted_passages = load_labelled_passages_from_wandb(
                     run=restart_run
                 )
-                console.print(
-                    f"[green]✓ Loaded {len(already_predicted_passages)} already-predicted passages[/green]"
+                logger.info(
+                    f"✓ Loaded {len(already_predicted_passages)} already-predicted passages"
                 )
 
                 # Filter out already-predicted passages based on ID
@@ -197,31 +197,29 @@ def main(
                     p for p in labelled_passages if p.id not in already_predicted_ids
                 ]
                 num_skipped = len_before - len(labelled_passages)
-                console.print(
+                logger.info(
                     f"Skipped {num_skipped} already-predicted passages. {len(labelled_passages)} remaining to predict."
                 )
             except Exception as e:
-                console.print(
-                    f"[red]⚠ Could not load already-predicted passages: {e}[/red]"
-                )
-                console.print("Continuing without skipping any passages")
+                logger.warning(f"⚠ Could not load already-predicted passages: {e}")
+                logger.info("Continuing without skipping any passages")
 
         if deduplicate_inputs:
             original_count = len(labelled_passages)
             labelled_passages = deduplicate_labelled_passages(labelled_passages)
             deduplicated_count = len(labelled_passages)
-            console.print(
+            logger.info(
                 f"Deduplicated {original_count} passages to {deduplicated_count} based on their text field"
                 f"(removed {original_count - deduplicated_count} duplicates)"
             )
 
         if limit:
             labelled_passages = labelled_passages[:limit]
-            console.print(f"Limited number of passages to {len(labelled_passages)}")
+            logger.info(f"Limited number of passages to {len(labelled_passages)}")
 
         # 2. optionally exclude training data
         if exclude_training_data:
-            console.print(
+            logger.info(
                 "Fetching training data from classifier's W&B run to exclude from prediction..."
             )
             try:
@@ -238,7 +236,7 @@ def main(
                             artifact_dir
                         )
 
-                        console.print(
+                        logger.info(
                             f"✓ Loaded {len(training_data)} passages from training data artifact"
                         )
 
@@ -255,16 +253,16 @@ def main(
                         num_labelled_passages_removed = (
                             len_labelled_passages_before - len(labelled_passages)
                         )
-                        console.print(
+                        logger.info(
                             f"Removed {num_labelled_passages_removed} passages from labelled passages dataset. {len(labelled_passages)} remaining."
                         )
 
                     else:
-                        console.print(
+                        logger.warning(
                             "⚠ No training-data artifact found in classifier's run, skipping exclusion"
                         )
             except Exception as e:
-                console.print(
+                logger.warning(
                     f"⚠ Could not load training data: {e}\nContinuing with prediction without excluding training data"
                 )
 
@@ -280,7 +278,7 @@ def main(
 
         if prediction_threshold is not None:
             classifier.set_prediction_threshold(prediction_threshold)
-            console.print(
+            logger.info(
                 f"Classifier prediction threshold set to {prediction_threshold}"
             )
 
@@ -294,12 +292,12 @@ def main(
             passages_processed = 0
 
             if stop_after_n_positives is not None:
-                console.print(
-                    f"[cyan]Early stopping enabled: will stop after finding {stop_after_n_positives} positive passages[/cyan]"
+                logger.info(
+                    f"Early stopping enabled: will stop after finding {stop_after_n_positives} positive passages"
                 )
 
-            console.print(
-                "[cyan]You can end prediction early by pressing Ctrl+C. This will save passages predicted thus far.[/cyan]"
+            logger.info(
+                "You can end prediction early by pressing Ctrl+C. This will save passages predicted thus far."
             )
 
             for i in range(0, len(labelled_passages), batch_size):
@@ -320,28 +318,26 @@ def main(
                     batch_positives = sum(1 for p in batch_output if len(p.spans) > 0)
                     positives_found += batch_positives
 
-                    console.print(
-                        f"[cyan]Processed {passages_processed}/{len(labelled_passages)} passages, "
-                        f"found {positives_found} positives ({batch_positives} in batch)[/cyan]"
+                    logger.info(
+                        f"Processed {passages_processed}/{len(labelled_passages)} passages, "
+                        f"found {positives_found} positives ({batch_positives} in batch)"
                     )
 
                     if positives_found >= stop_after_n_positives:
-                        console.print(
-                            f"[green]✓ Reached target of {stop_after_n_positives} positives. "
-                            f"Stopping early (skipped {len(labelled_passages) - passages_processed} passages)[/green]"
+                        logger.info(
+                            f"✓ Reached target of {stop_after_n_positives} positives. "
+                            f"Stopping early (skipped {len(labelled_passages) - passages_processed} passages)"
                         )
                         break
                 else:
-                    console.print(
-                        f"[cyan]Processed {passages_processed}/{len(labelled_passages)} passages[/cyan]"
+                    logger.info(
+                        f"Processed {passages_processed}/{len(labelled_passages)} passages"
                     )
 
         except Exception as e:
             prediction_exception = e
-            console.print(
-                f"[red]⚠ Prediction failed: {e}[/red]\n"
-                f"[yellow]Saving {len(output_labelled_passages)} partial results...[/yellow]"
-            )
+            logger.error(f"⚠ Prediction failed: {e}")
+            logger.info(f"Saving {len(output_labelled_passages)} partial results...")
 
         finally:
             if output_labelled_passages or already_predicted_passages:
@@ -359,17 +355,15 @@ def main(
 
                 labelled_passages_path.parent.mkdir(parents=True, exist_ok=True)
                 labelled_passages_path.write_text(labelled_passages_jsonl)
-                console.print(
-                    f"[green]✓ Saved {len(all_passages)} passages to {labelled_passages_path}[/green]"
+                logger.info(
+                    f"✓ Saved {len(all_passages)} passages to {labelled_passages_path}"
                 )
 
                 if track_and_upload and run:
                     log_labelled_passages_artifact_to_wandb_run(
                         all_passages, run=run, concept=classifier.concept
                     )
-                    console.print(
-                        f"[green]✓ Uploaded passages to W&B run {run.name}[/green]"
-                    )
+                    logger.info(f"✓ Uploaded passages to W&B run {run.name}")
 
         # Re-raise the exception after saving
         if prediction_exception:

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -6,7 +6,6 @@ import click
 import pandas as pd
 import typer
 import wandb
-from rich.console import Console
 
 from knowledge_graph.classifier import EmbeddingClassifier, KeywordClassifier
 from knowledge_graph.classifier.classifier import Classifier
@@ -14,13 +13,12 @@ from knowledge_graph.config import WANDB_ENTITY, equity_columns, processed_data_
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.sampling import create_balanced_sample, split_evenly
-from knowledge_graph.utils import serialise_pydantic_list_as_jsonl
+from knowledge_graph.utils import get_logger, serialise_pydantic_list_as_jsonl
 from knowledge_graph.wandb_helpers import log_labelled_passages_artifact_to_wandb_run
 from knowledge_graph.wikibase import WikibaseSession
 from scripts.train import parse_kwargs_from_strings
 
 app = typer.Typer()
-console = Console()
 
 CORPUS_TYPES = [
     "Litigation",
@@ -106,6 +104,8 @@ def main(
     :param concept_override: List of concept property overrides in key=value format (e.g., description, labels)
     :type concept_override: Optional[list[str]]
     """
+    logger = get_logger()
+
     # Calculate the optimal number of positive and negative samples to take
     negative_sample_size = math.floor(sample_size * min_negative_proportion)
     positive_sample_size = sample_size - negative_sample_size
@@ -122,7 +122,7 @@ def main(
 
         try:
             dataset = pd.read_feather(dataset_path)
-            console.log(f"Loaded {len(dataset)} passages from {dataset_path}")
+            logger.info(f"Loaded {len(dataset)} passages from {dataset_path}")
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 f"{dataset_path} not found. If you haven't already, you should run:\n"
@@ -135,7 +135,7 @@ def main(
         dataset = cast(
             pd.DataFrame, dataset[dataset[corpus_type_col].isin(corpus_types_include)]
         )
-        console.log(
+        logger.info(
             f"Filtered to corpus types {corpus_types_include}: "
             f"{len(dataset)} passages remain"
         )
@@ -144,14 +144,14 @@ def main(
         dataset = cast(
             pd.DataFrame, dataset[~dataset[corpus_type_col].isin(corpus_types_exclude)]
         )
-        console.log(
+        logger.info(
             f"Excluded corpus types {corpus_types_exclude}: "
             f"{len(dataset)} passages remain"
         )
 
     # Limit dataset size if needed
     if len(dataset) > max_size_to_sample_from:
-        console.log(
+        logger.info(
             f"Limiting input data from {len(dataset)} rows to {max_size_to_sample_from}"
         )
         dataset = cast(pd.DataFrame, dataset.iloc[:max_size_to_sample_from])
@@ -161,15 +161,13 @@ def main(
     concept = wikibase.get_concept(wikibase_id, include_labels_from_subconcepts=True)
 
     if concept_overrides := parse_kwargs_from_strings(concept_override):
-        console.log(f"🔧 Applying custom concept properties: {concept_overrides}")
+        logger.info(f"🔧 Applying custom concept properties: {concept_overrides}")
         for key, value in concept_overrides.items():
             if hasattr(concept, key):
                 setattr(concept, key, value)
-                console.log(f"  ✓ Set concept.{key} = {value}")
+                logger.info(f"  ✓ Set concept.{key} = {value}")
             else:
-                console.log(
-                    f"  ⚠️  Warning: concept has no attribute '{key}'", style="yellow"
-                )
+                logger.warning(f"  ⚠️  Warning: concept has no attribute '{key}'")
 
     job_type = "sample"
     wandb_config = {
@@ -202,9 +200,9 @@ def main(
 
         for model in models:
             model.fit()
-            console.log(f"🤖 Created a {model}")
+            logger.info(f"🤖 Created a {model}")
             classifier_ids.append(model.id)
-            console.log(f"Running {model} on {len(raw_text_passages)} passages.")
+            logger.info(f"Running {model} on {len(raw_text_passages)} passages.")
 
             predictions = model.predict(
                 raw_text_passages, batch_size=100, show_progress=True
@@ -212,7 +210,7 @@ def main(
 
             # Add a column to the dataset for each classifier's predictions
             dataset[model.name] = predictions
-            console.log(
+            logger.info(
                 f"📊 Found {sum(bool(pred) for pred in predictions)} positive passages "
                 f"using the {model}"
             )
@@ -268,7 +266,7 @@ def main(
         if len(negative_samples) > negative_sample_size:
             negative_samples = negative_samples.sample(negative_sample_size)
 
-        console.log(
+        logger.info(
             f"📊 Sampled {len(positive_samples)} positive passages, "
             f"{len(negative_samples)} negative passages"
         )
@@ -282,16 +280,16 @@ def main(
         sampled_passages = sampled_passages.sample(frac=1)
 
         # Log the distribution of samples for the user
-        console.log("📊 Distribution of samples by classifier:")
+        logger.info("📊 Distribution of samples by classifier:")
         for model in models:
             positive_samples = sampled_passages[
                 sampled_passages[model.name].astype(bool)
             ]
-            console.log(f"{model.name}: {len(positive_samples)}")
+            logger.info(f"{model.name}: {len(positive_samples)}")
 
-        console.log("\n📊 Value counts for the sampled dataset:")
+        logger.info("\n📊 Value counts for the sampled dataset:")
         for column in equity_columns:
-            console.log(sampled_passages[column].value_counts(), end="\n\n")
+            logger.info(str(sampled_passages[column].value_counts()))
 
         # Convert sampled passage rows to LabelledPassage objects and save them
         labelled_passages = []
@@ -317,16 +315,16 @@ def main(
         with open(sampled_passages_path, "w", encoding="utf-8") as f:
             f.write(serialise_pydantic_list_as_jsonl(labelled_passages))
 
-        console.log(f"Saved sampled passages to {sampled_passages_path}")
+        logger.info(f"Saved sampled passages to {sampled_passages_path}")
 
         if track_and_upload and run:
-            console.log("📄 Creating labelled passages artifact")
+            logger.info("📄 Creating labelled passages artifact")
             log_labelled_passages_artifact_to_wandb_run(
                 labelled_passages=labelled_passages,
                 run=run,
                 concept=concept,
             )
-            console.log("✅ Labelled passages uploaded successfully")
+            logger.info("✅ Labelled passages uploaded successfully")
 
 
 if __name__ == "__main__":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -12,7 +12,6 @@ import wandb
 from prefect.client.schemas.objects import FlowRun
 from prefect.deployments import run_deployment
 from pydantic import BaseModel, Field
-from rich.console import Console
 from wandb.errors.errors import CommError
 from wandb.sdk.wandb_run import Run
 
@@ -38,6 +37,7 @@ from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.labelling import ArgillaConfig
 from knowledge_graph.openrouter_pricing import get_openrouter_pricing
+from knowledge_graph.utils import get_logger
 from knowledge_graph.version import Version
 from knowledge_graph.wandb_helpers import (
     load_labelled_passages_from_wandb,
@@ -92,16 +92,16 @@ def deduplicate_training_data(
     evaluation_data: list[LabelledPassage],
 ) -> list[LabelledPassage]:
     """Remove passages from training data that appear in evaluation data."""
-    console = Console()
+    logger = get_logger()
 
     eval_texts = {passage.text for passage in evaluation_data}
 
-    console.log(f"📊 Starting with {len(training_data)} passages for training")
+    logger.info(f"📊 Starting with {len(training_data)} passages for training")
 
     filtered = [p for p in training_data if p.text not in eval_texts]
 
     removed_count = len(training_data) - len(filtered)
-    console.log(
+    logger.info(
         f"🔍 Removed {removed_count} duplicate passages, training with {len(filtered)} passages"
     )
 
@@ -125,12 +125,12 @@ def limit_training_samples(
     :return: A (mostly) balanced subset of the training data.
     :rtype: list[LabelledPassage]
     """
-    console = Console()
+    logger = get_logger()
 
     positive_passages = [p for p in training_data if p.spans]
     negative_passages = [p for p in training_data if not p.spans]
 
-    console.log(
+    logger.info(
         f"📊 Starting with {len(positive_passages)} positive and "
         f"{len(negative_passages)} negative passages"
     )
@@ -154,7 +154,7 @@ def limit_training_samples(
     limited_positive = positive_passages[:pos_count]
     limited_negative = negative_passages[:neg_count]
 
-    console.log(
+    logger.info(
         f"✂️  Limited to {len(limited_positive)} positive and "
         f"{len(limited_negative)} negative passages "
         f"({len(limited_positive) + len(limited_negative)} total)"
@@ -174,11 +174,9 @@ def move_model_to_cpu(classifier: Classifier) -> None:
     able to load a classifier stored on CUDA and vice-versa.
     """
 
-    console = Console()
-
     if isinstance(classifier, BertBasedClassifier):
         classifier.move_model_to_device(torch.device("cpu"))
-        console.log("Moved model to CPU")
+        get_logger().info("Moved model to CPU")
 
 
 class StorageUpload(BaseModel):
@@ -240,7 +238,7 @@ def create_and_link_model_artifact(
         "concept_wikibase_revision": classifier.concept.wikibase_revision,
     }
     if isinstance(classifier, GPUBoundClassifier):
-        Console().log("Adding GPU requirement to metadata")
+        get_logger().info("Adding GPU requirement to metadata")
         compute_environment: ComputeEnvironment = {"gpu": True}
         metadata["compute_environment"] = compute_environment
 
@@ -315,7 +313,7 @@ def get_next_version(
         wikibase_id = classifier.concept.wikibase_id
         pattern = rf"artifact membership '.*?' not found in '{namespace.entity}/{wikibase_id}'"
         if re.search(pattern, error_message):
-            Console().log(
+            get_logger().info(
                 f"No previous wandb version found, '{target_path}' will be at v0"
             )
             next_version = Version("v0")
@@ -353,7 +351,7 @@ def upload_model_artifact(
         wandb_model_artifact_filename,
     )
 
-    Console().log(f"Uploading {classifier.name} to {key} in bucket {bucket}")
+    get_logger().info(f"Uploading {classifier.name} to {key} in bucket {bucket}")
 
     s3_client.upload_file(
         classifier_path,
@@ -363,7 +361,7 @@ def upload_model_artifact(
         Callback=lambda bytes_transferred: None,
     )
 
-    Console().log(f"Uploaded {classifier.name} to {key} in bucket {bucket}")
+    get_logger().info(f"Uploaded {classifier.name} to {key} in bucket {bucket}")
 
     return bucket, key
 
@@ -486,8 +484,8 @@ def main(
             },
             timeout=0,  # Don't wait for the flow to finish before continuing
         )
-        Console().print(
-            f"Deployment started. [blue][link={get_flow_run_ui_url(flow_run)}]Click here to open flow run on Prefect.[/link][/blue]"
+        get_logger().info(
+            f"Deployment started. Flow run URL: {get_flow_run_ui_url(flow_run)}"
         )
 
         return None  # Can't return the classifier when running remotely
@@ -520,8 +518,7 @@ async def train_classifier(
     force: bool = True,
 ) -> "Classifier":
     """Train a classifier and optionally track the run, uploading the model."""
-    # Create console locally to avoid serialization issues
-    console = Console()
+    logger = get_logger()
 
     project = wikibase_id
     namespace = Namespace(project=project, entity=WANDB_ENTITY)
@@ -538,7 +535,7 @@ async def train_classifier(
         if classifier_exists_in_wandb(namespace=namespace, target_path=target_path):
             # If the classifier already exists, just log and return the classifier without
             # running the redundant training/uploading process
-            console.log(
+            logger.info(
                 f"Classifier {classifier.id} already exists in W&B. Skipping training."
             )
             return classifier
@@ -592,12 +589,12 @@ async def train_classifier(
                 [p for p in deduplicated_training_data if p.spans]
             )
             train_num_negatives = len(deduplicated_training_data) - train_num_positives
-            Console().print(
+            logger.info(
                 f"Training data has length {len(deduplicated_training_data)} with {train_num_positives} positive and {train_num_negatives} negative examples after deduplication."
             )
 
             if track_and_upload and run and deduplicated_training_data:
-                console.log("📄 Creating artifact for deduplicated training data")
+                logger.info("📄 Creating artifact for deduplicated training data")
                 log_labelled_passages_artifact_to_wandb_run(
                     labelled_passages=deduplicated_training_data,
                     run=run,
@@ -605,7 +602,7 @@ async def train_classifier(
                     classifier=classifier,
                     artifact_name="training-data",
                 )
-                console.log("✅ Training data artifact uploaded successfully")
+                logger.info("✅ Training data artifact uploaded successfully")
         else:
             deduplicated_training_data = []
 
@@ -643,7 +640,7 @@ async def train_classifier(
             classifier=classifier,
         )
 
-        console.log(f"Using next version {next_version}")
+        logger.info(f"Using next version {next_version}")
 
         # Set this _before_ the model is saved to disk
         classifier.version = Version(next_version)
@@ -655,7 +652,7 @@ async def train_classifier(
         )
         classifier_path.parent.mkdir(parents=True, exist_ok=True)
         classifier.save(classifier_path)
-        console.log(f"Saved {classifier} to {classifier_path}")
+        logger.info(f"Saved {classifier} to {classifier_path}")
 
         if track_and_upload:
             region_name = "eu-west-1"
@@ -699,14 +696,14 @@ async def train_classifier(
             )
 
             if track_and_upload and run:
-                console.log("📄 Creating labelled passages artifact")
+                logger.info("📄 Creating labelled passages artifact")
                 log_labelled_passages_artifact_to_wandb_run(
                     labelled_passages=model_labelled_passages,
                     run=run,
                     concept=classifier.concept,
                     classifier=classifier,
                 )
-                console.log("✅ Labelled passages uploaded successfully")
+                logger.info("✅ Labelled passages uploaded successfully")
 
     return classifier
 
@@ -731,7 +728,7 @@ async def run_training(
 
     Optionally evaluate, track in W&B and upload the model to S3.
     """
-    console = Console()
+    logger = get_logger()
 
     # Validate parameter dependencies
     validate_params(track_and_upload=track_and_upload, aws_env=aws_env)
@@ -745,26 +742,24 @@ async def run_training(
     )
 
     if concept_overrides:
-        console.log(f"🔧 Applying custom concept properties: {concept_overrides}")
+        logger.info(f"🔧 Applying custom concept properties: {concept_overrides}")
         for key, value in concept_overrides.items():
             if hasattr(concept, key):
                 setattr(concept, key, value)
-                console.log(f"  ✓ Set concept.{key} = {value}")
+                logger.info(f"  ✓ Set concept.{key} = {value}")
             else:
-                console.log(
-                    f"  ⚠️  Warning: concept has no attribute '{key}'", style="yellow"
-                )
+                logger.warning(f"  ⚠️  Warning: concept has no attribute '{key}'")
 
     # Fetch labelled passages from W&B if specified
     labelled_passages = None
     if training_data_wandb_path:
-        console.log(
+        logger.info(
             f"📥 Fetching training data from W&B artifact path: {training_data_wandb_path}"
         )
         labelled_passages = load_labelled_passages_from_wandb(
             wandb_path=training_data_wandb_path
         )
-        console.log(f"✅ Loaded {len(labelled_passages)} labelled passages from W&B")
+        logger.info(f"✅ Loaded {len(labelled_passages)} labelled passages from W&B")
 
     classifier = ClassifierFactory.create(
         concept=concept,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -778,6 +778,10 @@ async def run_training(
         extra_wandb_config["training_data_wandb_path"] = training_data_wandb_path
     if limit_training_samples is not None:
         extra_wandb_config["limit_training_samples"] = limit_training_samples
+    if hasattr(classifier, "model_name"):
+        wandb_classifier_kwargs: dict[str, object] = dict(classifier_kwargs or {})
+        wandb_classifier_kwargs["model_name"] = getattr(classifier, "model_name")
+        extra_wandb_config["classifier_kwargs"] = wandb_classifier_kwargs
 
     return await train_classifier(
         classifier=classifier,


### PR DESCRIPTION
- use `knowledge_graph.utils.get_logger` method for train, predict and sample scripts, which uses the Prefect logger if possible before falling back to the standard logger
- add `model_name` kwarg to W&B when training, even if the default is used. Fixes behaviour where model name was not being logged - see `ruby-forest-20` below

<img width="963" height="133" alt="image" src="https://github.com/user-attachments/assets/0f3bd663-b86d-49b8-a09a-61fcccb9626a" />
