### PR TITLE
fix: await get_concept_async in push_new_dataset to avoid nested even…

### DIFF
--- a/flows/push_new_dataset.py
+++ b/flows/push_new_dataset.py
@@ -70,7 +70,7 @@ async def push_new_dataset(
         else None,
         url=config.wikibase_url,
     )
-    concept = wikibase.get_concept(wikibase_id)
+    concept = await wikibase.get_concept_async(wikibase_id)
     logger.info(f"✅ Loaded metadata for {concept}")
 
     dataset = argilla.create_dataset(concept, workspace=workspace_name)

--- a/tests/flows/test_push_new_dataset.py
+++ b/tests/flows/test_push_new_dataset.py
@@ -36,7 +36,7 @@ def patched_push_dependencies(labelled_passages, mock_concept, test_config):
 
         mock_wikibase = MagicMock()
         mock_wikibase_cls.return_value = mock_wikibase
-        mock_wikibase.get_concept.return_value = mock_concept
+        mock_wikibase.get_concept_async = AsyncMock(return_value=mock_concept)
 
         yield {
             "load": mock_load,


### PR DESCRIPTION
…t loop

## Description
Fixes the push new dataset prefect flow that is failing with:
```
Encountered exception during execution: RuntimeError('Cannot run the event loop while another loop is running')
```

push_new_dataset is an async Prefect flow, so Prefect's engine is already running an event loop when the flow executes. Calling the sync wrapper wikibase.get_concept() inside it tried to start a nested loop.run_until_complete(), which Python doesn't allow.

Fix: switch to await wikibase.get_concept_async() and update the test mock accordingly.
