### PR TITLE
use `utils.get_logger(__name__)` everywhere

### DIFF
--- a/knowledge_graph/classifier/bert_based.py
+++ b/knowledge_graph/classifier/bert_based.py
@@ -38,7 +38,7 @@ from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.span import Span
 from knowledge_graph.utils import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 def compute_metrics(eval_pred: EvalPrediction) -> dict[str, float]:

--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -49,7 +49,7 @@ from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.span import Span
 from knowledge_graph.utils import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 # BIO label scheme
 O_LABEL = 0

--- a/knowledge_graph/classifier/embedding.py
+++ b/knowledge_graph/classifier/embedding.py
@@ -1,4 +1,3 @@
-import logging
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -15,8 +14,9 @@ from knowledge_graph.classifier.classifier import (
 from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import ClassifierID, Identifier
 from knowledge_graph.span import Span
+from knowledge_graph.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class _EmbeddingCache:

--- a/knowledge_graph/classifier/keyword.py
+++ b/knowledge_graph/classifier/keyword.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from datetime import datetime
 
@@ -6,8 +5,9 @@ from knowledge_graph.classifier.classifier import Classifier, ZeroShotClassifier
 from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import ClassifierID
 from knowledge_graph.span import Span, merge_overlapping_spans
+from knowledge_graph.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class KeywordClassifier(Classifier, ZeroShotClassifier):

--- a/knowledge_graph/classifier/large_language_model.py
+++ b/knowledge_graph/classifier/large_language_model.py
@@ -248,7 +248,7 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
         :param float | None threshold: Optional prediction threshold
         :return list[Span]: A list of spans identified in the text
         """
-        logger = get_logger()
+        logger = get_logger(__name__)
         if threshold is not None:
             logger.warning(
                 f"`threshold` parameter ignored - {self.__class__.__name__} does not output prediction probabilities",
@@ -300,7 +300,7 @@ class BaseLLMClassifier(Classifier, ZeroShotClassifier, VariantEnabledClassifier
         :param float | None threshold: Optional prediction threshold
         :return list[list[Span]]: A list of span lists identified in each text
         """
-        logger = get_logger()
+        logger = get_logger(__name__)
         self._check_and_nest_event_loop()
 
         async def run_predictions():

--- a/knowledge_graph/ensemble/__init__.py
+++ b/knowledge_graph/ensemble/__init__.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Sequence, cast, overload
 
 from rich.console import Console
@@ -18,9 +17,9 @@ from knowledge_graph.classifier.classifier import (
 from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import ClassifierID
 from knowledge_graph.span import Span
-from knowledge_graph.utils import iterate_batch
+from knowledge_graph.utils import get_logger, iterate_batch
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class IncompatibleSubClassifiersError(Exception):

--- a/knowledge_graph/labelled_passage.py
+++ b/knowledge_graph/labelled_passage.py
@@ -1,5 +1,4 @@
 import html
-import logging
 import re
 from collections import defaultdict
 from datetime import datetime
@@ -10,8 +9,9 @@ from pydantic import BaseModel, Field, model_validator
 
 from knowledge_graph.identifiers import Identifier, WikibaseID
 from knowledge_graph.span import Span, merge_overlapping_spans
+from knowledge_graph.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class LabelledPassage(BaseModel):

--- a/knowledge_graph/openrouter_pricing.py
+++ b/knowledge_graph/openrouter_pricing.py
@@ -1,12 +1,13 @@
 """Fetch pricing information from OpenRouter API."""
 
-import logging
 from typing import Optional
 
 import httpx
 from pydantic import BaseModel, Field
 
-logger = logging.getLogger(__name__)
+from knowledge_graph.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class ModelPricing(BaseModel):

--- a/knowledge_graph/span.py
+++ b/knowledge_graph/span.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from collections import OrderedDict
 from datetime import datetime
@@ -9,8 +8,9 @@ from pydantic import BaseModel, Field, computed_field, model_validator
 from typing_extensions import Self
 
 from knowledge_graph.identifiers import Identifier, WikibaseID
+from knowledge_graph.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class SpanXMLConceptFormattingError(Exception):

--- a/knowledge_graph/utils.py
+++ b/knowledge_graph/utils.py
@@ -14,7 +14,7 @@ from rich.logging import RichHandler
 LoggingAdapter = logging.LoggerAdapter[logging.Logger]
 
 
-def get_logger() -> logging.Logger | LoggingAdapter:
+def get_logger(name: str = "knowledge_graph") -> logging.Logger | LoggingAdapter:
     """
     Get a logger via Prefect.
 
@@ -32,12 +32,12 @@ def get_logger() -> logging.Logger | LoggingAdapter:
     try:
         return prefect.logging.get_run_logger()
     except prefect.exceptions.MissingContextError:
-        logger = logging.getLogger("knowledge_graph")
-        if not logger.handlers:
-            logger.addHandler(RichHandler())
-        if not logger.level:
-            logger.setLevel(logging.INFO)
-        return logger
+        root = logging.getLogger("knowledge_graph")
+        if not root.handlers:
+            root.addHandler(RichHandler())
+        if not root.level:
+            root.setLevel(logging.INFO)
+        return logging.getLogger(name)
 
 
 T = TypeVar("T")

--- a/knowledge_graph/wandb_helpers.py
+++ b/knowledge_graph/wandb_helpers.py
@@ -1,7 +1,6 @@
 """Some helper functions for IO with Weights & Biases, to ensure consistency."""
 
 import json
-import logging
 import tempfile
 from pathlib import Path
 
@@ -18,10 +17,11 @@ from knowledge_graph.config import (
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.utils import (
     deserialise_pydantic_list_with_fallback,
+    get_logger,
     serialise_pydantic_list_as_jsonl,
 )
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class WandbArtifactNotFoundError(Exception):

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -31,7 +31,7 @@ from knowledge_graph.exceptions import (
 from knowledge_graph.identifiers import ClassifierID, WikibaseID
 from knowledge_graph.utils import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 dotenv.load_dotenv()
 
 
@@ -134,7 +134,7 @@ class WikibaseSession:
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get the HTTP client, initializing session on first use"""
-        logger = get_logger()
+        logger = get_logger(__name__)
         if self._client is None:
             logger.debug("Initialising Wikibase HTTP client and session")
             self._client = httpx.AsyncClient(timeout=self.DEFAULT_TIMEOUT)
@@ -242,7 +242,7 @@ class WikibaseSession:
                     initial=RETRY_INITIAL_WAIT, max=RETRY_MAX_WAIT
                 ),
                 retry=retry_if_exception_type((HTTPStatusError, ReadTimeout)),
-                before_sleep=before_sleep_log(get_logger(), logging.WARNING),  # type: ignore[arg-type]
+                before_sleep=before_sleep_log(get_logger(__name__), logging.WARNING),  # type: ignore[arg-type]
                 reraise=True,
             ):
                 with attempt:
@@ -553,7 +553,7 @@ class WikibaseSession:
         retry=retry_if_exception_type(
             (HTTPStatusError, RequestError, json.JSONDecodeError)
         ),
-        before_sleep=before_sleep_log(get_logger(), logging.WARNING),  # type: ignore[arg-type]
+        before_sleep=before_sleep_log(get_logger(__name__), logging.WARNING),  # type: ignore[arg-type]
         reraise=True,
     )
     async def get_concepts_async(

--- a/knowledge_graph/wikidata.py
+++ b/knowledge_graph/wikidata.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import Optional
 
 import httpx
@@ -15,8 +14,9 @@ from knowledge_graph.async_bridge import async_to_sync
 from knowledge_graph.concept import Concept
 from knowledge_graph.exceptions import ConceptNotFoundError
 from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 MAX_RETRIES = 5


### PR DESCRIPTION
More logger fixing since finding inconsistencies in how we log since working more with Prefect (see #1158 & #1161). This PR makes sure all submodules in `knowledge_graph/`:

- call `utils.get_logger`
- call it with `__name__`, so we can see the submodule making the logging statement