### PR TITLE
fix: ensure artifact keys validate successfully

### DIFF
--- a/flows/aggregate.py
+++ b/flows/aggregate.py
@@ -45,6 +45,7 @@ from flows.utils import (
     build_run_output_identifier,
     collect_unique_file_stems_under_prefix,
     map_as_sub_flow,
+    sanitise_artifact_key_component,
 )
 from knowledge_graph.cloud import AwsEnv, get_async_session
 from knowledge_graph.concept import Concept
@@ -452,8 +453,10 @@ async def create_aggregate_inference_summary_artifact(
     if not flow_run_name:
         flow_run_name = f"unknown-{generate_slug(2)}"
 
+    sanitised_flow_run_name = sanitise_artifact_key_component(flow_run_name)
+
     await create_table_artifact(  # pyright: ignore[reportGeneralTypeIssues]
-        key=f"batch-aggregate-{config.aws_env.value}-{flow_run_name}",
+        key=f"batch-aggregate-{config.aws_env.value}-{sanitised_flow_run_name}",
         table=details,
         description=overview_description,
     )

--- a/flows/inference.py
+++ b/flows/inference.py
@@ -54,6 +54,7 @@ from flows.utils import (
     filter_non_english_language_file_stems,
     map_as_sub_flow,
     return_with,
+    sanitise_artifact_key_component,
     wait_for_semaphore,
 )
 from knowledge_graph.classifier import Classifier
@@ -853,8 +854,10 @@ async def create_inference_on_batch_summary_artifact(
     if not flow_run_name:
         flow_run_name = f"unknown-{generate_slug(2)}"
 
+    sanitised_flow_run_name = sanitise_artifact_key_component(flow_run_name)
+
     await acreate_table_artifact(
-        key=f"batch-inference-{config.aws_env.value}-{flow_run_name}",
+        key=f"batch-inference-{config.aws_env.value}-{sanitised_flow_run_name}",
         table=document_details,
         description=overview_description,
     )

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -104,6 +104,12 @@ def file_name_from_path(path: str) -> str:
     return os.path.splitext(os.path.basename(path))[0]
 
 
+def sanitise_artifact_key_component(value: str) -> str:
+    """Convert a string into a valid Prefect artifact key component."""
+    sanitised = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return sanitised or "unknown"
+
+
 def get_flow_run_ui_url(flow_run: FlowRun):
     """Determine the prefect console URL for a flow run."""
     return f"{get_current_settings().ui_url}/flow-runs/flow-run/{flow_run.id}"

--- a/tests/flows/test_aggregate.py
+++ b/tests/flows/test_aggregate.py
@@ -126,7 +126,7 @@ async def test_aggregate_batch_of_documents(
     flow_run = FlowRun(
         id=uuid.UUID("0199bef8-7e41-7afc-9b4c-d3abd406be84"),
         flow_id=uuid.UUID("b213352f-3214-48e3-8f5d-ec19959cb28e"),
-        name="test-flow-run",
+        name="test-flow-run (Copy)",
         state=Running(),
     )
 
@@ -196,7 +196,7 @@ async def test_aggregate_batch_of_documents(
         f"Expected {COUNT} concepts to be outputted, found: {len(all_collected_ids)}"
     )
 
-    summary_artifact = await Artifact.get("batch-aggregate-sandbox-test-flow-run")
+    summary_artifact = await Artifact.get("batch-aggregate-sandbox-test-flow-run-copy")
     assert summary_artifact and summary_artifact.description
     assert summary_artifact.data == "[]"
 
@@ -219,7 +219,7 @@ async def test_aggregate_batch_of_documents__with_failures(
     flow_run = FlowRun(
         id=uuid.UUID("0199bef8-7e41-7afc-9b4c-d3abd406be84"),
         flow_id=uuid.UUID("b213352f-3214-48e3-8f5d-ec19959cb28e"),
-        name="test-flow-run",
+        name="test-flow-run (Copy)",
         state=Running(),
     )
 
@@ -237,7 +237,7 @@ async def test_aggregate_batch_of_documents__with_failures(
             return_state=True,  # type: ignore[reportArgumentType]
         )
 
-    summary_artifact = await Artifact.get("batch-aggregate-sandbox-test-flow-run")
+    summary_artifact = await Artifact.get("batch-aggregate-sandbox-test-flow-run-copy")
     assert summary_artifact and summary_artifact.description
     artifact_data = json.loads(summary_artifact.data)
     failure_stems = [f["Failed document Stem"] for f in artifact_data]

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -10,6 +10,7 @@ import pytest
 from prefect.client.schemas.objects import FlowRun, State, StateType, TaskRun
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.flows import flow
+from prefect.types.names import raise_on_name_alphanumeric_dashes_only
 from prefect.variables import Variable
 
 from flows.utils import (
@@ -33,6 +34,7 @@ from flows.utils import (
     map_as_sub_flow,
     remove_translated_suffix,
     s3_file_exists,
+    sanitise_artifact_key_component,
 )
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.utils import iterate_batch
@@ -48,6 +50,23 @@ from knowledge_graph.utils import iterate_batch
 )
 def test_file_name_from_path(path, expected):
     assert file_name_from_path(path) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("exuberant-dragonfly (Copy)", "exuberant-dragonfly-copy"),
+        ("UPPER_case.and spaces", "upper-case-and-spaces"),
+        ("!!!", "unknown"),
+    ],
+)
+def test_sanitise_artifact_key_component(value: str, expected: str) -> None:
+    actual = sanitise_artifact_key_component(value)
+    assert actual == expected
+    assert (
+        raise_on_name_alphanumeric_dashes_only(actual, field_name="Artifact key")
+        == actual
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Copying to a new run in prefect will now append `(Copy)` on to the end of the flow run name, we use the flow run name on artifact table creation but the parenthesis cannot be used in table artifact keys. This makes sure flor run names are sanitised before being used. This was a problem [here](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069e8872-eb32-7d85-8000-dd5a094d0259). 