### PR TITLE
fix: classifier_ids tuple expecting enum for both values

### DIFF
--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -52,12 +52,16 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
     Returns:
         pl.DataFrame: A DataFrame with all concepts, ready for Parquet write
     """
-    df = pl.DataFrame(
-        [
-            concept.model_dump(exclude={"labelled_passages"}, mode="python")
-            for concept in concepts
+    records = []
+    for concept in concepts:
+        record = concept.model_dump(exclude={"labelled_passages"}, mode="python")
+        record["classifier_ids"] = [
+            (rank.value, str(classifier_id))
+            for rank, classifier_id in concept.classifier_ids
         ]
-    )
+        records.append(record)
+
+    df = pl.DataFrame(records)
 
     # Cast Null columns to proper types for consistent schema Polars
     # infers Null type when all values are None, but we want explicit

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -90,14 +90,14 @@ def test_concepts_to_dataframe__with_classifier_ids(mock_concepts):
     ClassifierID too, since the first element (StatementRank) is an Enum.
     """
     mock_concepts[0].classifier_ids = [
-        (StatementRank.PREFERRED, ClassifierID("abcd1234")),
+        (StatementRank.PREFERRED, ClassifierID("abcd2345")),
         (StatementRank.NORMAL, ClassifierID("wxyz9876")),
     ]
 
     df = concepts_to_dataframe(mock_concepts)
 
     assert df["classifier_ids"][0].to_list() == [
-        ["preferred", "abcd1234"],
+        ["preferred", "abcd2345"],
         ["normal", "wxyz9876"],
     ]
 

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -21,6 +21,7 @@ from flows.sync_concepts import (
 from flows.utils import S3Uri
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import ClassifierID, StatementRank
 from knowledge_graph.result import Err, Error, Ok, is_err, is_ok, unwrap_err, unwrap_ok
 from knowledge_graph.wikibase import WikibaseAuth
 
@@ -78,6 +79,27 @@ def test_concepts_to_dataframe(mock_concepts):
     # Verify types for Delta Lake compatibility
     assert df["description"].dtype == pl.Utf8 or all(df["description"].is_null())
     assert df["definition"].dtype == pl.Utf8 or all(df["definition"].is_null())
+
+
+def test_concepts_to_dataframe__with_classifier_ids(mock_concepts):
+    """
+    Regression test for AttributeError: 'ClassifierID' object has no attribute 'value'.
+
+    Polars infers a tuple's serialization from its first element's type, so a
+    (StatementRank, ClassifierID) tuple made it try to call `.value` on the
+    ClassifierID too, since the first element (StatementRank) is an Enum.
+    """
+    mock_concepts[0].classifier_ids = [
+        (StatementRank.PREFERRED, ClassifierID("abcd1234")),
+        (StatementRank.NORMAL, ClassifierID("wxyz9876")),
+    ]
+
+    df = concepts_to_dataframe(mock_concepts)
+
+    assert df["classifier_ids"][0].to_list() == [
+        ["preferred", "abcd1234"],
+        ["normal", "wxyz9876"],
+    ]
 
 
 def test_dataframe_to_concepts__roundtrip(mock_concepts):


### PR DESCRIPTION
A new field has been added to the Concept model for classifier_ids. This is a tuple of enum (statement rank) and string (classifier_id).

In polars, the type of both fields in the tuple is inferred as an enum causing a failure in the sync_concepts flow trying to retrieve ClassifierID.value for a string.

This fix sets each value and prevents this issue.