### PR TITLE
fix: predict script outputs probabilities for negative predictions

### DIFF
--- a/knowledge_graph/classifier/bert_token_classifier.py
+++ b/knowledge_graph/classifier/bert_token_classifier.py
@@ -537,6 +537,51 @@ class BertTokenClassifier(
 
         return batch_labels, batch_probs, offset_mapping
 
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """
+        Return the per-text positive-class probability.
+
+        For this token-level model, the passage-level probability is the maximum
+        probability of any non-O ("B"/"I") prediction across the passage's content
+        tokens, i.e. the model's strongest signal that any token mentions the concept.
+        """
+        if self._use_dropout_during_inference:
+            with self._dropout_enabled():
+                with torch.no_grad():
+                    return self._forward_positive_probs(texts)
+        self.model.eval()  # type: ignore[attr-defined]
+        with torch.no_grad():
+            return self._forward_positive_probs(texts)
+
+    def _forward_positive_probs(self, texts: Sequence[str]) -> list[float]:
+        """Return the max non-O token probability per text (content tokens only)."""
+        tokenized = self.tokenizer(
+            list(texts),
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="pt",
+            return_offsets_mapping=True,
+        )
+        offset_mapping = tokenized.pop("offset_mapping")
+        inputs = {k: v.to(self.device) for k, v in tokenized.items()}
+        logits = self.model(**inputs).logits  # [batch, seq_len, num_labels]
+
+        probs = torch.softmax(logits, dim=-1)
+        # P(token mentions the concept) = 1 - P(O)
+        positive_probs = 1.0 - probs[..., O_LABEL]  # [batch, seq_len]
+
+        # Only consider real text tokens: special tokens have (start_idx, end_idx) == (0, 0) and
+        # padding tokens have attention_mask == 0.
+        offsets = offset_mapping.to(positive_probs.device)
+        content_mask = (offsets[..., 0] != offsets[..., 1]) & inputs[
+            "attention_mask"
+        ].bool()
+
+        # Where a passage has no content tokens, fall back to 0.0.
+        masked = positive_probs.masked_fill(~content_mask, 0.0)
+        return masked.max(dim=-1).values.tolist()
+
     def fit(
         self,
         labelled_passages: list[LabelledPassage],

--- a/knowledge_graph/classifier/classifier.py
+++ b/knowledge_graph/classifier/classifier.py
@@ -336,6 +336,18 @@ class ProbabilityCapableClassifier(ABC):
     overwrites probabilities – like the VotingClassifier.
     """
 
+    @abstractmethod
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """
+        Return per-text positive-class probability P(class=1) in [0, 1].
+
+        Unlike `predict`, which only emits a `Span` (and thus a probability) for
+        positive predictions, this returns a probability for *every* text, including
+        negatives, independent of the threshold/argmax decision. This is needed for
+        threshold calibration and for reporting probabilities on negative predictions.
+        """
+        ...
+
 
 @runtime_checkable
 class VariantEnabledClassifier(Protocol):

--- a/knowledge_graph/classifier/embedding.py
+++ b/knowledge_graph/classifier/embedding.py
@@ -328,6 +328,35 @@ class EmbeddingClassifier(Classifier, ZeroShotClassifier, ProbabilityCapableClas
             )
             threshold = 0.0
 
+        similarities = self._similarities(texts, show_progress_bar=show_progress_bar)
+
+        spans_per_text = []
+        for text, similarity in zip(texts, similarities):
+            spans = []
+            if similarity > threshold:
+                spans = [
+                    Span(
+                        text=text,
+                        concept_id=self.concept.wikibase_id,
+                        prediction_probability=float(similarity),
+                        start_index=0,
+                        end_index=len(text),
+                        labellers=[str(self)],
+                        timestamps=[datetime.now()],
+                    )
+                ]
+            spans_per_text.append(spans)
+
+        return spans_per_text
+
+    def _similarities(
+        self, texts: Sequence[str], show_progress_bar: bool = False
+    ) -> list[float]:
+        """
+        Return the dot product between each text and the concept embedding.
+
+        For normalised embeddings, this is equivalent to the cosine similarity.
+        """
         # get embeddings for all text
         if self._cache is None:
             # if there's no cache, calculate all embeddings
@@ -365,22 +394,8 @@ class EmbeddingClassifier(Classifier, ZeroShotClassifier, ProbabilityCapableClas
 
             keys = cache_keys
 
-        spans_per_text = []
-        for text, key in zip(texts, keys):
-            similarity = float(self.concept_embedding @ embeddings_dict[key].T)
-            spans = []
-            if similarity > threshold:
-                spans = [
-                    Span(
-                        text=text,
-                        concept_id=self.concept.wikibase_id,
-                        prediction_probability=float(similarity),
-                        start_index=0,
-                        end_index=len(text),
-                        labellers=[str(self)],
-                        timestamps=[datetime.now()],
-                    )
-                ]
-            spans_per_text.append(spans)
+        return [float(self.concept_embedding @ embeddings_dict[key].T) for key in keys]
 
-        return spans_per_text
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """Return the per-text cosine similarity to the concept embedding."""
+        return self._similarities(texts)

--- a/knowledge_graph/classifier/targets.py
+++ b/knowledge_graph/classifier/targets.py
@@ -133,6 +133,13 @@ class BaseTargetClassifier(
             results.append(spans)
         return results
 
+    def predict_proba_batch(self, texts: Sequence[str]) -> list[float]:
+        """Return the per-text positive-class probability for the target type."""
+        predictions: list[list[dict]] = self.pipeline(
+            texts, padding=True, truncation=True, top_k=None
+        )
+        return [self._get_score(prediction) for prediction in predictions]
+
     def fit(self, **kwargs) -> "BaseTargetClassifier":
         """Targets classifiers cannot be trained directly."""
         warnings.warn(

--- a/knowledge_graph/labelled_passage.py
+++ b/knowledge_graph/labelled_passage.py
@@ -200,19 +200,25 @@ def labelled_passages_to_dataframe(
 
     boolean_predictions = [bool(lp.spans) for lp in labelled_passages]
 
-    if all(
-        [
-            span.prediction_probability is None
-            for lp in labelled_passages
-            for span in lp.spans
-        ]
-    ):
+    # Positives carry their probability on spans; negatives (no spans) carry it on
+    # metadata["prediction_probability"], if the classifier produced one.
+    has_span_probability = any(
+        span.prediction_probability is not None
+        for lp in labelled_passages
+        for span in lp.spans
+    )
+    has_metadata_probability = any(
+        lp.metadata.get("prediction_probability") is not None
+        for lp in labelled_passages
+    )
+
+    if not has_span_probability and not has_metadata_probability:
         prediction_probabilities = [None] * len(labelled_passages)
     else:
         prediction_probabilities = [
             max([span.prediction_probability or 0 for span in lp.spans])
             if lp.spans
-            else 0
+            else lp.metadata.get("prediction_probability", 0)
             for lp in labelled_passages
         ]
 

--- a/knowledge_graph/labelling.py
+++ b/knowledge_graph/labelling.py
@@ -24,6 +24,7 @@ from dotenv import find_dotenv, load_dotenv
 from pydantic import SecretStr
 
 from knowledge_graph.classifier import Classifier
+from knowledge_graph.classifier.classifier import ProbabilityCapableClassifier
 from knowledge_graph.concept import Concept
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelled_passage import (
@@ -778,11 +779,16 @@ def label_passages_with_classifier(
     labelled_passages: list[LabelledPassage],
     batch_size: int = 16,
     show_progress: bool = False,
+    include_prediction_probabilities: bool = False,
 ) -> list[LabelledPassage]:
     """
     Label passages using the provided classifier.
 
     Overwrites any spans that already exist in the labelled passages.
+
+    If `include_prediction_probabilities` is set and the classifier is a
+    `ProbabilityCapableClassifier`, the passage-level P(class=1) is stored under
+    `metadata["prediction_probability"]` on every output passage, including negatives.
     """
 
     input_texts = [lp.text for lp in labelled_passages]
@@ -792,13 +798,23 @@ def label_passages_with_classifier(
         show_progress=show_progress,
     )
 
-    output_labelled_passages = [
-        labelled_passage.model_copy(
-            update={"spans": model_predicted_spans[idx]},
-            deep=True,
+    prediction_probabilities: list[float] | None = None
+    if include_prediction_probabilities and isinstance(
+        classifier, ProbabilityCapableClassifier
+    ):
+        prediction_probabilities = classifier.predict_proba_batch(input_texts)
+
+    output_labelled_passages = []
+    for idx, labelled_passage in enumerate(labelled_passages):
+        update: dict = {"spans": model_predicted_spans[idx]}
+        if prediction_probabilities is not None:
+            update["metadata"] = {
+                **labelled_passage.metadata,
+                "prediction_probability": prediction_probabilities[idx],
+            }
+        output_labelled_passages.append(
+            labelled_passage.model_copy(update=update, deep=True)
         )
-        for idx, labelled_passage in enumerate(labelled_passages)
-    ]
 
     return output_labelled_passages
 

--- a/knowledge_graph/wandb_helpers.py
+++ b/knowledge_graph/wandb_helpers.py
@@ -115,7 +115,10 @@ def log_labelled_passages_table_to_wandb_run(
         df["spans"] = df["spans"].apply(json.dumps)
 
     prediction_probabilities = [
-        max((s.prediction_probability or 0.0) for s in p.spans) if p.spans else None
+        max((s.prediction_probability or 0.0) for s in p.spans)
+        if p.spans
+        # negatives have no spans; fall back to the passage-level probability if set
+        else p.metadata.get("prediction_probability")
         for p in labelled_passages
     ]
 

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -334,6 +334,7 @@ async def run_prediction(
                     labelled_passages=batch,
                     batch_size=batch_size,
                     show_progress=True,
+                    include_prediction_probabilities=True,
                 )
 
                 passages_processed += len(batch)
@@ -497,6 +498,10 @@ def main(
 
     Saves predicted passages to a local directory. Tracks the run and uploads results
     if `track_and_upload` is set.
+
+    For probability-capable classifiers inference is run twice per passage – once to
+    get the prediction, and once to get the prediction probability. This is due to the
+    fact that we only store `Span` objects for *positive* predictions.
     """
     if use_prefect:
         flow_name = "predict-adhoc"

--- a/tests/test_bert_token_classifier.py
+++ b/tests/test_bert_token_classifier.py
@@ -1,7 +1,10 @@
 """Tests for BertTokenClassifier alignment and span reconstruction utilities."""
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
+import torch
 from transformers import EvalPrediction
 
 from knowledge_graph.classifier.bert_token_classifier import (
@@ -9,6 +12,7 @@ from knowledge_graph.classifier.bert_token_classifier import (
     I_LABEL,
     IGNORE_LABEL,
     O_LABEL,
+    BertTokenClassifier,
     _align_labels_with_tokens,
     _compute_entity_metrics,
     _reconstruct_spans_from_predictions,
@@ -337,3 +341,53 @@ class TestComputeEntityMetrics:
         assert result["precision"] == pytest.approx(0.0)
         assert result["recall"] == pytest.approx(0.0)
         assert result["f1"] == pytest.approx(0.0)
+
+
+class TestPredictProbaBatch:
+    """Tests for BertTokenClassifier.predict_proba_batch (passage-level probability)."""
+
+    @staticmethod
+    def _make_classifier(logits: torch.Tensor, attention_mask, offset_mapping):
+        """Build a classifier with a mocked tokenizer/model (no model download)."""
+        clf = BertTokenClassifier.__new__(BertTokenClassifier)
+        clf._use_dropout_during_inference = False
+        clf.device = "cpu"
+
+        batch = {
+            "input_ids": torch.zeros_like(logits[..., 0], dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask),
+            "offset_mapping": torch.tensor(offset_mapping),
+        }
+        clf.tokenizer = MagicMock(return_value=batch)
+        clf.model = MagicMock(return_value=MagicMock(logits=logits))
+        return clf
+
+    def test_max_non_o_probability_over_content_tokens(self):
+        """Returns max P(not-O) over content tokens; specials/padding are excluded."""
+        # Two passages, seq_len 4, labels [O, B, I]. Peaked logits ⇒ ~one-hot softmax.
+        POS = [0.0, 10.0, 0.0]  # P(not-O) ≈ 1
+        NEG = [10.0, 0.0, 0.0]  # P(not-O) ≈ 0
+        logits = torch.tensor(
+            [
+                # passage 0: [CLS]=O, content=POS, content=NEG, [SEP]=POS(masked)
+                [NEG, POS, NEG, POS],
+                # passage 1: [CLS]=POS(masked), content=NEG, [SEP]=POS(masked), PAD=POS(masked)
+                [POS, NEG, POS, POS],
+            ]
+        )
+        attention_mask = [[1, 1, 1, 1], [1, 1, 1, 0]]
+        # special tokens (and padding) have a zero-width (0, 0) offset
+        offset_mapping = [
+            [[0, 0], [0, 3], [3, 6], [0, 0]],
+            [[0, 0], [0, 3], [0, 0], [0, 0]],
+        ]
+        clf = self._make_classifier(logits, attention_mask, offset_mapping)
+
+        probs = clf.predict_proba_batch(["positive passage", "negative passage"])
+
+        assert len(probs) == 2
+        assert all(0.0 <= p <= 1.0 for p in probs)
+        # passage 0 has a strongly-positive content token; passage 1 does not
+        assert probs[0] > 0.9
+        assert probs[1] < 0.1
+        assert probs[0] > probs[1]

--- a/tests/test_classifier_mixins.py
+++ b/tests/test_classifier_mixins.py
@@ -1,8 +1,11 @@
 """Tests for isinstance behaviour of classifier mixins."""
 
+import pytest
+
 from knowledge_graph.classifier.classifier import (
     Classifier,
     GPUBoundClassifier,
+    ProbabilityCapableClassifier,
     ZeroShotClassifier,
 )
 from knowledge_graph.concept import Concept
@@ -56,3 +59,15 @@ def test_isinstance_for_a_non_gpu_classifier():
     """Test that a non-GPU classifier is not an instance of the GPU marker class."""
     classifier = DummyClassifier(concept)
     assert not isinstance(classifier, GPUBoundClassifier)
+
+
+def test_probability_capable_classifier_requires_predict_proba_batch():
+    """A ProbabilityCapableClassifier subclass must implement predict_proba_batch."""
+
+    class IncompleteProbabilityClassifier(
+        DummyClassifier, ProbabilityCapableClassifier
+    ):
+        """Declares the capability but does not implement the required method."""
+
+    with pytest.raises(TypeError):
+        IncompleteProbabilityClassifier(concept)  # type: ignore[abstract]

--- a/tests/test_labelled_passage.py
+++ b/tests/test_labelled_passage.py
@@ -297,6 +297,52 @@ def test_labelled_passages_to_dataframe_without_probabilities(
     assert df["prediction_probability"].tolist() == [None, None]
 
 
+def test_labelled_passages_to_dataframe_uses_metadata_probability_for_negatives():
+    """Negatives (no spans) take their probability from metadata["prediction_probability"]."""
+    passages = [
+        LabelledPassage(
+            text="positive passage",
+            spans=[
+                Span(
+                    text="positive passage",
+                    start_index=0,
+                    end_index=16,
+                    concept_id="Q123",
+                    prediction_probability=0.8,
+                )
+            ],
+            metadata={"prediction_probability": 0.8},
+        ),
+        LabelledPassage(
+            text="negative passage",
+            spans=[],
+            metadata={"prediction_probability": 0.2},
+        ),
+    ]
+
+    df = labelled_passages_to_dataframe(passages)
+
+    assert df["prediction"].tolist() == [True, False]
+    assert df["prediction_probability"].tolist() == [0.8, 0.2]
+
+
+def test_labelled_passages_to_dataframe_all_negatives_with_metadata_probability():
+    """An all-negative batch still surfaces metadata probabilities (no spans at all)."""
+    passages = [
+        LabelledPassage(
+            text="neg one", spans=[], metadata={"prediction_probability": 0.1}
+        ),
+        LabelledPassage(
+            text="neg two", spans=[], metadata={"prediction_probability": 0.3}
+        ),
+    ]
+
+    df = labelled_passages_to_dataframe(passages)
+
+    assert df["prediction"].tolist() == [False, False]
+    assert df["prediction_probability"].tolist() == [0.1, 0.3]
+
+
 def test_dataframe_to_labelled_passages_without_human_labels():
     """Test that passages created without human labels have no spans."""
     df = pd.DataFrame(

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -7,12 +7,16 @@ from argilla import Dataset, ResponseStatus
 from hypothesis import given
 from hypothesis import strategies as st
 
-from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.classifier import Classifier
+from knowledge_graph.classifier.classifier import ProbabilityCapableClassifier
+from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import ClassifierID, WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.labelling import (
     ArgillaSession,
     ResourceAlreadyExistsError,
     ResourceDoesNotExistError,
+    label_passages_with_classifier,
 )
 from knowledge_graph.span import Span
 
@@ -986,3 +990,58 @@ def test_whether_format_metadata_replaces_dots_with_hyphens(metadata):
         result = session._format_metadata_keys_for_argilla(metadata)
         for key in result.keys():
             assert "." not in key, f"Key '{key}' contains a dot"
+
+
+class _DummyProbaClassifier(Classifier, ProbabilityCapableClassifier):
+    """A dummy probability-capable classifier; positive if 'yes' is in the text."""
+
+    def _predict(self, text: str, threshold: float | None = None) -> list[Span]:
+        if "yes" in text:
+            return [
+                Span(
+                    text=text,
+                    start_index=0,
+                    end_index=len(text),
+                    concept_id=self.concept.wikibase_id,
+                    prediction_probability=0.9,
+                )
+            ]
+        return []
+
+    def predict_proba_batch(self, texts) -> list[float]:
+        return [0.9 if "yes" in t else 0.1 for t in texts]
+
+    @property
+    def id(self) -> ClassifierID:
+        return ClassifierID("dummyprb")
+
+
+def test_label_passages_attaches_prediction_probabilities_when_requested():
+    """Every output passage (incl. spanless negatives) carries the passage-level prob."""
+    classifier = _DummyProbaClassifier(Concept(wikibase_id="Q1", preferred_label="t"))
+    passages = [
+        LabelledPassage(text="yes positive", spans=[], metadata={"existing": "v"}),
+        LabelledPassage(text="no negative", spans=[]),
+    ]
+
+    result = label_passages_with_classifier(
+        classifier, passages, include_prediction_probabilities=True
+    )
+
+    # span presence still distinguishes positive from negative
+    assert [bool(p.spans) for p in result] == [True, False]
+    # both carry the passage-level probability
+    assert result[0].metadata["prediction_probability"] == 0.9
+    assert result[1].metadata["prediction_probability"] == 0.1
+    # pre-existing metadata is preserved
+    assert result[0].metadata["existing"] == "v"
+
+
+def test_label_passages_omits_prediction_probabilities_by_default():
+    """Without the opt-in flag, metadata is left untouched."""
+    classifier = _DummyProbaClassifier(Concept(wikibase_id="Q1", preferred_label="t"))
+    passages = [LabelledPassage(text="no negative", spans=[])]
+
+    result = label_passages_with_classifier(classifier, passages)
+
+    assert "prediction_probability" not in result[0].metadata


### PR DESCRIPTION
- adds `include_prediction_probabilities` argument for `label_passages_with_classifier` method, which adds probabilities of negative predictions in labelled passage metadata
- predict and model evaluate generate prediction probabilities for negative examples
- test that probabilities of negatives are returned by `labelled_passages_to_dataframe`

you can see it work in the `runs["summary"].passages` table in [this W&B run](https://wandb.ai/climatepolicyradar/Q912/runs/xf4bjvqc?nw=nwuserkdutia)

<img width="1442" height="672" alt="image" src="https://github.com/user-attachments/assets/b6982316-61de-4a1a-9e3b-5f62fc1e63d8" />
