### PR TITLE
use entity-level metrics for BERT token classifier

### DIFF
--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -6,13 +6,25 @@ import tempfile
 from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import datetime
+from typing import cast
 
 import numpy as np
 import pandas as pd
 import torch
 from datasets import Dataset
 from rich.logging import RichHandler
-from sklearn.metrics import accuracy_score
+from seqeval.metrics import (
+    accuracy_score as seqeval_accuracy_score,
+)
+from seqeval.metrics import (
+    f1_score as seqeval_f1_score,
+)
+from seqeval.metrics import (
+    precision_score as seqeval_precision_score,
+)
+from seqeval.metrics import (
+    recall_score as seqeval_recall_score,
+)
 from sklearn.model_selection import train_test_split
 from sklearn.utils.class_weight import compute_class_weight
 from transformers import (
@@ -192,42 +204,39 @@ def _count_bio_labels(label_sequences: list[list[int]]) -> dict[int, int]:
     return counts
 
 
-def _compute_token_metrics(eval_pred: EvalPrediction) -> dict[str, float]:
+def _compute_entity_metrics(eval_pred: EvalPrediction) -> dict[str, float]:
     """
-    Compute token-level metrics from token predictions.
+    Compute entity-level metrics from BIO token predictions via seqeval.
 
-    Note: precision/recall/F1 here are token-level, not span-level. A 5-token
-    entity counts as 5 positives. This is used for early stopping during
-    training; the production quality signal is the span-level Jaccard metric
-    computed by evaluate_classifier.
+    A predicted span counts as a true positive only if its boundary matches a
+    gold span exactly.
     """
     predictions = np.argmax(eval_pred.predictions, axis=2)  # [batch, seq_len]
     labels = eval_pred.label_ids  # [batch, seq_len]
 
-    # Flatten, ignoring positions with IGNORE_LABEL
-    mask = labels != IGNORE_LABEL
-    flat_preds = predictions[mask]
-    flat_labels = labels[mask]
+    true_labels: list[list[str]] = [
+        [
+            ID2LABEL[int(lbl)]
+            for (_, lbl) in zip(pred_seq, lbl_seq)
+            if lbl != IGNORE_LABEL
+        ]
+        for pred_seq, lbl_seq in zip(predictions, labels)
+    ]
+    true_predictions: list[list[str]] = [
+        [ID2LABEL[int(p)] for (p, lbl) in zip(pred_seq, lbl_seq) if lbl != IGNORE_LABEL]
+        for pred_seq, lbl_seq in zip(predictions, labels)
+    ]
 
-    accuracy = accuracy_score(flat_labels, flat_preds)
-
-    # Token-level positives: any non-O token
-    pred_positive = flat_preds != O_LABEL
-    gold_positive = flat_labels != O_LABEL
-
-    tp = int(np.sum(pred_positive & gold_positive))
-    fp = int(np.sum(pred_positive & ~gold_positive))
-    fn = int(np.sum(~pred_positive & gold_positive))
-
-    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
-    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
-    f1 = (
-        2 * precision * recall / (precision + recall)
-        if (precision + recall) > 0
-        else 0.0
-    )
-
-    return {"accuracy": accuracy, "f1": f1, "precision": precision, "recall": recall}
+    # seqeval's *_score return `float | list[float]` depending on `average`; the
+    # default returns a scalar.
+    return {
+        "accuracy": cast(float, seqeval_accuracy_score(true_labels, true_predictions)),
+        "f1": cast(float, seqeval_f1_score(true_labels, true_predictions)),
+        "precision": cast(
+            float, seqeval_precision_score(true_labels, true_predictions)
+        ),
+        "recall": cast(float, seqeval_recall_score(true_labels, true_predictions)),
+    }
 
 
 class WeightedTokenTrainer(Trainer):
@@ -697,7 +706,7 @@ class BertTokenClassifier(
                 args=training_args,
                 train_dataset=train_dataset,
                 eval_dataset=validation_dataset,
-                compute_metrics=_compute_token_metrics,
+                compute_metrics=_compute_entity_metrics,
                 class_weights=weight_tensor,
                 callbacks=[
                     EarlyStoppingCallback(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,14 @@ transformers = [
   "sentence-transformers>=5.1.0",
   "transformers[torch]>=4.55.0",
   "accelerate>=1.6.0",
+  "seqeval>=1.2.2",
 ]
 transformers_gpu = [
   "torch>=2.7.1",
   "sentence-transformers>=5.1.0",
   "transformers[torch]==4.57.1",
   "accelerate>=1.6.0",
+  "seqeval>=1.2.2",
 ]
 # https://docs.coiled.io/user_guide/software/docker.html
 # https://docs.coiled.io/user_guide/software/package-sync-advanced.html

--- a/tests/test_bert_token_classifier.py
+++ b/tests/test_bert_token_classifier.py
@@ -10,7 +10,7 @@ from knowledge_graph.classifier.bert_token_classifier import (
     IGNORE_LABEL,
     O_LABEL,
     _align_labels_with_tokens,
-    _compute_token_metrics,
+    _compute_entity_metrics,
     _reconstruct_spans_from_predictions,
 )
 from knowledge_graph.identifiers import WikibaseID
@@ -275,8 +275,8 @@ def _make_eval_prediction(
     )
 
 
-class TestComputeTokenMetrics:
-    """Tests for _compute_token_metrics"""
+class TestComputeEntityMetrics:
+    """Tests for _compute_entity_metrics (seqeval entity-level scoring)."""
 
     def test_perfect_predictions(self):
         """All correct predictions should give F1=1, accuracy=1."""
@@ -285,7 +285,7 @@ class TestComputeTokenMetrics:
             [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
         ]
         labels = [[O_LABEL, B_LABEL, I_LABEL]]
-        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        result = _compute_entity_metrics(_make_eval_prediction(preds, labels))
         assert result["accuracy"] == pytest.approx(1.0)
         assert result["f1"] == pytest.approx(1.0)
         assert result["precision"] == pytest.approx(1.0)
@@ -297,7 +297,7 @@ class TestComputeTokenMetrics:
             [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
         ]
         labels = [[O_LABEL, B_LABEL, I_LABEL]]
-        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
+        result = _compute_entity_metrics(_make_eval_prediction(preds, labels))
         assert result["recall"] == pytest.approx(0.0)
         assert result["f1"] == pytest.approx(0.0)
 
@@ -308,31 +308,32 @@ class TestComputeTokenMetrics:
             [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]],
         ]
         labels = [[IGNORE_LABEL, B_LABEL, I_LABEL, IGNORE_LABEL]]
-        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
-        # Only positions 1 and 2 count: both predicted correctly
+        result = _compute_entity_metrics(_make_eval_prediction(preds, labels))
+        # Only positions 1 and 2 count: both predicted correctly → 1 entity matched
         assert result["accuracy"] == pytest.approx(1.0)
         assert result["f1"] == pytest.approx(1.0)
 
-    def test_token_level_not_span_level(self):
-        """A 3-token entity contributes 3 TPs, not 1 (token-level semantics)."""
+    def test_multi_token_entity_counts_once(self):
+        """A perfectly-predicted 3-token entity contributes a single TP (entity-level)."""
         # Gold: B I I (one 3-token entity). Predict: B I I (perfect).
         preds = [
             [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
         ]
         labels = [[B_LABEL, I_LABEL, I_LABEL]]
-        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
-        # 3 TP, 0 FP, 0 FN → precision=1, recall=1, f1=1
+        result = _compute_entity_metrics(_make_eval_prediction(preds, labels))
         assert result["precision"] == pytest.approx(1.0)
         assert result["recall"] == pytest.approx(1.0)
+        assert result["f1"] == pytest.approx(1.0)
 
-    def test_partial_overlap(self):
-        """Predicting only part of an entity: precision=1, recall=0.5."""
-        # Gold: B I. Predict: B O (miss the I token).
+    def test_partial_span_match_scores_zero(self):
+        """Partial span recovery should score 0 at entity level (boundary must match)."""
+        # Gold: B I (one 2-token entity). Predict: B O (truncated — entity boundary wrong).
         preds = [
             [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]],
         ]
         labels = [[B_LABEL, I_LABEL]]
-        result = _compute_token_metrics(_make_eval_prediction(preds, labels))
-        assert result["precision"] == pytest.approx(1.0)
-        assert result["recall"] == pytest.approx(0.5)
-        assert result["f1"] == pytest.approx(2 / 3)
+        result = _compute_entity_metrics(_make_eval_prediction(preds, labels))
+        # Predicted entity [B] does not match gold entity [B, I] → 0 TP, 1 FP, 1 FN
+        assert result["precision"] == pytest.approx(0.0)
+        assert result["recall"] == pytest.approx(0.0)
+        assert result["f1"] == pytest.approx(0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -2500,6 +2500,7 @@ mcp = [
 transformers = [
     { name = "accelerate" },
     { name = "sentence-transformers" },
+    { name = "seqeval" },
     { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-15-knowledge-graph-transformers') or (extra == 'extra-15-knowledge-graph-transformers' and extra == 'extra-15-knowledge-graph-transformers-gpu')" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-15-knowledge-graph-transformers') or (extra == 'extra-15-knowledge-graph-transformers' and extra == 'extra-15-knowledge-graph-transformers-gpu')" },
     { name = "transformers", extra = ["torch"], marker = "extra == 'extra-15-knowledge-graph-transformers'" },
@@ -2507,6 +2508,7 @@ transformers = [
 transformers-gpu = [
     { name = "accelerate" },
     { name = "sentence-transformers" },
+    { name = "seqeval" },
     { name = "torch", version = "2.7.1+cu118", source = { registry = "https://download.pytorch.org/whl/cu118" } },
     { name = "transformers", extra = ["torch"], marker = "extra == 'extra-15-knowledge-graph-transformers-gpu'" },
 ]
@@ -2578,6 +2580,8 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "sentence-transformers", marker = "extra == 'transformers'", specifier = ">=5.1.0" },
     { name = "sentence-transformers", marker = "extra == 'transformers-gpu'", specifier = ">=5.1.0" },
+    { name = "seqeval", marker = "extra == 'transformers'", specifier = ">=1.2.2" },
+    { name = "seqeval", marker = "extra == 'transformers-gpu'", specifier = ">=1.2.2" },
     { name = "snowflake-connector-python", extras = ["secure-local-storage"], specifier = ">=4.4.0" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.7.1" },
     { name = "tabulate", specifier = ">=0.9.0" },
@@ -5298,6 +5302,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/3a/38/10d6bfe23df1bfc65
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/3e/bb34de65a5787f76848a533afbb6610e01fbcdd59e76d8679c254e02255c/sentry_sdk-2.34.1-py2.py3-none-any.whl", hash = "sha256:b7a072e1cdc5abc48101d5146e1ae680fa81fe886d8d95aaa25a0b450c818d32", size = 357743, upload-time = "2025-07-30T11:13:36.145Z" },
 ]
+
+[[package]]
+name = "seqeval"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scikit-learn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/2d/233c79d5b4e5ab1dbf111242299153f3caddddbb691219f363ad55ce783d/seqeval-1.2.2.tar.gz", hash = "sha256:f28e97c3ab96d6fcd32b648f6438ff2e09cfba87f05939da9b3970713ec56e6f", size = 43605, upload-time = "2020-10-24T00:24:54.926Z" }
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
eval loss and eval f1 [were both going up](https://wandb.ai/climatepolicyradar/Q32/runs/pgi68yk6?nw=nwuserkdutia) with a token-level f1 metric 🥴 

i'm not sure I fully understand why this is happening, but having an entity-level measure which better tracks the actual span metrics should help the training process to pick the correct model in the end

I chose this because it's what the [Huggingface token classification tutorial](https://huggingface.co/learn/llm-course/chapter7/2) uses