### PR TITLE
enable running of adhoc KG prediction in prefect

### DIFF
--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -323,7 +323,7 @@ async def run_prediction(
                 )
 
             logger.info(
-                "You can end prediction early by pressing Ctrl+C. This will save passages predicted thus far."
+                "You can end prediction early by pressing Ctrl+C or cancelling the Prefect flow. This will save passages predicted thus far."
             )
 
             for i in range(0, len(labelled_passages), batch_size):

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -9,8 +9,15 @@ import snowflake.connector
 import typer
 import wandb
 from dotenv import load_dotenv
+from prefect.client.schemas.objects import FlowRun
+from prefect.deployments import run_deployment
 
-from knowledge_graph.cloud import AwsEnv, get_s3_client
+from flows.utils import get_flow_run_ui_url
+from knowledge_graph.cloud import (
+    AwsEnv,
+    generate_deployment_name,
+    get_s3_client,
+)
 from knowledge_graph.config import WANDB_ENTITY, predictions_dir
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
@@ -465,6 +472,13 @@ def main(
             help="Optional W&B run path to restart from. Loads already-predicted passages from this run and skips them.",
         ),
     ] = None,
+    use_prefect: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            help=("Run on Prefect. Note that the results won't be available locally."),
+        ),
+    ] = False,
 ):
     """
     Load labelled passages from local dir or W&B, and run a classifier on them.
@@ -472,22 +486,51 @@ def main(
     Saves predicted passages to a local directory. Tracks the run and uploads results
     if `track_and_upload` is set.
     """
-    asyncio.run(
-        run_prediction(
-            wikibase_id=wikibase_id,
-            classifier_wandb_path=classifier_wandb_path,
-            labelled_passages_path=labelled_passages_path,
-            labelled_passages_wandb_run_path=labelled_passages_wandb_run_path,
-            track_and_upload=track_and_upload,
-            batch_size=batch_size,
-            limit=limit,
-            deduplicate_inputs=deduplicate_inputs,
-            exclude_training_data=exclude_training_data,
-            prediction_threshold=prediction_threshold,
-            stop_after_n_positives=stop_after_n_positives,
-            restart_from_wandb_run=restart_from_wandb_run,
+    if use_prefect:
+        flow_name = "predict-adhoc"
+        deployment_name = generate_deployment_name(
+            flow_name=flow_name, aws_env=AwsEnv.production
         )
-    )
+        qualified_name = f"{flow_name}/{deployment_name}"
+
+        flow_run: FlowRun = run_deployment(  # type: ignore[misc]
+            name=qualified_name,
+            parameters={
+                "wikibase_id": wikibase_id,
+                "classifier_wandb_path": classifier_wandb_path,
+                "labelled_passages_wandb_run_path": labelled_passages_wandb_run_path,
+                "track_and_upload": track_and_upload,
+                "batch_size": batch_size,
+                "limit": limit,
+                "deduplicate_inputs": deduplicate_inputs,
+                "exclude_training_data": exclude_training_data,
+                "prediction_threshold": prediction_threshold,
+                "stop_after_n_positives": stop_after_n_positives,
+                "restart_from_wandb_run": restart_from_wandb_run,
+                "aws_env": AwsEnv.production,
+            },
+            timeout=0,  # Don't wait for the flow to finish before continuing
+        )
+        get_logger().info(
+            f"Deployment started. Flow run URL: {get_flow_run_ui_url(flow_run)}"
+        )
+    else:
+        asyncio.run(
+            run_prediction(
+                wikibase_id=wikibase_id,
+                classifier_wandb_path=classifier_wandb_path,
+                labelled_passages_path=labelled_passages_path,
+                labelled_passages_wandb_run_path=labelled_passages_wandb_run_path,
+                track_and_upload=track_and_upload,
+                batch_size=batch_size,
+                limit=limit,
+                deduplicate_inputs=deduplicate_inputs,
+                exclude_training_data=exclude_training_data,
+                prediction_threshold=prediction_threshold,
+                stop_after_n_positives=stop_after_n_positives,
+                restart_from_wandb_run=restart_from_wandb_run,
+            )
+        )
 
 
 @app.command()

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -360,6 +360,11 @@ async def run_prediction(
                         f"Processed {passages_processed}/{len(labelled_passages)} passages"
                     )
 
+        except KeyboardInterrupt:
+            logger.info(
+                f"Prediction stopped early by user. "
+                f"Saving {len(output_labelled_passages)} passages predicted thus far..."
+            )
         except Exception as e:
             prediction_exception = e
             logger.error(f"⚠ Prediction failed: {e}")


### PR DESCRIPTION
The `main` command of the predict adhoc prefect flow can now be run on prefect. This is used in the BERT classifier distillation flow.

[prefect run](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/06a0b166-89c0-7ff4-8000-c7509cd1895c?preview=true&tab=logs), also showing that stopping early still uploads results to W&B

<img width="1662" height="1102" alt="image" src="https://github.com/user-attachments/assets/5c09248a-fddd-4d6a-89bd-d53a4b497ead" />

resulting [W&B run](https://wandb.ai/climatepolicyradar/Q911/runs/4nu0cv4a?nw=nwuserkdutia) with 30 passages

<img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/0b8cfd8d-c51a-466b-9e43-de915e9b59fd" />



Also, now doesn't set a run to `failed` status when a user stops prediction early. [see run](https://wandb.ai/climatepolicyradar/Q911/runs/xtsmgm2d/overview?nw=nwuserkdutia)

<img width="530" height="397" alt="image" src="https://github.com/user-attachments/assets/683fdcc6-bff6-49e5-a7da-70ec54581ee8" />

