### PR TITLE
`ProbabilityCapableClassifier` always implements `predict_proba_batch`

### DIFF
--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -537,6 +537,51 @@ class BertTokenClassifier(
 
         return batch_labels, batch_probs, offset_mapping
 
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """
+        Return the per-text positive-class probability.
+
+        For this token-level model, the passage-level probability is the maximum
+        probability of any non-O ("B"/"I") prediction across the passage's content
+        tokens, i.e. the model's strongest signal that any token mentions the concept.
+        """
+        if self._use_dropout_during_inference:
+            with self._dropout_enabled():
+                with torch.no_grad():
+                    return self._forward_positive_probs(texts)
+        self.model.eval()  # type: ignore[attr-defined]
+        with torch.no_grad():
+            return self._forward_positive_probs(texts)
+
+    def _forward_positive_probs(self, texts: Sequence[str]) -> list[float]:
+        """Return the max non-O token probability per text (content tokens only)."""
+        tokenized = self.tokenizer(
+            list(texts),
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="pt",
+            return_offsets_mapping=True,
+        )
+        offset_mapping = tokenized.pop("offset_mapping")
+        inputs = {k: v.to(self.device) for k, v in tokenized.items()}
+        logits = self.model(**inputs).logits  # [batch, seq_len, num_labels]
+
+        probs = torch.softmax(logits, dim=-1)
+        # P(token mentions the concept) = 1 - P(O)
+        positive_probs = 1.0 - probs[..., O_LABEL]  # [batch, seq_len]
+
+        # Only consider real text tokens: special tokens have (start_idx, end_idx) == (0, 0) and
+        # padding tokens have attention_mask == 0.
+        offsets = offset_mapping.to(positive_probs.device)
+        content_mask = (offsets[..., 0] != offsets[..., 1]) & inputs[
+            "attention_mask"
+        ].bool()
+
+        # Where a passage has no content tokens, fall back to 0.0.
+        masked = positive_probs.masked_fill(~content_mask, 0.0)
+        return masked.max(dim=-1).values.tolist()
+
     def fit(
         self,
         labelled_passages: list[LabelledPassage],

--- a/knowledge_graph/classifier/classifier.py
+++ b/knowledge_graph/classifier/classifier.py
@@ -336,6 +336,18 @@ class ProbabilityCapableClassifier(ABC):
     overwrites probabilities – like the VotingClassifier.
     """
 
+    @abstractmethod
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """
+        Return per-text positive-class probability P(class=1) in [0, 1].
+
+        Unlike `predict`, which only emits a `Span` (and thus a probability) for
+        positive predictions, this returns a probability for *every* text, including
+        negatives, independent of the threshold/argmax decision. This is needed for
+        threshold calibration and for reporting probabilities on negative predictions.
+        """
+        ...
+
 
 @runtime_checkable
 class VariantEnabledClassifier(Protocol):

--- a/knowledge_graph/classifier/embedding.py
+++ b/knowledge_graph/classifier/embedding.py
@@ -328,6 +328,35 @@ class EmbeddingClassifier(Classifier, ZeroShotClassifier, ProbabilityCapableClas
             )
             threshold = 0.0
 
+        similarities = self._similarities(texts, show_progress_bar=show_progress_bar)
+
+        spans_per_text = []
+        for text, similarity in zip(texts, similarities):
+            spans = []
+            if similarity > threshold:
+                spans = [
+                    Span(
+                        text=text,
+                        concept_id=self.concept.wikibase_id,
+                        prediction_probability=float(similarity),
+                        start_index=0,
+                        end_index=len(text),
+                        labellers=[str(self)],
+                        timestamps=[datetime.now()],
+                    )
+                ]
+            spans_per_text.append(spans)
+
+        return spans_per_text
+
+    def _similarities(
+        self, texts: Sequence[str], show_progress_bar: bool = False
+    ) -> list[float]:
+        """
+        Return the dot product between each text and the concept embedding.
+
+        For normalised embeddings, this is equivalent to the cosine similarity.
+        """
         # get embeddings for all text
         if self._cache is None:
             # if there's no cache, calculate all embeddings
@@ -365,22 +394,8 @@ class EmbeddingClassifier(Classifier, ZeroShotClassifier, ProbabilityCapableClas
 
             keys = cache_keys
 
-        spans_per_text = []
-        for text, key in zip(texts, keys):
-            similarity = float(self.concept_embedding @ embeddings_dict[key].T)
-            spans = []
-            if similarity > threshold:
-                spans = [
-                    Span(
-                        text=text,
-                        concept_id=self.concept.wikibase_id,
-                        prediction_probability=float(similarity),
-                        start_index=0,
-                        end_index=len(text),
-                        labellers=[str(self)],
-                        timestamps=[datetime.now()],
-                    )
-                ]
-            spans_per_text.append(spans)
+        return [float(self.concept_embedding @ embeddings_dict[key].T) for key in keys]
 
-        return spans_per_text
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """Return the per-text cosine similarity to the concept embedding."""
+        return self._similarities(texts)

--- a/knowledge_graph/classifier/targets.py
+++ b/knowledge_graph/classifier/targets.py
@@ -133,6 +133,13 @@ class BaseTargetClassifier(
             results.append(spans)
         return results
 
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """Return the per-text positive-class probability for the target type."""
+        predictions: list[list[dict]] = self.pipeline(
+            texts, padding=True, truncation=True, top_k=None
+        )
+        return [self._get_score(prediction) for prediction in predictions]
+
     def fit(self, **kwargs) -> "BaseTargetClassifier":
         """Targets classifiers cannot be trained directly."""
         warnings.warn(

--- a/tests/test_bert_token_classifier.py
+++ b/tests/test_bert_token_classifier.py
@@ -1,7 +1,10 @@
 """Tests for BertTokenClassifier alignment and span reconstruction utilities."""
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
+import torch
 from transformers import EvalPrediction
 
 from knowledge_graph.classifier.bert_token_classifier import (
@@ -9,6 +12,7 @@ from knowledge_graph.classifier.bert_token_classifier import (
     I_LABEL,
     IGNORE_LABEL,
     O_LABEL,
+    BertTokenClassifier,
     _align_labels_with_tokens,
     _compute_entity_metrics,
     _reconstruct_spans_from_predictions,
@@ -337,3 +341,53 @@ class TestComputeEntityMetrics:
         assert result["precision"] == pytest.approx(0.0)
         assert result["recall"] == pytest.approx(0.0)
         assert result["f1"] == pytest.approx(0.0)
+
+
+class TestPredictProbaBatch:
+    """Tests for BertTokenClassifier.predict_proba_batch (passage-level probability)."""
+
+    @staticmethod
+    def _make_classifier(logits: torch.Tensor, attention_mask, offset_mapping):
+        """Build a classifier with a mocked tokenizer/model (no model download)."""
+        clf = BertTokenClassifier.__new__(BertTokenClassifier)
+        clf._use_dropout_during_inference = False
+        clf.device = "cpu"
+
+        batch = {
+            "input_ids": torch.zeros_like(logits[..., 0], dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask),
+            "offset_mapping": torch.tensor(offset_mapping),
+        }
+        clf.tokenizer = MagicMock(return_value=batch)
+        clf.model = MagicMock(return_value=MagicMock(logits=logits))
+        return clf
+
+    def test_max_non_o_probability_over_content_tokens(self):
+        """Returns max P(not-O) over content tokens; specials/padding are excluded."""
+        # Two passages, seq_len 4, labels [O, B, I]. Peaked logits ⇒ ~one-hot softmax.
+        POS = [0.0, 10.0, 0.0]  # P(not-O) ≈ 1
+        NEG = [10.0, 0.0, 0.0]  # P(not-O) ≈ 0
+        logits = torch.tensor(
+            [
+                # passage 0: [CLS]=O, content=POS, content=NEG, [SEP]=POS(masked)
+                [NEG, POS, NEG, POS],
+                # passage 1: [CLS]=POS(masked), content=NEG, [SEP]=POS(masked), PAD=POS(masked)
+                [POS, NEG, POS, POS],
+            ]
+        )
+        attention_mask = [[1, 1, 1, 1], [1, 1, 1, 0]]
+        # special tokens (and padding) have a zero-width (0, 0) offset
+        offset_mapping = [
+            [[0, 0], [0, 3], [3, 6], [0, 0]],
+            [[0, 0], [0, 3], [0, 0], [0, 0]],
+        ]
+        clf = self._make_classifier(logits, attention_mask, offset_mapping)
+
+        probs = clf.predict_proba_batch(["positive passage", "negative passage"])
+
+        assert len(probs) == 2
+        assert all(0.0 <= p <= 1.0 for p in probs)
+        # passage 0 has a strongly-positive content token; passage 1 does not
+        assert probs[0] > 0.9
+        assert probs[1] < 0.1
+        assert probs[0] > probs[1]

--- a/tests/test_classifier_mixins.py
+++ b/tests/test_classifier_mixins.py
@@ -1,8 +1,11 @@
 """Tests for isinstance behaviour of classifier mixins."""
 
+import pytest
+
 from knowledge_graph.classifier.classifier import (
     Classifier,
     GPUBoundClassifier,
+    ProbabilityCapableClassifier,
     ZeroShotClassifier,
 )
 from knowledge_graph.concept import Concept
@@ -56,3 +59,15 @@ def test_isinstance_for_a_non_gpu_classifier():
     """Test that a non-GPU classifier is not an instance of the GPU marker class."""
     classifier = DummyClassifier(concept)
     assert not isinstance(classifier, GPUBoundClassifier)
+
+
+def test_probability_capable_classifier_requires_predict_proba_batch():
+    """A ProbabilityCapableClassifier subclass must implement predict_proba_batch."""
+
+    class IncompleteProbabilityClassifier(
+        DummyClassifier, ProbabilityCapableClassifier
+    ):
+        """Declares the capability but does not implement the required method."""
+
+    with pytest.raises(TypeError):
+        IncompleteProbabilityClassifier(concept)  # type: ignore[abstract]


### PR DESCRIPTION
As per the docstring in the new `abstractmethod`:

> Unlike `predict`, which only emits a `Span` (and thus a probability) for positive predictions, this returns a probability for *every* text, including negatives, independent of the threshold/argmax decision. This is needed for threshold calibration and for reporting probabilities on negative predictions.

This is so we can keep trusting mixins to implement the methods that are required to use the classifiers they describe downstream. E.g. we can use `if isinstance(classifier, ProbabilityCapableClassifier)` everywhere rather than `if hasattr(classifier, "predict_proba_batch")`.