### PR TITLE
fix BERT token classifier training for modernBERT models

### DIFF
--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -310,11 +310,22 @@ class BertTokenClassifier(
 
     def download_model_and_tokenizer(self) -> None:
         """Download pretrained base model and tokenizer"""
+
+        if "ModernBERT" in self.model_name:
+            extra_clf_kwargs = {
+                # `reference_compile=False` disables ModernBERT's torch.compile path, which
+                # would otherwise require a C compiler at runtime (absent from our slim image)
+                "reference_compile": False,
+            }
+        else:
+            extra_clf_kwargs = {}
+
         self.model: PreTrainedModel = AutoModelForTokenClassification.from_pretrained(
             self.model_name,
             num_labels=NUM_LABELS,
             id2label=ID2LABEL,
             label2id=LABEL2ID,
+            **extra_clf_kwargs,
         )
         self.tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
             self.model_name


### PR DESCRIPTION
Applies the fix from #1120 and #1123 to the token classifier – skips trying to use the C compiler when the model is a modernBERT model. 

I'm aware that we should deduplicate some of the logic in the two BERT classifiers, but that can come later

