### PR TITLE
fix: set NO_CACHE for tasks that have dataframe as input

### DIFF
--- a/flows/vibe_check_generate_datasets.py
+++ b/flows/vibe_check_generate_datasets.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from mypy_boto3_s3 import S3Client
 from prefect import flow, task
+from prefect.cache_policies import NO_CACHE
 
 from flows.config import Config
 from flows.sample import load_dataset_from_s3
@@ -50,7 +51,7 @@ async def _set_up_environment(
     return config, s3_client
 
 
-@task
+@task(cache_policy=NO_CACHE)
 def generate_embeddings(
     df: pd.DataFrame, embedding_model_name: str, batch_size: int
 ) -> np.ndarray:
@@ -86,7 +87,7 @@ def generate_embeddings(
     return embeddings
 
 
-@task(retries=3, retry_delay_seconds=5)
+@task(retries=3, retry_delay_seconds=5, cache_policy=NO_CACHE)
 def upload_vibe_checker_files(
     s3_client: S3Client,
     df: pd.DataFrame,


### PR DESCRIPTION
the flow [ran successfully](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/06a2fd26-dc8d-76ef-8000-dd4b245e40d3?preview=true&tab=logs), but with an error related to task caching.

this PR disables that caching. closes SCI-838

``` text
Error encountered when computing cache key - result will not be persisted.
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/prefect/cache_policies.py", line 374, in compute_key
    return hash_objects(hashed_inputs, raise_on_failure=True)
  File "/usr/local/lib/python3.13/site-packages/prefect/utilities/hashing.py", line 89, in hash_objects
    raise HashError(msg)
prefect.exceptions.HashError: Unable to create hash - objects could not be serialized.
  JSON error: Unable to serialize unknown type: <class 'pandas.core.series.Series'>
  Pickle error: cannot pickle 'SSLContext' object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/prefect/task_engine.py", line 171, in compute_transaction_key
    key = self.task.cache_policy.compute_key(
        task_ctx=task_run_context,
        inputs=self.parameters or {},
        flow_parameters=parameters or {},
    )
  File "/usr/local/lib/python3.13/site-packages/prefect/cache_policies.py", line 214, in compute_key
    policy_key = policy.compute_key(
        task_ctx=task_ctx,
    ...<2 lines>...
        **kwargs,
    )
  File "/usr/local/lib/python3.13/site-packages/prefect/cache_policies.py", line 384, in compute_key
    raise ValueError(msg) from exc
ValueError: Unable to create hash - objects could not be serialized.
  JSON error: Unable to serialize unknown type: <class 'pandas.core.series.Series'>
  Pickle error: cannot pickle 'SSLContext' object

This often occurs when task inputs contain objects that cannot be cached like locks, file handles, or other system resources.

To resolve this, you can:
  1. Exclude these arguments by defining a custom `cache_key_fn`
  2. Disable caching by passing `cache_policy=NO_CACHE`
```