### PR TITLE
fetch classifier ids as part of concept

### DIFF
--- a/knowledge_graph/concept.py
+++ b/knowledge_graph/concept.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
-from knowledge_graph.identifiers import ConceptID, WikibaseID
+from knowledge_graph.identifiers import (
+    ClassifierID,
+    ConceptID,
+    StatementRank,
+    WikibaseID,
+)
 from knowledge_graph.labelled_passage import LabelledPassage
 
 if TYPE_CHECKING:
@@ -65,6 +70,13 @@ class Concept(BaseModel):
         default_factory=list,
         description=(
             "List of concept IDs for concepts this should not be confused with"
+        ),
+    )
+    classifier_ids: list[tuple[StatementRank, ClassifierID]] = Field(
+        default_factory=list,
+        description=(
+            "Classifier IDs associated with this concept (Wikibase property P20), "
+            "each paired with its Wikibase statement rank"
         ),
     )
     recursive_subconcept_of: Optional[list[WikibaseID]] = Field(

--- a/knowledge_graph/identifiers.py
+++ b/knowledge_graph/identifiers.py
@@ -186,3 +186,11 @@ class ConceptID(Identifier):
 
     This is intended for typing clarity rather than extending the Identifier class.
     """
+
+
+class StatementRank(Enum):
+    """Rank levels for statements on Wikibase items"""
+
+    PREFERRED = "preferred"
+    NORMAL = "normal"
+    DEPRECATED = "deprecated"

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Any, Final, NamedTuple
 
 import dotenv
@@ -28,7 +27,7 @@ from knowledge_graph.exceptions import (
     InvalidConceptError,
     RevisionNotFoundError,
 )
-from knowledge_graph.identifiers import ClassifierID, WikibaseID
+from knowledge_graph.identifiers import ClassifierID, StatementRank, WikibaseID
 from knowledge_graph.utils import get_logger
 
 logger = get_logger(__name__)
@@ -38,14 +37,6 @@ dotenv.load_dotenv()
 MAX_RETRIES = 5
 RETRY_INITIAL_WAIT = 1.0
 RETRY_MAX_WAIT = 60.0
-
-
-class StatementRank(Enum):
-    """Rank levels for statements on Wikibase items"""
-
-    PREFERRED = "preferred"
-    NORMAL = "normal"
-    DEPRECATED = "deprecated"
 
 
 class WikibaseAuth(BaseModel):
@@ -503,6 +494,12 @@ class WikibaseSession:
                         concept.negative_concepts.append(
                             self._resolve_redirect(value["id"])
                         )
+
+        concept.classifier_ids = self._parse_classifier_id_claims(
+            concept.wikibase_id,
+            claims.get(self.classifier_id_property_id, []),
+            raise_on_error=False,
+        )
 
     async def _incorporate_negative_concepts(self, concept: Concept) -> Concept:
         """
@@ -1295,28 +1292,21 @@ class WikibaseSession:
         """
         return await self.search_concepts_async(search_term, limit, timestamp)
 
-    async def get_classifier_ids_async(
+    def _parse_classifier_id_claims(
         self,
-        wikibase_id: WikibaseID,
+        wikibase_id: WikibaseID | None,
+        claims: list[dict],
+        raise_on_error: bool = True,
     ) -> list[tuple[StatementRank, ClassifierID]]:
-        """Get the classifier IDs and their ranks for a given Wikibase item"""
+        """
+        Parse classifier ID (P20) claims into validated (rank, classifier ID) tuples.
 
-        client = await self._get_client()
-        response = await client.get(
-            url=self.api_url,
-            params={
-                "action": "wbgetentities",
-                "ids": wikibase_id,
-                "format": "json",
-            },
-        )
-        response.raise_for_status()
-        data = response.json()
-
-        claims = data["entities"][wikibase_id]["claims"].get(
-            self.classifier_id_property_id, []
-        )
-
+        :param wikibase_id: The item the claims belong to (for error messages)
+        :param claims: The list of P20 statements from the Wikibase API
+        :param raise_on_error: If True, raise a ValueError when any statement has an
+            invalid rank or classifier ID format. If False, log the invalid statement
+            and skip it, returning the valid ones.
+        """
         classifier_ids = []
         validation_errors = []
         for claim in claims:
@@ -1348,13 +1338,39 @@ class WikibaseSession:
                 logger.error(validation_message)
                 validation_errors.append(validation_message)
 
-        if validation_errors:
+        if validation_errors and raise_on_error:
             raise ValueError(
                 f"Validation error for Wikibase ID: {wikibase_id} \n"
                 + "\n".join(validation_errors)
             )
 
         return classifier_ids
+
+    async def get_classifier_ids_async(
+        self,
+        wikibase_id: WikibaseID,
+    ) -> list[tuple[StatementRank, ClassifierID]]:
+        """Get the classifier IDs and their ranks for a given Wikibase item"""
+
+        client = await self._get_client()
+        response = await client.get(
+            url=self.api_url,
+            params={
+                "action": "wbgetentities",
+                "ids": wikibase_id,
+                "format": "json",
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        claims = data["entities"][wikibase_id]["claims"].get(
+            self.classifier_id_property_id, []
+        )
+
+        return self._parse_classifier_id_claims(
+            wikibase_id, claims, raise_on_error=True
+        )
 
     @async_to_sync
     async def get_classifier_ids(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,19 @@ def mock_wikibase_revisions_json():
                         }
                     }
                 ],
+                "P20": [
+                    {
+                        "rank": "preferred",
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P20",
+                            "datavalue": {
+                                "value": "abcd2345",
+                                "type": "string",
+                            },
+                        },
+                    }
+                ],
             },
         }
 

--- a/tests/test_concept.py
+++ b/tests/test_concept.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from knowledge_graph.concept import Concept
-from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.identifiers import ClassifierID, StatementRank, WikibaseID
 from tests.common_strategies import concept_label_strategy, wikibase_id_strategy
 
 
@@ -56,6 +56,17 @@ def test_whether_concepts_produce_the_same_hash_regardless_of_alternative_label_
         wikibase_id=WikibaseID("Q123"),
     )
     assert hash(concept1) == hash(concept2)
+
+
+def test_whether_classifier_ids_do_not_affect_concept_id():
+    base = Concept(preferred_label="Test", wikibase_id=WikibaseID("Q123"))
+    with_classifiers = Concept(
+        preferred_label="Test",
+        wikibase_id=WikibaseID("Q123"),
+        classifier_ids=[(StatementRank.PREFERRED, ClassifierID("abcd2345"))],
+    )
+    assert base.id == with_classifiers.id
+    assert hash(base) == hash(with_classifiers)
 
 
 @given(

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 
 from knowledge_graph.concept import Concept
-from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.identifiers import ClassifierID, StatementRank, WikibaseID
 
 
 def test_wikibase____init__(MockedWikibaseSession, monkeypatch, mock_wikibase_url):
@@ -31,6 +31,64 @@ def test_wikibase__get_concept(MockedWikibaseSession):
     assert isinstance(concept, Concept)
     assert concept.wikibase_id == "Q10"
     assert concept.wikibase_revision == 12345
+    assert concept.classifier_ids == [
+        (StatementRank.PREFERRED, ClassifierID("abcd2345"))
+    ]
+
+
+def _classifier_id_claim(rank: str, value: str) -> dict:
+    """Build a Wikibase P20 (classifier ID) statement for tests."""
+    return {
+        "rank": rank,
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P20",
+            "datavalue": {"value": value, "type": "string"},
+        },
+    }
+
+
+def test_wikibase__parse_classifier_id_claims(MockedWikibaseSession):
+    wikibase = MockedWikibaseSession()
+
+    valid_claims = [
+        _classifier_id_claim("preferred", "abcd2345"),
+        _classifier_id_claim("deprecated", "wxyz6789"),
+    ]
+    assert wikibase._parse_classifier_id_claims(WikibaseID("Q10"), valid_claims) == [
+        (StatementRank.PREFERRED, ClassifierID("abcd2345")),
+        (StatementRank.DEPRECATED, ClassifierID("wxyz6789")),
+    ]
+
+    # An empty list of claims yields an empty result
+    assert wikibase._parse_classifier_id_claims(WikibaseID("Q10"), []) == []
+
+
+def test_wikibase__parse_classifier_id_claims__malformed_raises_when_strict(
+    MockedWikibaseSession,
+):
+    wikibase = MockedWikibaseSession()
+    bad_claims = [
+        _classifier_id_claim("preferred", "not-a-valid-id"),
+        _classifier_id_claim("normal", "abcd2345"),
+    ]
+    with pytest.raises(ValueError, match="Validation error"):
+        wikibase._parse_classifier_id_claims(
+            WikibaseID("Q10"), bad_claims, raise_on_error=True
+        )
+
+
+def test_wikibase__parse_classifier_id_claims__malformed_skipped_when_not_strict(
+    MockedWikibaseSession,
+):
+    wikibase = MockedWikibaseSession()
+    bad_claims = [
+        _classifier_id_claim("preferred", "not-a-valid-id"),
+        _classifier_id_claim("normal", "abcd2345"),
+    ]
+    assert wikibase._parse_classifier_id_claims(
+        WikibaseID("Q10"), bad_claims, raise_on_error=False
+    ) == [(StatementRank.NORMAL, ClassifierID("abcd2345"))]
 
 
 def test_wikibase__get_all_concept_ids(MockedWikibaseSession):


### PR DESCRIPTION
This has been built to enable fetching "all concepts which have classifiers" in concept store MCP. See context in ticket: https://linear.app/climate-policy-radar/issue/SCI-902/allow-concept-store-mcp-to-access-classifier-id-and-not-to-be-confused

