### PR TITLE
Revert "fix: classifier_ids tuple expecting enum for both values (#1225)" and ignore new classifier_ids column

### DIFF
--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -52,16 +52,12 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
     Returns:
         pl.DataFrame: A DataFrame with all concepts, ready for Parquet write
     """
-    records = []
-    for concept in concepts:
-        record = concept.model_dump(exclude={"labelled_passages"}, mode="python")
-        record["classifier_ids"] = [
-            (rank.value, str(classifier_id))
-            for rank, classifier_id in concept.classifier_ids
+    df = pl.DataFrame(
+        [
+            concept.model_dump(exclude={"labelled_passages"}, mode="python")
+            for concept in concepts
         ]
-        records.append(record)
-
-    df = pl.DataFrame(records)
+    )
 
     # Cast Null columns to proper types for consistent schema Polars
     # infers Null type when all values are None, but we want explicit

--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -54,7 +54,9 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
     """
     df = pl.DataFrame(
         [
-            concept.model_dump(exclude={"labelled_passages"}, mode="python")
+            concept.model_dump(
+                exclude={"labelled_passages", "classifier_ids"}, mode="python"
+            )
             for concept in concepts
         ]
     )

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -21,7 +21,6 @@ from flows.sync_concepts import (
 from flows.utils import S3Uri
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.concept import Concept
-from knowledge_graph.identifiers import ClassifierID, StatementRank
 from knowledge_graph.result import Err, Error, Ok, is_err, is_ok, unwrap_err, unwrap_ok
 from knowledge_graph.wikibase import WikibaseAuth
 
@@ -79,27 +78,6 @@ def test_concepts_to_dataframe(mock_concepts):
     # Verify types for Delta Lake compatibility
     assert df["description"].dtype == pl.Utf8 or all(df["description"].is_null())
     assert df["definition"].dtype == pl.Utf8 or all(df["definition"].is_null())
-
-
-def test_concepts_to_dataframe__with_classifier_ids(mock_concepts):
-    """
-    Regression test for AttributeError: 'ClassifierID' object has no attribute 'value'.
-
-    Polars infers a tuple's serialization from its first element's type, so a
-    (StatementRank, ClassifierID) tuple made it try to call `.value` on the
-    ClassifierID too, since the first element (StatementRank) is an Enum.
-    """
-    mock_concepts[0].classifier_ids = [
-        (StatementRank.PREFERRED, ClassifierID("abcd2345")),
-        (StatementRank.NORMAL, ClassifierID("wxyz9876")),
-    ]
-
-    df = concepts_to_dataframe(mock_concepts)
-
-    assert df["classifier_ids"][0].to_list() == [
-        ["preferred", "abcd2345"],
-        ["normal", "wxyz9876"],
-    ]
 
 
 def test_dataframe_to_concepts__roundtrip(mock_concepts):


### PR DESCRIPTION
Revert "fix: classifier_ids tuple expecting enum for both values (#1225)"
and remove classifier_ids from being written to s3 to avoid schema conflicts between historical files and new files

This avoids historical data not having the classifier_ids field and new data going forward having this field. 
It is not used downstream in snowflake as the classifier_specs already contains this information and avoids incomplete data for historical classifiers.