### PR TITLE
fix: set dataloader_num_workers to 0 for bert models

### DIFF
--- a/knowledge_graph/classifier/bert_based.py
+++ b/knowledge_graph/classifier/bert_based.py
@@ -611,7 +611,7 @@ class BertBasedClassifier(
                 load_best_model_at_end=True,
                 metric_for_best_model="eval_f1",
                 greater_is_better=True,
-                dataloader_num_workers=2,
+                dataloader_num_workers=0,
                 report_to=["wandb"] if enable_wandb else [],
                 disable_tqdm=True,
                 # W&B-specific settings when enabled

--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -694,7 +694,7 @@ class BertTokenClassifier(
                 load_best_model_at_end=True,
                 metric_for_best_model="eval_f1",
                 greater_is_better=True,
-                dataloader_num_workers=2,
+                dataloader_num_workers=0,
                 report_to=["wandb"] if enable_wandb else [],
                 disable_tqdm=True,
                 run_name=(f"{self.concept.id}_{self.name}" if enable_wandb else None),


### PR DESCRIPTION
training modernBERT fails on coiled, with an exception ending in `RuntimeError: DataLoader worker (pid 135) exited unexpectedly with exit code 1. Details are lost due to multiprocessing. Rerunning with num_workers=0 may give better error trace.` - [run here](https://wandb.ai/climatepolicyradar/Q32/runs/bxuwis3h/logs?nw=nwuserkdutia)

#689 implemented this change as well as a bunch of others, but with no attached explanation. The [Huggingface docs](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.Seq2SeqTrainingArguments.dataloader_num_workers) explain this value and state that its default is 0, which we're reverting to.