### PR TITLE
fix: allow BERT threshold calibration below 0.5

### DIFF
--- a/knowledge_graph/classifier/bert_based.py
+++ b/knowledge_graph/classifier/bert_based.py
@@ -293,62 +293,60 @@ class BertBasedClassifier(
         self, texts: Sequence[str], threshold: float | None = None
     ) -> list[list[Span]]:
         """Predict whether the supplied texts contain instances of the concept."""
-        if self._use_dropout_during_inference:
-            with self._dropout_enabled():
-                with torch.no_grad():
-                    scores, predicted_classes = self._forward(texts)
-        else:
-            self.model.eval()  # type: ignore[attr-defined]
-            with torch.no_grad():
-                scores, predicted_classes = self._forward(texts)
+        positive_probs = self.predict_proba_batch(texts)
 
-        effective_threshold = (
-            threshold if threshold is not None else self.prediction_threshold
-        )
+        if threshold is not None:
+            effective_threshold = threshold
+        elif self.prediction_threshold is not None:
+            effective_threshold = self.prediction_threshold
+        else:
+            effective_threshold = 0.5
 
         now = datetime.now()
         labeller = str(self)
         results = []
-        for text, score, cls in zip(texts, scores, predicted_classes):
+        for text, pos_prob in zip(texts, positive_probs):
             text_results = []
-            # LABEL_1 (class index 1) is the positive prediction.
-            if cls == 1:
-                if effective_threshold is None or score >= effective_threshold:
-                    span = Span(
-                        text=text,
-                        concept_id=self.concept.wikibase_id,
-                        prediction_probability=score,
-                        start_index=0,
-                        end_index=len(text),
-                        labellers=[labeller],
-                        timestamps=[now],
-                    )
-                    text_results.append(span)
+            if pos_prob >= effective_threshold:
+                span = Span(
+                    text=text,
+                    concept_id=self.concept.wikibase_id,
+                    prediction_probability=pos_prob,
+                    start_index=0,
+                    end_index=len(text),
+                    labellers=[labeller],
+                    timestamps=[now],
+                )
+                text_results.append(span)
             results.append(text_results)
 
         return results
 
-    def _forward(self, texts: Sequence[str]) -> tuple[list[float], list[int]]:
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
         """
-        Run a batched forward pass and return per-text scores and predicted classes.
+        Return P(class=1) per text, independent of the argmax decision.
 
-        :param texts: Texts to classify.
-        :returns: Tuple of `(scores, predicted_classes)` where `scores[i]` is the
-            probability of the predicted class for text `i`
+        This is needed because `predict` only returns a `Span` for positive examples,
+        but probability calibration needs examples from probabilities 0 <= p <= 1.
         """
-        device = self.device
+        if self._use_dropout_during_inference:
+            with self._dropout_enabled():
+                with torch.no_grad():
+                    return self._forward_positive_probs(texts)
+        self.model.eval()  # type: ignore[attr-defined]
+        with torch.no_grad():
+            return self._forward_positive_probs(texts)
+
+    def _forward_positive_probs(self, texts: Sequence[str]) -> list[float]:
         inputs = self.tokenizer(
             list(texts),
             padding=True,
             truncation=True,
             max_length=512,
             return_tensors="pt",
-        ).to(device)
+        ).to(self.device)
         logits = self.model(**inputs).logits
-        probs = torch.softmax(logits, dim=-1)
-        predicted_classes = torch.argmax(probs, dim=-1)
-        scores = probs[torch.arange(len(probs)), predicted_classes]
-        return scores.tolist(), predicted_classes.tolist()
+        return torch.softmax(logits, dim=-1)[:, 1].tolist()
 
     def get_variant(
         self, random_seed: int | None = None, dropout_rate: float = 0.1

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -495,6 +495,12 @@ def evaluate_classifier(
         gold_standard_labelled_passages, model_labelled_passages
     )
 
+    pred_probabilities: list[float] | None = None
+    if hasattr(classifier, "predict_proba_batch"):
+        pred_probabilities = classifier.predict_proba_batch(  # type: ignore[attr-defined]
+            [p.text for p in gold_standard_labelled_passages]
+        )
+
     if wandb_run:
         log_metrics_to_wandb(wandb_run, df)  # type: ignore
         console.log("📊 Logging validation set predictions to W&B")
@@ -507,6 +513,7 @@ def evaluate_classifier(
             wandb_run,
             predictions=model_labelled_passages,
             ground_truth=gold_standard_labelled_passages,
+            pred_probabilities=pred_probabilities,
         )
 
     return df, model_labelled_passages, passage_level_cm
@@ -516,6 +523,7 @@ def create_wandb_model_evaluation_charts(
     wandb_run: Run,
     predictions: list[LabelledPassage],
     ground_truth: list[LabelledPassage],
+    pred_probabilities: list[float] | None = None,
 ) -> None:
     """
     Plot ROC, precision-recall and confusion matrix plots in the W&B run.
@@ -529,7 +537,7 @@ def create_wandb_model_evaluation_charts(
     ground_truth_labels = [1 if lp.spans else 0 for lp in ground_truth]
     binary_predictions = [1 if lp.spans else 0 for lp in predictions]
 
-    if all(
+    if pred_probabilities is None and all(
         [
             span.prediction_probability is not None
             for pred in predictions
@@ -548,6 +556,7 @@ def create_wandb_model_evaluation_charts(
             for pred in predictions
         ]
 
+    if pred_probabilities is not None:
         precision, recall, pr_thresholds = precision_recall_curve(
             ground_truth_labels, pred_probabilities
         )


### PR DESCRIPTION
I found an issue where the optimal F1 threshold was being set to 0 ([see run](https://wandb.ai/climatepolicyradar/Q32/runs/n4iax93o/overview?nw=nwuserkdutia)).

<img width="439" height="199" alt="image" src="https://github.com/user-attachments/assets/af90cbe8-e94e-48ed-a961-71c09d819dba" />

This was because of how classifiers work in this code – they only return `Span` objects for positive predictions, so we only get prediction probabilities over 0.5. You can see this reflected in the _threshold_ column of the precision-recall table (same run as above).

<img width="2172" height="348" alt="image" src="https://github.com/user-attachments/assets/03633291-b821-447d-b851-fa288d571c45" />

So, this PR refactors `BertBasedClassifier` to have a `predict_proba_batch` method, which returns the probabilities for _all texts_. It's then used in the `predict` method and the model evaluation charts. I've also refactored the model evaluation charts to use probabilities from the validation set predictions, meaning we'll get points on the charts that make a bit more sense in the context of the validation set. [See new run with the fix](https://wandb.ai/climatepolicyradar/Q32/runs/kf1163u3?nw=nwuserkdutia).

<img width="2180" height="475" alt="image" src="https://github.com/user-attachments/assets/0d12a9f6-64a5-47e9-90b8-fa60709fc5a6" />
