### PR TITLE
fix: move model to CPU in modify threshold script

### DIFF
--- a/scripts/modify_threshold.py
+++ b/scripts/modify_threshold.py
@@ -32,6 +32,7 @@ from knowledge_graph.wandb_helpers import load_classifier_from_wandb
 from scripts.train import (
     StorageUpload,
     get_next_version,
+    move_model_to_cpu,
     upload_model_artifact,
 )
 
@@ -127,6 +128,8 @@ def main(
     )
     console.log(f"Saving classifier to {classifier_path}...")
     classifier_path.parent.mkdir(parents=True, exist_ok=True)
+
+    move_model_to_cpu(classifier)
     classifier.save(classifier_path)
 
     # Upload to S3


### PR DESCRIPTION
the train script moves the model to CPU before it's saved ([here](https://github.com/climatepolicyradar/knowledge-graph/blob/da3006d94c949f33e098ead4eb5f37ef868b3a76/scripts/train.py#L633)), meaning it's compatible with any device. this was missed from the modify_threshold script, causing the error

```
Executing flow 'inference-batch-of-documents-gpu' for flow run 'pristine-loon'...
Loading classifier Q1829:7n27za9e:v1
Encountered exception during execution: RuntimeError('torch.UntypedStorage(): Storage device not recognized: mps')
Traceback (most recent call last):
...
  File "/usr/local/lib/python3.13/site-packages/torch/storage.py", line 268, in mps
    return torch.UntypedStorage(self.size(), device="mps").copy_(self, False)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: torch.UntypedStorage(): Storage device not recognized: mps
pristine-loon transitioned from Running → Failed
Finished in state Failed('Flow run encountered an exception: RuntimeError: torch.UntypedStorage(): Storage device not recognized: mps')
```