### PR TITLE
fix: fetches WANDB_API_KEY from SSM in push_new_dataset

### DIFF
--- a/flows/config.py
+++ b/flows/config.py
@@ -24,6 +24,7 @@ WIKIBASE_USERNAME_SSM_NAME = "/Wikibase/Cloud/ServiceAccount/Username"
 WIKIBASE_URL_SSM_NAME = "/Wikibase/Cloud/URL"
 ARGILLA_URL_SSM_NAME = "/Argilla/APIURL"
 ARGILLA_API_KEY_SSM_NAME = "/Argilla/Owner/APIKey"
+WANDB_API_KEY_SSM_NAME = "WANDB_API_KEY"
 
 
 def validate_s3_prefix(value: str) -> str:
@@ -221,6 +222,17 @@ class Config(BaseModel):
                     pass
                 else:
                     raise
+
+        if not config.wandb_api_key:
+            try:
+                config.wandb_api_key = SecretStr(
+                    get_aws_ssm_param(
+                        WANDB_API_KEY_SSM_NAME,
+                        aws_env=config.aws_env,
+                    )
+                )
+            except Exception:
+                logger.debug("allowing no W&B API key parameter")
 
         return config
 

--- a/flows/predict.py
+++ b/flows/predict.py
@@ -23,8 +23,8 @@ async def _set_up_prediction_environment(
     if not config:
         config = await Config.create()
 
-    wandb_api_key = SecretStr(get_aws_ssm_param("WANDB_API_KEY", aws_env=aws_env))
-    wandb.login(key=wandb_api_key.get_secret_value())
+    if config.wandb_api_key:
+        wandb.login(key=config.wandb_api_key.get_secret_value())
 
     openrouter_api_key = SecretStr(
         get_aws_ssm_param("/OpenRouter/KGApiKey", aws_env=aws_env)

--- a/flows/push_new_dataset.py
+++ b/flows/push_new_dataset.py
@@ -2,9 +2,10 @@ from typing import Annotated, Optional
 
 import wandb
 from prefect import flow
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from flows.config import Config
+from knowledge_graph.cloud import get_aws_ssm_param
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelling import ArgillaSession
 from knowledge_graph.utils import get_logger
@@ -44,8 +45,13 @@ async def push_new_dataset(
     if not config:
         config = await Config.create()
 
-    if config.wandb_api_key:
-        wandb.login(key=config.wandb_api_key.get_secret_value())
+    try:
+        wandb_api_key = SecretStr(
+            get_aws_ssm_param("WANDB_API_KEY", aws_env=config.aws_env)
+        )
+        wandb.login(key=wandb_api_key.get_secret_value())
+    except Exception:
+        logger.warning("WANDB_API_KEY not found in SSM, falling back to env var")
 
     labelled_passages = load_labelled_passages_from_wandb(
         wandb_path=wandb_artifact_path

--- a/flows/push_new_dataset.py
+++ b/flows/push_new_dataset.py
@@ -2,10 +2,9 @@ from typing import Annotated, Optional
 
 import wandb
 from prefect import flow
-from pydantic import Field, SecretStr
+from pydantic import Field
 
 from flows.config import Config
-from knowledge_graph.cloud import get_aws_ssm_param
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelling import ArgillaSession
 from knowledge_graph.utils import get_logger
@@ -45,13 +44,8 @@ async def push_new_dataset(
     if not config:
         config = await Config.create()
 
-    try:
-        wandb_api_key = SecretStr(
-            get_aws_ssm_param("WANDB_API_KEY", aws_env=config.aws_env)
-        )
-        wandb.login(key=wandb_api_key.get_secret_value())
-    except Exception:
-        logger.warning("WANDB_API_KEY not found in SSM, falling back to env var")
+    if config.wandb_api_key:
+        wandb.login(key=config.wandb_api_key.get_secret_value())
 
     labelled_passages = load_labelled_passages_from_wandb(
         wandb_path=wandb_artifact_path

--- a/flows/train.py
+++ b/flows/train.py
@@ -7,10 +7,9 @@ import boto3
 import wandb
 import yaml
 from prefect import flow
-from pydantic import SecretStr
 
 from flows.config import Config
-from knowledge_graph.cloud import AwsEnv, get_aws_ssm_param
+from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelling import ArgillaConfig
 from knowledge_graph.utils import get_logger
@@ -40,8 +39,8 @@ async def _set_up_training_environment(
     ):
         raise ValueError("Missing values in config.")
 
-    wandb_api_key = SecretStr(get_aws_ssm_param("WANDB_API_KEY", aws_env=aws_env))
-    wandb.login(key=wandb_api_key.get_secret_value())
+    if config.wandb_api_key:
+        wandb.login(key=config.wandb_api_key.get_secret_value())
 
     wikibase_config = WikibaseConfig(
         username=config.wikibase_username,

--- a/tests/flows/test_push_new_dataset.py
+++ b/tests/flows/test_push_new_dataset.py
@@ -24,13 +24,11 @@ def patched_push_dependencies(labelled_passages, mock_concept, test_config):
     with (
         patch("flows.push_new_dataset.load_labelled_passages_from_wandb") as mock_load,
         patch("flows.push_new_dataset.wandb.login") as mock_wandb_login,
-        patch("flows.push_new_dataset.get_aws_ssm_param") as mock_ssm,
         patch("flows.push_new_dataset.Config") as mock_config_cls,
         patch("flows.push_new_dataset.ArgillaSession") as mock_argilla_cls,
         patch("flows.push_new_dataset.WikibaseSession") as mock_wikibase_cls,
     ):
         mock_load.return_value = labelled_passages
-        mock_ssm.return_value = "test-wandb-api-key"
         mock_config_cls.create = AsyncMock(return_value=test_config)
 
         mock_argilla = MagicMock()
@@ -43,7 +41,6 @@ def patched_push_dependencies(labelled_passages, mock_concept, test_config):
         yield {
             "load": mock_load,
             "wandb_login": mock_wandb_login,
-            "ssm": mock_ssm,
             "argilla": mock_argilla,
             "argilla_cls": mock_argilla_cls,
             "wikibase_cls": mock_wikibase_cls,
@@ -67,10 +64,10 @@ async def test_push_new_dataset_loads_passages_from_wandb_artifact(
 
 
 @pytest.mark.asyncio
-async def test_push_new_dataset_logs_into_wandb_using_ssm_key(
+async def test_push_new_dataset_logs_into_wandb_when_api_key_present(
     patched_push_dependencies, test_config
 ):
-    """The flow should fetch the W&B API key from SSM and call wandb.login."""
+    """The flow should call wandb.login when the config has a W&B API key."""
     await push_new_dataset(
         wikibase_id=WikibaseID("Q787"),
         wandb_artifact_path="climatepolicyradar/Q787/labelled-passages:v0",
@@ -78,21 +75,21 @@ async def test_push_new_dataset_logs_into_wandb_using_ssm_key(
     )
 
     patched_push_dependencies["wandb_login"].assert_called_once_with(
-        key="test-wandb-api-key"
+        key=test_config.wandb_api_key.get_secret_value()
     )
 
 
 @pytest.mark.asyncio
-async def test_push_new_dataset_skips_wandb_login_when_ssm_fetch_fails(
+async def test_push_new_dataset_skips_wandb_login_without_api_key(
     patched_push_dependencies, test_config
 ):
-    """The flow should not call wandb.login when the SSM fetch fails."""
-    patched_push_dependencies["ssm"].side_effect = Exception("SSM unavailable")
+    """The flow should not call wandb.login when the config has no W&B API key."""
+    config_no_key = test_config.model_copy(update={"wandb_api_key": None})
 
     await push_new_dataset(
         wikibase_id=WikibaseID("Q787"),
         wandb_artifact_path="climatepolicyradar/Q787/labelled-passages:v0",
-        config=test_config,
+        config=config_no_key,
     )
 
     patched_push_dependencies["wandb_login"].assert_not_called()

--- a/tests/flows/test_push_new_dataset.py
+++ b/tests/flows/test_push_new_dataset.py
@@ -24,11 +24,13 @@ def patched_push_dependencies(labelled_passages, mock_concept, test_config):
     with (
         patch("flows.push_new_dataset.load_labelled_passages_from_wandb") as mock_load,
         patch("flows.push_new_dataset.wandb.login") as mock_wandb_login,
+        patch("flows.push_new_dataset.get_aws_ssm_param") as mock_ssm,
         patch("flows.push_new_dataset.Config") as mock_config_cls,
         patch("flows.push_new_dataset.ArgillaSession") as mock_argilla_cls,
         patch("flows.push_new_dataset.WikibaseSession") as mock_wikibase_cls,
     ):
         mock_load.return_value = labelled_passages
+        mock_ssm.return_value = "test-wandb-api-key"
         mock_config_cls.create = AsyncMock(return_value=test_config)
 
         mock_argilla = MagicMock()
@@ -41,6 +43,7 @@ def patched_push_dependencies(labelled_passages, mock_concept, test_config):
         yield {
             "load": mock_load,
             "wandb_login": mock_wandb_login,
+            "ssm": mock_ssm,
             "argilla": mock_argilla,
             "argilla_cls": mock_argilla_cls,
             "wikibase_cls": mock_wikibase_cls,
@@ -64,10 +67,10 @@ async def test_push_new_dataset_loads_passages_from_wandb_artifact(
 
 
 @pytest.mark.asyncio
-async def test_push_new_dataset_logs_into_wandb_when_api_key_present(
+async def test_push_new_dataset_logs_into_wandb_using_ssm_key(
     patched_push_dependencies, test_config
 ):
-    """The flow should call wandb.login when a W&B API key is in Config."""
+    """The flow should fetch the W&B API key from SSM and call wandb.login."""
     await push_new_dataset(
         wikibase_id=WikibaseID("Q787"),
         wandb_artifact_path="climatepolicyradar/Q787/labelled-passages:v0",
@@ -75,21 +78,21 @@ async def test_push_new_dataset_logs_into_wandb_when_api_key_present(
     )
 
     patched_push_dependencies["wandb_login"].assert_called_once_with(
-        key=test_config.wandb_api_key.get_secret_value()
+        key="test-wandb-api-key"
     )
 
 
 @pytest.mark.asyncio
-async def test_push_new_dataset_skips_wandb_login_without_api_key(
+async def test_push_new_dataset_skips_wandb_login_when_ssm_fetch_fails(
     patched_push_dependencies, test_config
 ):
-    """The flow should not call wandb.login when no W&B API key is configured."""
-    config_no_key = test_config.model_copy(update={"wandb_api_key": None})
+    """The flow should not call wandb.login when the SSM fetch fails."""
+    patched_push_dependencies["ssm"].side_effect = Exception("SSM unavailable")
 
     await push_new_dataset(
         wikibase_id=WikibaseID("Q787"),
         wandb_artifact_path="climatepolicyradar/Q787/labelled-passages:v0",
-        config=config_no_key,
+        config=test_config,
     )
 
     patched_push_dependencies["wandb_login"].assert_not_called()

--- a/tests/flows/test_train.py
+++ b/tests/flows/test_train.py
@@ -18,9 +18,6 @@ async def test_train_on_gpu(mock_s3_client, mock_wandb, test_config):
             "flows.train.run_training", return_value=AsyncMock()
         ) as mock_run_training,
         patch("boto3.session.Session", return_value=mock_session),
-        patch(
-            "flows.train.get_aws_ssm_param", return_value="mock-wandb-api-key"
-        ) as mock_get_aws_ssm_param,
     ):
         pass_through_kwargs = {
             "wikibase_id": WikibaseID("Q1"),
@@ -34,9 +31,6 @@ async def test_train_on_gpu(mock_s3_client, mock_wandb, test_config):
             config=test_config,
         )
 
-        mock_get_aws_ssm_param.assert_called_once_with(
-            "WANDB_API_KEY", aws_env=AwsEnv.labs
-        )
         mock_run_training.assert_called_once()
         got_kwargs = mock_run_training.call_args.kwargs
         for kwarg, value in pass_through_kwargs.items():


### PR DESCRIPTION
## Description
Fixes the following error for the push-new-dataset Prefect flow:
```
Encountered exception during execution: UsageError('No API key configured. Use `wandb login` to log in.')
```
Config.create() does not fetch WANDB_API_KEY from SSM, so config.wandb_api_key was always None and wandb.login() was never called, causing wandb.Api() to fail with "No API key configured".

Now it fetches the key directly from SSM (consistent with the sample flow), and warns rather than silently debug-log when the fetch fails so the issue is visible in Prefect logs.
