### PR TITLE
debug llmclassifier errors

### DIFF
--- a/knowledge_graph/classifier/large_language_model.py
+++ b/knowledge_graph/classifier/large_language_model.py
@@ -386,6 +386,8 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
 class LLMClassifier(BaseLLMClassifier):
     """A classifier which uses a third-party LLM to identify concept mentions in text"""
 
+    N_RETRIES = 3
+
     def __init__(
         self,
         concept: Concept,
@@ -441,6 +443,7 @@ class LLMClassifier(BaseLLMClassifier):
             model=self.model_name,
             system_prompt=self.system_prompt,
             output_type=output_type,
+            retries=self.N_RETRIES,
         )
 
 

--- a/knowledge_graph/classifier/large_language_model.py
+++ b/knowledge_graph/classifier/large_language_model.py
@@ -271,8 +271,7 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
                 )
         except (UnexpectedModelBehavior, ValidationError) as e:
             logger.warning(
-                f"LLM failed to produce valid response after retries: {e}. "
-                f"Text (truncated): {text[:100]}..."
+                f"LLM failed to produce valid response after retries: {e}. Text: {text}"
             )
             return []
 
@@ -343,12 +342,11 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
                 if isinstance(response, (UnexpectedModelBehavior, ValidationError)):
                     logger.warning(
                         f"LLM failed to produce valid response after retries: {response}. "
-                        f"Text (truncated): {text[:100]}..."
+                        f"Text: {text}"
                     )
                 else:
                     logger.warning(
-                        f"Prediction failed with exception: {response}. "
-                        f"Text (truncated): {text[:100]}..."
+                        f"Prediction failed with exception: {response}. Text: {text}"
                     )
                 batch_spans.append([])
                 continue


### PR DESCRIPTION
When running the LLMClassifier on my machine I get lots of error messages that look like 

``` text
[04/22/26 15:35:42] WARNING  WARNING:knowledge_graph.classifier.large_language_model:LLM failed to produce valid response after retries: Invalid response from OpenAI chat completions endpoint: 1 validation error for ChatCompletion                                                 large_language_model.py:344
                             choices.0.finish_reason                                                                                                                                                                                                                                                              
                               Input should be 'stop', 'length', 'tool_calls', 'content_filter' or 'function_call' [type=literal_error, input_value=None, input_type=NoneType]                                                                                                                                    
                                 For further information visit https://errors.pydantic.dev/2.11/v/literal_error. Text (truncated): 4.7.6 Improvements envisaged...                                                                                                                                                
```

This PR makes the reason hopefully easier to debug or fix, by not truncating the text that fails (meaning we can test it manually against the classifier) and increasing the default number of retries when using remote LLMs.