### PR TITLE
fix: adds artifact wait to sample and push flow

### DIFF
--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -277,6 +277,7 @@ def run_sampling(
             logger.info("✅ Labelled passages uploaded successfully")
 
     if track_and_upload and logged_artifact is not None:
+        logged_artifact.wait()
         if logged_artifact.version is None:
             raise RuntimeError(
                 f"W&B did not assign a version to the artifact for {wikibase_id}"


### PR DESCRIPTION
### Description
Fixes the following issue in create-evaluation-dataset-in-argilla. After sampling, accessing artifact.version immediately raised:
```
ArtifactNotLoggedError: 'Artifact.version' used prior to logging artifact or while in offline mode. Call Artifact.wait() before accessing logged artifact properties.
```

Fixed by calling logged_artifact.wait() after the W&B run context exits, blocking until the artifact is fully committed server-side before reading the version.