### PR TITLE
manage feather files bucket in pulumi

### DIFF
--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -1,0 +1,4 @@
+config:
+  aws:region: eu-west-1
+  knowledge-graph:labs_aws_account_id:
+    secure: AAABAE9YGvlG4Zl7PdMdBy7e/6/IN/5rES+duMJ/Bj89Jpgk1P1YpyTEDL4=

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: knowledge-graph
+description: infrastructure for the KG
+runtime:
+  name: python
+  options:
+    toolchain: uv
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-python

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,5 @@
 # AWS S3 bucket infra-as-code
 
-The code in this repo manages the bucket `s3://cpr-kg-feather-files` which exists in production and has cross-account access to labs.
+The code in this repo manages the bucket `s3://cpr-kg-feather-files` which exists in production and has cross-account access to labs. Labs cross-account access is needed as the feather files stored in this bucket are used by processes related to model training (AWS production) and the vibe checker (AWS labs).
 
 Vibe checker infra on AWS labs is managed separately in `vibe-checker/infra`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,5 @@
+# AWS S3 bucket infra-as-code
+
+The code in this repo manages the bucket `s3://cpr-kg-feather-files` which exists in production and has cross-account access to labs.
+
+Vibe checker infra on AWS labs is managed separately in `vibe-checker/infra`.

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,0 +1,58 @@
+import pulumi
+import pulumi_aws as aws
+
+config = pulumi.Config()
+labs_aws_account_id = config.get("labs_aws_account_id")
+
+production_knowledge_graph_feather_files_bucket = aws.s3.Bucket(
+    "production-knowledge-graph-feather-files-bucket",
+    bucket="cpr-kg-feather-files",
+    grants=[
+        aws.s3.BucketGrantArgs(
+            id="0fedc730a2af259d90402b1197e87cf40c4014a20851f540cac4269c0156abb9",
+            permissions=["FULL_CONTROL"],
+            type="CanonicalUser",
+        )
+    ],
+    region="eu-west-1",
+    request_payer="BucketOwner",
+    server_side_encryption_configuration=aws.s3.BucketServerSideEncryptionConfigurationArgs(
+        rule=aws.s3.BucketServerSideEncryptionConfigurationRuleArgs(
+            apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(
+                sse_algorithm="AES256",
+            ),
+            bucket_key_enabled=True,
+        ),
+    ),
+    opts=pulumi.ResourceOptions(protect=True),
+)
+
+# Grant the labs AWS account read-only access to the feather files bucket
+labs_cross_account_policy = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            sid="LabsCrossAccountReadOnly",
+            effect="Allow",
+            principals=[
+                aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                    type="AWS",
+                    identifiers=[f"arn:aws:iam::{labs_aws_account_id}:root"],
+                )
+            ],
+            actions=[
+                "s3:GetObject",
+                "s3:ListBucket",
+            ],
+            resources=[
+                "arn:aws:s3:::cpr-kg-feather-files",
+                "arn:aws:s3:::cpr-kg-feather-files/*",
+            ],
+        ),
+    ],
+)
+
+production_knowledge_graph_feather_files_bucket_policy = aws.s3.BucketPolicy(
+    "production-knowledge-graph-feather-files-bucket-policy",
+    bucket=production_knowledge_graph_feather_files_bucket.id,
+    policy=labs_cross_account_policy.json,
+)

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -2,7 +2,7 @@ import pulumi
 import pulumi_aws as aws
 
 config = pulumi.Config()
-labs_aws_account_id = config.get("labs_aws_account_id")
+labs_aws_account_id = config.require_secret("labs_aws_account_id")
 
 production_knowledge_graph_feather_files_bucket = aws.s3.Bucket(
     "production-knowledge-graph-feather-files-bucket",


### PR DESCRIPTION
`pulumi up` succeeds and adds the required cross-account access to the existing bucket. 

Not verified that access works for the vibe checker yet, but now this is in code this can be managed in a separate PR!