### PR TITLE
argilla user management cli

### DIFF
--- a/scripts/argilla/README.md
+++ b/scripts/argilla/README.md
@@ -1,8 +1,16 @@
 # Scripts for working with Argilla
 
-There are two scripts in this folder:
+## Datasets
 
 - `push_new_dataset`: adds passages to a new dataset in Argilla
 - `extend_existing_dataset`: adds *more* passages to a dataset in Argilla. Avoids duplicates being added to Argilla from the input JSONL, based on an exact text match.
 
 Both require use of the sample script (`scripts/sample.py`). They're set to load in 130 passages by default, meaning that the output of the sample script can be larger.
+
+## Users
+
+- `users.py`: manage Argilla users. It has two commands:
+  - `create`: interactively create a single user as an `annotator` or an `owner`. Labellers are also assigned to the `knowledge-graph` workspace.
+  - `list`: print every Argilla user with their name, role and workspace memberships.
+
+Argilla owner credentials are pulled from SSM (`/Argilla/APIURL` and `/Argilla/Owner/APIKey`), so you must be authenticated to AWS when running it. Run with `uv run python scripts/argilla/users.py create` or `... list`.

--- a/scripts/argilla/users.py
+++ b/scripts/argilla/users.py
@@ -1,0 +1,183 @@
+"""
+Manage Argilla users.
+
+Two commands:
+
+- `create`: interactively create a single user as an annotator or an owner.
+  Annotators are also assigned to the knowledge-graph workspace.
+- `list`: print every Argilla user with their name, role and workspaces.
+
+Argilla owner credentials are pulled from SSM, so you must be authenticated to
+AWS (the default credentials / profile is used) when running this script.
+"""
+
+import os
+import re
+import secrets
+
+import typer
+from argilla._models import Role
+from cpr_sdk.ssm import get_aws_ssm_param
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+
+from knowledge_graph.labelling import (
+    ArgillaSession,
+    ResourceAlreadyExistsError,
+    ResourceDoesNotExistError,
+)
+
+app = typer.Typer()
+console = Console()
+
+WORKSPACE_NAME = "knowledge-graph"
+
+# Roles a user can be created with via this script.
+ROLE_CHOICES = [Role.annotator.value, Role.owner.value]
+
+# Argilla only accepts usernames of letters, digits, hyphens and underscores
+# that don't start with a hyphen or underscore.
+USERNAME_PATTERN = re.compile(r"^(?!-|_)[A-Za-z0-9-_]+$")
+
+
+def _connect() -> ArgillaSession:
+    """
+    Connect to Argilla using owner credentials pulled from SSM.
+
+    Sets the ARGILLA_API_URL / ARGILLA_API_KEY environment variables from SSM
+    (so they're picked up by ArgillaSession) and returns a connected session.
+    Requires AWS authentication for SSM access.
+    """
+    with console.status("Fetching Argilla credentials from SSM..."):
+        os.environ["ARGILLA_API_URL"] = get_aws_ssm_param("/Argilla/APIURL")
+        os.environ["ARGILLA_API_KEY"] = get_aws_ssm_param("/Argilla/Owner/APIKey")
+
+    with console.status("Connecting to Argilla..."):
+        session = ArgillaSession()
+    console.log("✅ Connected to Argilla")
+    return session
+
+
+@app.command("create")
+def create():
+    """Interactively create a single Argilla user (annotator or owner)."""
+    argilla = _connect()
+
+    username = Prompt.ask("Username").strip()
+    if not username:
+        raise typer.BadParameter("Username cannot be empty")
+    if not USERNAME_PATTERN.match(username):
+        raise typer.BadParameter(
+            f"Invalid username '{username}'. Usernames may only contain letters, "
+            "digits, hyphens and underscores (no dots or spaces), and cannot start "
+            "with a hyphen or underscore. E.g. use 'silke-vanbeselaere'."
+        )
+
+    role_name = Prompt.ask(
+        "Role",
+        choices=ROLE_CHOICES,
+        default=Role.annotator.value,
+    )
+    role = Role(role_name)
+
+    first_name = Prompt.ask("First name (optional)", default="").strip() or None
+    last_name = Prompt.ask("Last name (optional)", default="").strip() or None
+
+    password = Prompt.ask(
+        "Password (leave blank to auto-generate)",
+        password=True,
+        default="",
+    ).strip()
+
+    if password_was_generated := not password:
+        password = secrets.token_urlsafe(16)
+    else:
+        confirm = Prompt.ask("Confirm password", password=True).strip()
+        if confirm != password:
+            raise typer.BadParameter("Passwords do not match")
+
+    # Make sure the knowledge-graph workspace exists before assigning (annotators only).
+    workspace = None
+    if role == Role.annotator:
+        try:
+            workspace = argilla.get_workspace(WORKSPACE_NAME)
+        except ResourceDoesNotExistError:
+            console.log(f"Workspace '{WORKSPACE_NAME}' not found, creating it")
+            workspace = argilla.create_workspace(WORKSPACE_NAME)
+
+    try:
+        # Use the returned User object directly for the workspace assignment: the
+        # session caches username lookups, so a fresh get_user() after creation
+        # would return a stale "not found" result.
+        user = argilla.create_user(
+            username=username,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            role=role,
+        )
+        console.log(f"✅ Created user '{username}' with role '{role_name}'")
+    except ResourceAlreadyExistsError:
+        console.print(
+            f"[yellow]User '{username}' already exists — "
+            "ensuring workspace membership only.[/yellow]"
+        )
+        user = argilla.get_user(username=username)
+        password_was_generated = False
+
+    if role == Role.annotator and workspace is not None:
+        members = argilla.client.users.list(workspace=workspace)
+        if any(member.username == username for member in members):
+            console.log(f"'{username}' is already in workspace '{WORKSPACE_NAME}'")
+        else:
+            user.add_to_workspace(workspace)
+            console.log(f"✅ Added '{username}' to workspace '{WORKSPACE_NAME}'")
+
+    console.print()
+    console.print(f"[bold green]User:[/bold green] {username}")
+    console.print(f"  Role:      {role_name}")
+    if role == Role.annotator:
+        console.print(f"  Workspace: {WORKSPACE_NAME}")
+    if password_was_generated:
+        console.print(
+            f"  Password:  [bold]{password}[/bold] "
+            "(auto-generated — copy it now, it won't be shown again)"
+        )
+
+
+@app.command("list")
+def list_users():
+    """List all Argilla users with their name, role and workspaces."""
+    argilla = _connect()
+
+    with console.status("Loading users and workspaces..."):
+        # Build a username -> [workspace names] map from workspace membership.
+        workspaces_by_user: dict[str, list[str]] = {}
+        for workspace in argilla.client.workspaces:
+            if not workspace.name:
+                continue
+            for member in argilla.client.users.list(workspace=workspace):
+                workspaces_by_user.setdefault(member.username, []).append(
+                    workspace.name
+                )
+
+        users = argilla.client.users.list()
+
+    table = Table(title="Argilla users")
+    table.add_column("Username", style="bold")
+    table.add_column("Name")
+    table.add_column("Role")
+    table.add_column("Workspaces")
+
+    for user in sorted(users, key=lambda u: u.username):
+        name = " ".join(filter(None, [user.first_name, user.last_name])).strip()
+        workspaces = ", ".join(sorted(workspaces_by_user.get(user.username, [])))
+        table.add_row(user.username, name, str(user.role), workspaces)
+
+    console.print(table)
+    console.print(f"{len(users)} user(s) total")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/scripts/argilla/test_users.py
+++ b/tests/scripts/argilla/test_users.py
@@ -1,0 +1,211 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from knowledge_graph.labelling import (
+    ResourceAlreadyExistsError,
+    ResourceDoesNotExistError,
+)
+from scripts.argilla.users import WORKSPACE_NAME, app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_session():
+    session = MagicMock()
+    return session
+
+
+@pytest.fixture
+def mock_connect(mock_session):
+    with patch("scripts.argilla.users._connect", return_value=mock_session):
+        yield mock_session
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def test_create_annotator_creates_user_and_adds_to_workspace(
+    mock_connect, mock_workspace, mock_user
+):
+    session = mock_connect
+    workspace = mock_workspace(name=WORKSPACE_NAME)
+    user = mock_user(username="alice")
+    session.get_workspace.return_value = workspace
+    session.create_user.return_value = user
+    session.client.users.list.return_value = []
+
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["alice", "annotator", "", "", ""],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    session.create_user.assert_called_once()
+    user.add_to_workspace.assert_called_once_with(workspace)
+
+
+def test_create_with_blank_password_auto_generates_and_shows_it(
+    mock_connect, mock_workspace, mock_user
+):
+    session = mock_connect
+    workspace = mock_workspace(name=WORKSPACE_NAME)
+    user = mock_user(username="carol")
+    session.get_workspace.return_value = workspace
+    session.create_user.return_value = user
+    session.client.users.list.return_value = []
+
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["carol", "annotator", "", "", ""],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    assert "auto-generated" in result.output
+
+
+def test_create_rejects_mismatched_passwords(mock_connect):
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["eve", "annotator", "", "", "pass1", "pass2"],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code != 0
+
+
+def test_create_rejects_empty_username(mock_connect):
+    with patch("scripts.argilla.users.Prompt.ask", side_effect=[""]):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code != 0
+
+
+def test_create_when_user_already_exists_ensures_workspace_membership(
+    mock_connect, mock_workspace, mock_user
+):
+    """Running the CLI should still add an existing user to the relevant workspaces."""
+    session = mock_connect
+    workspace = mock_workspace(name=WORKSPACE_NAME)
+    existing = mock_user(username="frank")
+    session.get_workspace.return_value = workspace
+    session.create_user.side_effect = ResourceAlreadyExistsError("User", "frank")
+    session.get_user.return_value = existing
+    session.client.users.list.return_value = []  # not yet a member
+
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["frank", "annotator", "", "", ""],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    session.get_user.assert_called_once_with(username="frank")
+    existing.add_to_workspace.assert_called_once_with(workspace)
+
+
+def test_create_annotator_creates_workspace_when_it_does_not_exist(
+    mock_connect, mock_workspace, mock_user
+):
+    session = mock_connect
+    new_workspace = mock_workspace(name=WORKSPACE_NAME)
+    user = mock_user(username="grace")
+    session.get_workspace.side_effect = ResourceDoesNotExistError(
+        "Workspace", WORKSPACE_NAME
+    )
+    session.create_workspace.return_value = new_workspace
+    session.create_user.return_value = user
+    session.client.users.list.return_value = []
+
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["grace", "annotator", "", "", ""],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    session.create_workspace.assert_called_once_with(WORKSPACE_NAME)
+    user.add_to_workspace.assert_called_once_with(new_workspace)
+
+
+def test_create_skips_workspace_add_when_user_already_a_member(
+    mock_connect, mock_workspace, mock_user
+):
+    session = mock_connect
+    workspace = mock_workspace(name=WORKSPACE_NAME)
+    user = mock_user(username="heidi")
+    existing_member = MagicMock()
+    existing_member.username = "heidi"
+    session.get_workspace.return_value = workspace
+    session.create_user.return_value = user
+    session.client.users.list.return_value = [existing_member]
+
+    with patch(
+        "scripts.argilla.users.Prompt.ask",
+        side_effect=["heidi", "annotator", "", "", ""],
+    ):
+        result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    user.add_to_workspace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_shows_all_users(mock_connect):
+    session = mock_connect
+    session.client.workspaces = []
+
+    user_a = MagicMock()
+    user_a.username = "alice"
+    user_a.first_name = "Alice"
+    user_a.last_name = "Smith"
+    user_a.role = "annotator"
+
+    user_b = MagicMock()
+    user_b.username = "bob"
+    user_b.first_name = "Bob"
+    user_b.last_name = "Jones"
+    user_b.role = "owner"
+
+    session.client.users.list.return_value = [user_a, user_b]
+
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert "bob" in result.output
+
+
+def test_list_shows_workspace_memberships(mock_connect, mock_workspace):
+    session = mock_connect
+    ws = mock_workspace(name="knowledge-graph")
+    ws.name = "knowledge-graph"
+    session.client.workspaces = [ws]
+
+    member = MagicMock()
+    member.username = "ivan"
+    member.first_name = "Ivan"
+    member.last_name = ""
+    member.role = "annotator"
+
+    def list_side_effect(*args, workspace=None):
+        if workspace is ws:
+            return [member]
+        return [member]  # full user list
+
+    session.client.users.list.side_effect = list_side_effect
+
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "knowledge-graph" in result.output


### PR DESCRIPTION
Argilla dropped their CLI in `v2.0.0`. There are already utility functions for user management in `knowledge_graph/labelling`; this just assembles them into a CLI.

I used this to make `silke` a new account for them joining next week