### PR TITLE
fix: base64-decode Snowflake private key from SSM

### DIFF
--- a/flows/build_dataset_flow.py
+++ b/flows/build_dataset_flow.py
@@ -10,6 +10,7 @@ locally with: just build-dataset-download
 """
 
 import asyncio
+import base64
 import io
 from typing import cast
 
@@ -45,7 +46,9 @@ async def _set_up_build_dataset_environment(
     snowflake_account = get_aws_ssm_param(SNOWFLAKE_ACCOUNT_SSM, aws_env=aws_env)
     snowflake_user = get_aws_ssm_param(SNOWFLAKE_USER_SSM, aws_env=aws_env)
     snowflake_private_key = SecretStr(
-        get_aws_ssm_param(SNOWFLAKE_PRIVATE_KEY_SSM, aws_env=aws_env)
+        base64.b64decode(
+            get_aws_ssm_param(SNOWFLAKE_PRIVATE_KEY_SSM, aws_env=aws_env)
+        ).decode("utf-8")
     )
 
     return config, snowflake_account, snowflake_user, snowflake_private_key


### PR DESCRIPTION
The `kg-build-dataset` flow was failing with `MalformedFraming` when trying to load the Snowflake private key. 

The key is stored base64-encoded in SSM, but the code was passing the raw string directly to `load_pem_private_key`, which expects PEM bytes.

Fixed by base64-decoding the key after reading from SSM, this is how it's done in the data lake repo for the same SSM parameter. 

### What's changed

- `flows/build_dataset_flow.py`: base64-decode the private key from SSM before passing it to `run_build_dataset`
