### PR TITLE
Revert "Revert "Update classifier specs (automated)""

### DIFF
--- a/flows/classifier_specs/v2/production.yaml
+++ b/flows/classifier_specs/v2/production.yaml
@@ -469,9 +469,9 @@
   wandb_registry_version: v3
 - wikibase_id: Q1829
   concept_id: d2sckcja
-  classifier_id: fuqmphf9
+  classifier_id: 7n27za9e
   classifiers_profile: primary
-  wandb_registry_version: v0
+  wandb_registry_version: v1
   compute_environment:
     gpu: true
 - wikibase_id: Q1830


### PR DESCRIPTION
This reverts commit d7c3ed7236aa8d1ec6f25099b36243678a33f6cd.

Following a fix and the model getting retrained, see: https://github.com/climatepolicyradar/knowledge-graph/pull/1125