### PR TITLE
fix: adds geography csv to docker (SCI-835)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,6 +51,7 @@ htmlcov/
 
 # Local development
 data/
+!data/raw/geography-iso-3166.csv
 *.log
 .env
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ artifacts/*
 
 !data/raw/litigation-non-us.csv
 !data/raw/litigation-us.csv
+!data/raw/geography-iso-3166.csv
 
 tmp/
 scratch/

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY flows ./flows/
 COPY scripts ./scripts/
 COPY static_sites ./static_sites/
 COPY vibe-checker ./vibe-checker/
+COPY data/raw/geography-iso-3166.csv ./data/raw/geography-iso-3166.csv
 
 # Install the project
 RUN uv pip install --system -e .


### PR DESCRIPTION
The `kg-build-dataset` flow crashed on first run because`knowledge_graph/geography.py` reads `geography-iso-3166.csv` at module import time, and the file wasn't present in the Docker image.

### What's changed

- Un-gitignored `data/raw/geography-iso-3166.csv`
- Added it to the Dockerfile so it's copied into the image

### Root cause

`build_dataset_flow.py` is the first flow to import from `scripts/`, which chains to `knowledge_graph.geography`, which does a top-level `pd.read_csv()` on import. Other flows never triggered this code path so it wasn't caught earlier.
