### PR TITLE
fix mcp server deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -76,6 +76,9 @@ argilla_data/
 # Wandb
 wandb/
 
+artifacts/
+experiments/
+
 # Vibe checker webapp and infra (not needed in Python container)
 vibe-checker/webapp/
 vibe-checker/infra/

--- a/mcp/infra/__main__.py
+++ b/mcp/infra/__main__.py
@@ -81,6 +81,9 @@ image = docker.Image(
         context=str(root_dir.resolve()),
         dockerfile=str(dockerfile_path),
         platform="linux/amd64",  # Specify platform for cross-platform builds
+        # Force the legacy builder. The provider's default BuildKit path produces a
+        # context tar that Docker Engine 29.x rejects ("archive/tar: invalid tar header").
+        builder_version=docker.BuilderVersion.BUILDER_V1,
     ),
     image_name=pulumi.Output.concat(repo.repository_url, ":", git_commit_hash),
     registry=docker.RegistryArgs(


### PR DESCRIPTION
I found two things whilst trying to redeploy the concept store mcp server:

- the W&B `artifacts` dir (>8GB on my machine) was included in the docker image
- the build step was incompatible with new versions of docker desktop (claude helped me with this bit)

TOWARDS SCI-902