### PR TITLE
fix predict script aws env handling

### DIFF
--- a/flows/predict.py
+++ b/flows/predict.py
@@ -1,6 +1,5 @@
 import os
 
-import boto3
 import wandb
 from prefect import flow
 from pydantic import SecretStr
@@ -31,13 +30,6 @@ async def _set_up_prediction_environment(
         get_aws_ssm_param("/OpenRouter/KGApiKey", aws_env=aws_env)
     )
     os.environ["OPENROUTER_API_KEY"] = openrouter_api_key.get_secret_value()
-
-    use_aws_profiles = os.environ.get("USE_AWS_PROFILES", "false").lower() == "true"
-    session = boto3.session.Session(
-        profile_name=aws_env.value if use_aws_profiles else None,
-        region_name=config.bucket_region,
-    )
-    session.client("s3")
 
     return config
 

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -288,7 +288,9 @@ async def run_prediction(
         region_name = "eu-west-1"
         # When running in prefect the client is instantiated earlier
         # Set this, so W&B knows where to look for AWS credentials profile
-        os.environ["AWS_PROFILE"] = aws_env
+        # Only set AWS_PROFILE when using named profiles (local dev).
+        if os.environ.get("USE_AWS_PROFILES", "false").lower() == "true":
+            os.environ["AWS_PROFILE"] = aws_env.value
         get_s3_client(aws_env, region_name)
 
         classifier = load_classifier_from_wandb(classifier_wandb_path)


### PR DESCRIPTION
Attempt to fix another error with running adhoc prediction in prefect ([see flow](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/069f3277-8c35-7d92-8000-4ad5d8d4153d?preview=true&tab=logs))

```
Encountered exception during execution: ProfileNotFound('The config profile (prod) could not be found')
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/prefect/flow_engine.py", line 1792, in run_context
    yield self
  File "/usr/local/lib/python3.13/site-packages/prefect/flow_engine.py", line 1854, in run_flow_async
    await engine.call_flow_fn()
  File "/usr/local/lib/python3.13/site-packages/prefect/flow_engine.py", line 1806, in call_flow_fn
    result = await call_with_parameters(self.flow.fn, self.parameters)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/flows/predict.py", line 64, in predict_adhoc
    return await run_prediction(
           ^^^^^^^^^^^^^^^^^^^^^
    ...<12 lines>...
    )
    ^
  File "/app/scripts/predict.py", line 214, in run_prediction
    get_s3_client(aws_env, region_name)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/app/knowledge_graph/cloud.py", line 167, in get_s3_client
    return boto3.client("s3", region_name=region_name)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/boto3/__init__.py", line 93, in client
    return _get_default_session().client(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/boto3/session.py", line 337, in client
    return self._session.create_client(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        service_name, **create_client_kwargs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/botocore/session.py", line 949, in create_client
    verify = self.get_config_variable('ca_bundle')
  File "/usr/local/lib/python3.13/site-packages/botocore/session.py", line 325, in get_config_variable
    return self.get_component('config_store').get_config_variable(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        logical_name
        ^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/botocore/configprovider.py", line 502, in get_config_variable
    return provider.provide()
           ~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/botocore/configprovider.py", line 708, in provide
    value = provider.provide()
  File "/usr/local/lib/python3.13/site-packages/botocore/configprovider.py", line 795, in provide
    scoped_config = self._session.get_scoped_config()
  File "/usr/local/lib/python3.13/site-packages/botocore/session.py", line 424, in get_scoped_config
    raise ProfileNotFound(profile=profile_name)
botocore.exceptions.ProfileNotFound: The config profile (prod) could not be found
```

It looks like scripts/predict.py was always setting `os.environ["AWS_PROFILE"] = "prod"`, which failed on ECS. It should now only set that env variable when `os.environ["USE_AWS_PROFILES"] == "true"` 

Also deletes dead code in flows/predict.py as claude pointed out it had no global effect

