### PR TITLE
fix: don't fail new sources by default

### DIFF
--- a/flows/classifier_specs/spec_interface.py
+++ b/flows/classifier_specs/spec_interface.py
@@ -129,8 +129,13 @@ def should_skip_doc(stem: DocumentStem, spec: ClassifierSpec) -> bool:
     If the source (i.e. the first part of the id), is in the dont_run_on field, this
     will return true to recommend filtering out.
     """
-    source = stem.split(".")[0]
-    return DontRunOnEnum(source.lower()) in (spec.dont_run_on or [])
+    source = stem.split(".")[0].lower()
+    try:
+        source_enum = DontRunOnEnum(source)
+    except ValueError:
+        return False
+
+    return source_enum in (spec.dont_run_on or [])
 
 
 def yaml_spec_to_json(aws_env: AwsEnv):

--- a/tests/flows/classifier_specs/test_spec_interface.py
+++ b/tests/flows/classifier_specs/test_spec_interface.py
@@ -124,3 +124,13 @@ def test_should_skip_doc(stem, expected):
         dont_run_on=["af", "sabin"],
     )
     assert expected == should_skip_doc(stem, spec)
+
+
+def test_should_skip_doc__new_source_allowed_by_default():
+    spec = ClassifierSpec(
+        wikibase_id="Q1",
+        classifier_id="9999zzzz",
+        wandb_registry_version="v1",
+        dont_run_on=["af", "sabin"],
+    )
+    assert not should_skip_doc("random_new_corpus", spec)


### PR DESCRIPTION
We previously were much more cautious about new corpora but this is now just causing disruption for no reason