### PR TITLE
fix: recover vibe checker webapp lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ eggs/
 .eggs/
 lib/
 lib64/
+# The Python `lib/` rule above is unanchored, so it also matches the first-party
+# Next.js lib dir in the vibe-checker webapp. Keep that one tracked.
+!/vibe-checker/webapp/lib/
 parts/
 sdist/
 var/

--- a/vibe-checker/webapp/lib/api-response.ts
+++ b/vibe-checker/webapp/lib/api-response.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+export function successResponse<T>(data: T, status = 200) {
+  return NextResponse.json({ success: true, data }, { status });
+}
+
+export function errorResponse(error: unknown, status = 500) {
+  let message = "Unknown error";
+  let statusCode = status;
+
+  if (error instanceof Error) {
+    message = error.message;
+
+    if (
+      error.name === "CredentialsProviderError" ||
+      error.message.includes("Token is expired")
+    ) {
+      message =
+        "AWS credentials have expired. Please run 'aws sso login' to refresh your session.";
+      statusCode = 503;
+    } else if (
+      error.message.includes("BUCKET_NAME environment variable is not set")
+    ) {
+      message =
+        "Server configuration error: S3 bucket name is not configured.";
+      statusCode = 500;
+    } else if (error.message.includes("No body in S3 response")) {
+      message = "Failed to retrieve data from storage.";
+      statusCode = 502;
+    }
+  }
+
+  console.error("API Error:", error);
+  return NextResponse.json(
+    { success: false, error: message },
+    { status: statusCode },
+  );
+}

--- a/vibe-checker/webapp/lib/cache.ts
+++ b/vibe-checker/webapp/lib/cache.ts
@@ -1,0 +1,8 @@
+import NodeCache from "node-cache";
+
+/**
+ * In-memory cache shared across API routes. Entries expire after 15 minutes.
+ */
+const cache = new NodeCache({ stdTTL: 900, checkperiod: 120 });
+
+export default cache;

--- a/vibe-checker/webapp/lib/concept-helpers.ts
+++ b/vibe-checker/webapp/lib/concept-helpers.ts
@@ -1,0 +1,14 @@
+import { ConceptData, EnhancedConcept } from "@/types/concepts";
+
+/**
+ * Apply default values to a concept record so downstream UI can rely on every
+ * field being present.
+ */
+export function enrichConceptData(concept: ConceptData): EnhancedConcept {
+  return {
+    wikibase_id: concept.wikibase_id,
+    preferred_label: concept.preferred_label || concept.wikibase_id,
+    description: concept.description || `Concept ${concept.wikibase_id}`,
+    n_classifiers: concept.n_classifiers || 0,
+  };
+}

--- a/vibe-checker/webapp/lib/constants.ts
+++ b/vibe-checker/webapp/lib/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared constants for the vibe-checker webapp.
+ */
+
+export const PAGINATION = {
+  DEFAULT_PAGE_SIZE: 50,
+  MIN_PAGE: 1,
+};
+
+export const PUBLICATION_YEARS = {
+  MIN: 1990,
+  MAX: 2030,
+};
+
+export const DEBOUNCE = {
+  SEARCH: 300,
+  FILTERS: 500,
+};

--- a/vibe-checker/webapp/lib/prediction-filters.ts
+++ b/vibe-checker/webapp/lib/prediction-filters.ts
@@ -1,0 +1,73 @@
+import { FilterParams } from "@/types/filters";
+import { Prediction } from "@/types/predictions";
+
+/**
+ * Apply the user-selected filters to a set of predictions, in-memory.
+ */
+export function filterPredictions(
+  predictions: Prediction[],
+  filters: FilterParams,
+): Prediction[] {
+  return predictions.filter((prediction) => {
+    const metadata = prediction.metadata;
+
+    if (
+      filters.translated !== undefined &&
+      (metadata.translated === "True") !== filters.translated
+    ) {
+      return false;
+    }
+
+    if (
+      filters.corpus_type &&
+      metadata["document_metadata.corpus_type_name"] !== filters.corpus_type
+    ) {
+      return false;
+    }
+
+    if (
+      filters.world_bank_region &&
+      metadata.world_bank_region !== filters.world_bank_region
+    ) {
+      return false;
+    }
+
+    if (filters.publication_year_start || filters.publication_year_end) {
+      const year = new Date(
+        metadata["document_metadata.publication_ts"],
+      ).getFullYear();
+      if (
+        (filters.publication_year_start &&
+          year < filters.publication_year_start) ||
+        (filters.publication_year_end && year > filters.publication_year_end)
+      ) {
+        return false;
+      }
+    }
+
+    if (
+      filters.document_id &&
+      !metadata.document_id
+        .toLowerCase()
+        .includes(filters.document_id.toLowerCase())
+    ) {
+      return false;
+    }
+
+    if (filters.search) {
+      try {
+        const regex = new RegExp(filters.search.trim(), "i");
+        if (!regex.test(prediction.text)) return false;
+      } catch {
+        const term = filters.search.toLowerCase().trim();
+        if (!prediction.text.toLowerCase().includes(term)) return false;
+      }
+    }
+
+    return (
+      filters.has_predictions === undefined ||
+      (prediction.spans && prediction.spans.length > 0) ===
+        filters.has_predictions
+    );
+  });
+}

--- a/vibe-checker/webapp/lib/s3.ts
+++ b/vibe-checker/webapp/lib/s3.ts
@@ -1,0 +1,68 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { GetParameterCommand, SSMClient } from "@aws-sdk/client-ssm";
+import { fromContainerMetadata, fromIni } from "@aws-sdk/credential-providers";
+
+const region = process.env.AWS_REGION || "eu-west-1";
+
+/**
+ * Use container credentials when running on ECS, otherwise fall back to a local
+ * named profile (defaults to "labs").
+ */
+function getCredentials() {
+  const isEcs = !!process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+  return isEcs
+    ? fromContainerMetadata()
+    : fromIni({ profile: process.env.AWS_PROFILE || "labs" });
+}
+
+async function getSsmParameter(name: string): Promise<string> {
+  const client = new SSMClient({ region, credentials: getCredentials() });
+  try {
+    const response = await client.send(
+      new GetParameterCommand({ Name: name, WithDecryption: false }),
+    );
+    return (
+      response.Parameter?.Value ??
+      (() => {
+        throw new Error(`Parameter ${name} has no value`);
+      })()
+    );
+  } catch (error) {
+    throw new Error(
+      `Failed to retrieve ${name}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+export function createS3Client(): S3Client {
+  return new S3Client({ region, credentials: getCredentials() });
+}
+
+let cachedBucketName: string | null = null;
+let inFlightBucketName: Promise<string> | null = null;
+
+export async function getBucketName(): Promise<string> {
+  if (cachedBucketName !== null) {
+    return cachedBucketName;
+  }
+  if (inFlightBucketName !== null) {
+    return inFlightBucketName;
+  }
+  inFlightBucketName = (async () => {
+    try {
+      cachedBucketName = await getSsmParameter("/vibe-checker/bucket-name");
+      return cachedBucketName;
+    } catch (error) {
+      throw new Error(
+        `Failed to get bucket name: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } finally {
+      inFlightBucketName = null;
+    }
+  })();
+  return inFlightBucketName;
+}

--- a/vibe-checker/webapp/lib/urls.ts
+++ b/vibe-checker/webapp/lib/urls.ts
@@ -1,0 +1,20 @@
+/**
+ * Helpers for building external URLs (CPR app, Wikibase).
+ */
+
+export function buildDocumentUrl(
+  documentSlug: string,
+  familySlug: string,
+  pageNumber: number,
+): string {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_CPR_APP_URL || "https://app.climatepolicyradar.org";
+  return `${baseUrl}/documents/${documentSlug}?page=${pageNumber}&id=${familySlug}`;
+}
+
+export function buildWikibaseUrl(conceptId: string): string {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_WIKIBASE_URL ||
+    "https://climatepolicyradar.wikibase.cloud";
+  return `${baseUrl}/wiki/Item:${conceptId}`;
+}


### PR DESCRIPTION
a `.gitignore` hiccup meant a bunch of the vibe checker files were only on harrison's machine 😬 😮‍💨 🤦 

fortunately, claude managed to recover the files from labs ECR. confirmed that an `npm run build` works

``` text
vibe-checker/webapp 16:37 ‹fix/vibe-checker-webapp-lib› » npm run build

> webapp@0.1.0 build
> next build

   ▲ Next.js 15.5.2

   Creating an optimized production build ...
 ✓ Compiled successfully in 2.3s
 ✓ Linting and checking validity of types
 ✓ Collecting page data
 ✓ Generating static pages (7/7)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                                                     Size  First Load JS
┌ ○ /                                                         2.2 kB         110 kB
├ ○ /_not-found                                                995 B         103 kB
├ ƒ /[concept_id]                                            2.53 kB         108 kB
├ ƒ /[concept_id]/[classifier_id]                              54 kB         165 kB
├ ƒ /api/concepts                                              141 B         102 kB
├ ƒ /api/concepts/[concept_id]/classifiers                     141 B         102 kB
├ ƒ /api/concepts/[concept_id]/classifiers/[classifier_id]     141 B         102 kB
├ ƒ /api/health                                                141 B         102 kB
├ ƒ /api/predictions/[wikibase_id]/[classifier_id]             141 B         102 kB
├ ƒ /api/predictions/[wikibase_id]/[classifier_id]/download    141 B         102 kB
└ ○ /icon                                                      141 B         102 kB
+ First Load JS shared by all                                 102 kB
  ├ chunks/255-e3bf15caf1f1e0f9.js                           45.8 kB
  ├ chunks/4bd1b696-c023c6e3521b1417.js                      54.2 kB
  └ other shared chunks (total)                              1.92 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
``` 