### PR TITLE
fix: increase read timeout some more

### DIFF
--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -65,8 +65,8 @@ class WikibaseSession:
     """Async-first session for interacting with Wikibase, with sync proxy methods"""
 
     # Magic numbers
-    DEFAULT_TIMEOUT = 30
-    REDIRECT_REQUEST_TIMEOUT = 90
+    DEFAULT_TIMEOUT = 60
+    REDIRECT_REQUEST_TIMEOUT = 120
     DEFAULT_BATCH_SIZE = 50
     PAGE_REQUEST_SIZE = 500
     MAX_PAGE_REQUESTS = 2000  # Suitable up to 1M pages (500*2000)


### PR DESCRIPTION
We had another timeout error but at a different point. Suggesting the original fix did work but that we still need to manage our handling of wikibase with even more generous read timeouts