### PR TITLE
fix: force microsecond precision when fetching Snowflake results

### DIFF
--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -140,7 +140,7 @@ def run_build_dataset(
     """
 
     cur.execute(full_query)
-    df_full = cur.fetch_pandas_all()
+    df_full = cur.fetch_pandas_all(force_microsecond_precision=True)
 
     presample_query = f"""
     WITH filtered_data AS (
@@ -196,7 +196,7 @@ def run_build_dataset(
     """
 
     cur.execute(presample_query)
-    df = cur.fetch_pandas_all()
+    df = cur.fetch_pandas_all(force_microsecond_precision=True)
     con.close()
 
     logger = get_logger()


### PR DESCRIPTION
The build_dataset flow was failing with `ArrowInvalid: Schema at index 68 was different` because Snowflake returns large result sets in parallel batches, and some batches had `timestamp[ns]` while others had `timestamp[us]` for `DOCUMENT_METADATA_PUBLICATION_TS`. PyArrow refuses to concatenate batches with inconsistent schemas.

Fixed by passing `force_microsecond_precision=True` to both `fetch_pandas_all()` calls in `run_build_dataset`, forcing consistent microsecond precision across all batches.

I managed to reproduce error locally, and this should fix it