### PR TITLE
classifier training: thread `seed` through training script/flow; add threshold-independent metrics

### DIFF
--- a/flows/train.py
+++ b/flows/train.py
@@ -74,6 +74,7 @@ async def train_on_gpu(
     concept_overrides: Optional[dict[str, Any]] = None,
     training_data_wandb_path: Optional[str] = None,
     limit_training_samples: Optional[int] = None,
+    seed: Optional[int] = None,
     config: Config | None = None,
 ):
     """Trigger the training script in prefect on a GPU using coiled."""
@@ -94,6 +95,7 @@ async def train_on_gpu(
         concept_overrides=concept_overrides,
         training_data_wandb_path=training_data_wandb_path,
         limit_training_samples=limit_training_samples,
+        seed=seed,
     )
 
 
@@ -108,6 +110,7 @@ async def train_on_cpu(
     concept_overrides: Optional[dict[str, Any]] = None,
     training_data_wandb_path: Optional[str] = None,
     limit_training_samples: Optional[int] = None,
+    seed: Optional[int] = None,
     config: Config | None = None,
 ):
     """
@@ -134,6 +137,7 @@ async def train_on_cpu(
         concept_overrides=concept_overrides,
         training_data_wandb_path=training_data_wandb_path,
         limit_training_samples=limit_training_samples,
+        seed=seed,
     )
 
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -12,7 +12,12 @@ import wandb
 from rich import box
 from rich.console import Console
 from rich.table import Table
-from sklearn.metrics import precision_recall_curve, roc_curve
+from sklearn.metrics import (
+    average_precision_score,
+    precision_recall_curve,
+    roc_auc_score,
+    roc_curve,
+)
 from wandb.wandb_run import Run
 
 from knowledge_graph.classifier import Classifier
@@ -585,6 +590,12 @@ def create_wandb_model_evaluation_charts(
             "optimal_f1_threshold_precision": float(precision[optimal_idx_f1]),
             "optimal_f1_threshold_recall": float(recall[optimal_idx_f1]),
             "optimal_f1_threshold_f1_score": float(f1_scores[optimal_idx_f1]),
+            "passage_level_pr_auc": float(
+                average_precision_score(ground_truth_labels, pred_probabilities)
+            ),
+            "passage_level_roc_auc": float(
+                roc_auc_score(ground_truth_labels, pred_probabilities)
+            ),
         }
         for k, v in threshold_recommendations.items():
             wandb_run.summary[k] = v

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -606,6 +606,7 @@ async def train_classifier(
     train_validation_data: Optional[list[LabelledPassage]] = None,
     max_training_samples: Optional[int] = None,
     force: bool = True,
+    seed: Optional[int] = None,
 ) -> "Classifier":
     """Train a classifier and optionally track the run, uploading the model."""
     logger = get_logger()
@@ -696,9 +697,13 @@ async def train_classifier(
         else:
             deduplicated_training_data = []
 
+        fit_kwargs: dict[str, Any] = {}
+        if seed is not None:
+            fit_kwargs["seed"] = seed
         classifier.fit(
             labelled_passages=deduplicated_training_data,
             enable_wandb=track_and_upload,
+            **fit_kwargs,
         )
 
         # Log the final prompt to W&B. Useful for AutoLLMClassifier, which
@@ -812,6 +817,7 @@ async def run_training(
     training_data_wandb_path: Optional[str] = None,
     limit_training_samples: Optional[int] = None,
     force: bool = True,
+    seed: Optional[int] = None,
 ) -> Classifier:
     """
     Get a concept and create a classifier, then train the classifier.
@@ -868,6 +874,8 @@ async def run_training(
         extra_wandb_config["training_data_wandb_path"] = training_data_wandb_path
     if limit_training_samples is not None:
         extra_wandb_config["limit_training_samples"] = limit_training_samples
+    if seed is not None:
+        extra_wandb_config["seed"] = seed
     if hasattr(classifier, "model_name"):
         wandb_classifier_kwargs: dict[str, object] = dict(classifier_kwargs or {})
         wandb_classifier_kwargs["model_name"] = getattr(classifier, "model_name")
@@ -884,6 +892,7 @@ async def run_training(
         train_validation_data=labelled_passages,
         max_training_samples=limit_training_samples,
         force=force,
+        seed=seed,
     )
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -396,6 +396,31 @@ def test_create_wandb_model_evaluation_charts_logs_roc_and_pr_curves_when_probab
     assert "Precision-Recall Curve" in line_titles
 
 
+def test_create_wandb_model_evaluation_charts_logs_pr_and_roc_auc_to_summary():
+    texts = [f"passage {i}" for i in range(6)]
+    predictions = _make_passages_with_probability(texts[:3], has_span=True, prob=0.9)
+    predictions += _make_passages_with_probability(texts[3:], has_span=False, prob=0.0)
+    ground_truth = predictions[:]
+
+    mock_run = Mock()
+    mock_run.summary = {}
+
+    with (
+        patch("wandb.plot.line"),
+        patch("wandb.plot.confusion_matrix"),
+        patch("wandb.Table"),
+    ):
+        create_wandb_model_evaluation_charts(
+            wandb_run=mock_run,
+            predictions=predictions,
+            ground_truth=ground_truth,
+        )
+
+    for key in ("passage_level_pr_auc", "passage_level_roc_auc"):
+        assert key in mock_run.summary
+        assert 0.0 <= mock_run.summary[key] <= 1.0
+
+
 def test_create_wandb_model_evaluation_charts_skips_curves_when_no_probabilities():
     texts = [f"passage {i}" for i in range(4)]
     predictions = [


### PR DESCRIPTION
- random seed can be set in train script and flow (see #1201)
- add passage-level PR-AUC and ROC-AUC to evaluation for probability capable classifiers
- add a test that these new metrics appear in the run summary