### PR TITLE
fix(enri-1505): make concept sync robust to field schema changes

### DIFF
--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -61,19 +61,30 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
         ]
     )
 
-    # Cast Null columns to proper types for consistent schema Polars
-    # infers Null type when all values are None, but we want explicit
-    # types.
+    # Force explicit dtypes so empty/None columns don't infer as Null or
+    # List(Null), which differ from populated columns and break unioning the
+    # archive's Parquet files across runs.
     schema_casts = {
         "description": pl.Utf8,
         "definition": pl.Utf8,
+        "wikibase_id": pl.Utf8,
+        "wikibase_revision": pl.Int64,
+        "alternative_labels": pl.List(pl.Utf8),
+        "negative_labels": pl.List(pl.Utf8),
+        "subconcept_of": pl.List(pl.Utf8),
+        "has_subconcept": pl.List(pl.Utf8),
+        "related_concepts": pl.List(pl.Utf8),
+        "negative_concepts": pl.List(pl.Utf8),
         "recursive_subconcept_of": pl.List(pl.Utf8),
         "recursive_has_subconcept": pl.List(pl.Utf8),
     }
 
-    for col, dtype in schema_casts.items():
-        if col in df.columns and df[col].dtype == pl.Null:
-            df = df.with_columns(pl.col(col).cast(dtype))
+    if casts := [
+        pl.col(col).cast(dtype)
+        for col, dtype in schema_casts.items()
+        if col in df.columns and df[col].dtype != dtype
+    ]:
+        df = df.with_columns(casts)
 
     # Add sync timestamp to track when this version was synced
     df = df.with_columns(pl.lit(datetime.now(timezone.utc)).alias("synced_at"))

--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -52,26 +52,41 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
     Returns:
         pl.DataFrame: A DataFrame with all concepts, ready for Parquet write
     """
+    # mode="json" flattens enums and custom types (e.g. classifier_ids) to
+    # primitives; mode="python" leaves them as objects that crash Polars.
     df = pl.DataFrame(
         [
-            concept.model_dump(exclude={"labelled_passages"}, mode="python")
+            concept.model_dump(exclude={"labelled_passages"}, mode="json")
             for concept in concepts
         ]
     )
 
-    # Cast Null columns to proper types for consistent schema Polars
-    # infers Null type when all values are None, but we want explicit
-    # types.
+    # Force explicit dtypes so empty/None columns don't infer as Null or
+    # List(Null), which differ from populated columns and break unioning the
+    # archive's Parquet files across runs.
     schema_casts = {
         "description": pl.Utf8,
         "definition": pl.Utf8,
+        "wikibase_id": pl.Utf8,
+        "wikibase_revision": pl.Int64,
+        "alternative_labels": pl.List(pl.Utf8),
+        "negative_labels": pl.List(pl.Utf8),
+        "subconcept_of": pl.List(pl.Utf8),
+        "has_subconcept": pl.List(pl.Utf8),
+        "related_concepts": pl.List(pl.Utf8),
+        "negative_concepts": pl.List(pl.Utf8),
+        "classifier_ids": pl.List(pl.List(pl.Utf8)),  # (rank, id) pairs
         "recursive_subconcept_of": pl.List(pl.Utf8),
         "recursive_has_subconcept": pl.List(pl.Utf8),
     }
 
-    for col, dtype in schema_casts.items():
-        if col in df.columns and df[col].dtype == pl.Null:
-            df = df.with_columns(pl.col(col).cast(dtype))
+    casts = [
+        pl.col(col).cast(dtype)
+        for col, dtype in schema_casts.items()
+        if col in df.columns and df[col].dtype != dtype
+    ]
+    if casts:
+        df = df.with_columns(casts)
 
     # Add sync timestamp to track when this version was synced
     df = df.with_columns(pl.lit(datetime.now(timezone.utc)).alias("synced_at"))

--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -52,41 +52,28 @@ def concepts_to_dataframe(concepts: list[Concept]) -> pl.DataFrame:
     Returns:
         pl.DataFrame: A DataFrame with all concepts, ready for Parquet write
     """
-    # mode="json" flattens enums and custom types (e.g. classifier_ids) to
-    # primitives; mode="python" leaves them as objects that crash Polars.
     df = pl.DataFrame(
         [
-            concept.model_dump(exclude={"labelled_passages"}, mode="json")
+            concept.model_dump(
+                exclude={"labelled_passages", "classifier_ids"}, mode="python"
+            )
             for concept in concepts
         ]
     )
 
-    # Force explicit dtypes so empty/None columns don't infer as Null or
-    # List(Null), which differ from populated columns and break unioning the
-    # archive's Parquet files across runs.
+    # Cast Null columns to proper types for consistent schema Polars
+    # infers Null type when all values are None, but we want explicit
+    # types.
     schema_casts = {
         "description": pl.Utf8,
         "definition": pl.Utf8,
-        "wikibase_id": pl.Utf8,
-        "wikibase_revision": pl.Int64,
-        "alternative_labels": pl.List(pl.Utf8),
-        "negative_labels": pl.List(pl.Utf8),
-        "subconcept_of": pl.List(pl.Utf8),
-        "has_subconcept": pl.List(pl.Utf8),
-        "related_concepts": pl.List(pl.Utf8),
-        "negative_concepts": pl.List(pl.Utf8),
-        "classifier_ids": pl.List(pl.List(pl.Utf8)),  # (rank, id) pairs
         "recursive_subconcept_of": pl.List(pl.Utf8),
         "recursive_has_subconcept": pl.List(pl.Utf8),
     }
 
-    casts = [
-        pl.col(col).cast(dtype)
-        for col, dtype in schema_casts.items()
-        if col in df.columns and df[col].dtype != dtype
-    ]
-    if casts:
-        df = df.with_columns(casts)
+    for col, dtype in schema_casts.items():
+        if col in df.columns and df[col].dtype == pl.Null:
+            df = df.with_columns(pl.col(col).cast(dtype))
 
     # Add sync timestamp to track when this version was synced
     df = df.with_columns(pl.lit(datetime.now(timezone.utc)).alias("synced_at"))

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -44,7 +44,12 @@ from flows.wikibase_to_s3 import Config as WikibaseToS3Config
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.concept import Concept
 from knowledge_graph.config import wandb_model_artifact_filename
-from knowledge_graph.identifiers import Identifier, WikibaseID
+from knowledge_graph.identifiers import (
+    ClassifierID,
+    Identifier,
+    StatementRank,
+    WikibaseID,
+)
 from knowledge_graph.labelled_passage import LabelledPassage
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -715,6 +720,27 @@ def mock_concepts() -> Generator[list[Concept], None, None]:
             preferred_label="short-lived climate pollutant",
         ),
     ]
+
+
+@pytest.fixture
+def fully_populated_concept() -> Concept:
+    """A Concept with every collection field populated (ENRI-1505 regression)."""
+    return Concept(
+        wikibase_id=WikibaseID("Q40"),
+        wikibase_revision=42,
+        preferred_label="rising sea levels",
+        alternative_labels=["sea level rise"],
+        negative_labels=["falling sea levels"],
+        description="A short description of rising sea levels",
+        definition="A more exhaustive definition of rising sea levels",
+        subconcept_of=[WikibaseID("Q41")],
+        has_subconcept=[WikibaseID("Q42")],
+        related_concepts=[WikibaseID("Q43")],
+        negative_concepts=[WikibaseID("Q44")],
+        classifier_ids=[(StatementRank.PREFERRED, ClassifierID("abc23456"))],
+        recursive_subconcept_of=[WikibaseID("Q41"), WikibaseID("Q45")],
+        recursive_has_subconcept=[WikibaseID("Q42"), WikibaseID("Q46")],
+    )
 
 
 @pytest.fixture

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -114,6 +114,61 @@ def test_dataframe_to_concepts__roundtrip_fully_populated(fully_populated_concep
     )
 
 
+def test_concepts_to_dataframe__output_columns_are_pinned(fully_populated_concept):
+    """
+    Guard against unhandled Concept schema changes (ENRI-1505).
+
+    The columns written to S3 are pinned here. If a field is added to Concept
+    it will show up as a new column (or, if it can't be serialised, break the
+    sync), and this test will fail - prompting a decision about whether the new
+    field should be persisted or added to the exclude set in
+    concepts_to_dataframe to keep the output schema consistent.
+    """
+    df = concepts_to_dataframe([fully_populated_concept])
+
+    # classifier_ids and labelled_passages are deliberately excluded; id is a
+    # computed field and synced_at is added by concepts_to_dataframe.
+    expected_columns = {
+        "id",
+        "preferred_label",
+        "alternative_labels",
+        "negative_labels",
+        "description",
+        "definition",
+        "wikibase_id",
+        "wikibase_revision",
+        "subconcept_of",
+        "has_subconcept",
+        "related_concepts",
+        "negative_concepts",
+        "recursive_subconcept_of",
+        "recursive_has_subconcept",
+        "synced_at",
+    }
+    assert set(df.columns) == expected_columns
+
+
+def test_concepts_to_dataframe__schema_stable_across_files(
+    mock_concepts, fully_populated_concept, tmp_path
+):
+    """
+    Empty and populated concepts must produce the same Parquet schema (ENRI-1505).
+
+    The flow scans the archive as a glob of Parquet files written by separate
+    runs. Without explicit dtypes an empty list field infers List(Null) while a
+    populated one infers List(String), so files from different runs cannot be
+    read together. Write both and read them back as one to prove they union.
+    """
+    concepts_to_dataframe(mock_concepts).write_parquet(tmp_path / "empty.parquet")
+    concepts_to_dataframe([fully_populated_concept]).write_parquet(
+        tmp_path / "populated.parquet"
+    )
+
+    combined = pl.read_parquet(tmp_path / "*.parquet")
+
+    assert len(combined) == len(mock_concepts) + 1
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "existing_count,expected_new",

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -98,28 +98,20 @@ def test_dataframe_to_concepts__empty_dataframe():
     assert [] == dataframe_to_concepts(df)
 
 
-def test_dataframe_to_concepts__roundtrip_full_equality(fully_populated_concept):
-    """Test roundtrip with every field populated (ENRI-1505 regression)."""
+def test_dataframe_to_concepts__roundtrip_fully_populated(fully_populated_concept):
+    """
+    A concept with every field populated survives the roundtrip (ENRI-1505).
+
+    classifier_ids is deliberately excluded from what is written to S3 (see
+    concepts_to_dataframe), so it is not expected to round-trip.
+    """
     df = concepts_to_dataframe([fully_populated_concept])
     recovered = dataframe_to_concepts(df)
 
-    assert recovered == [fully_populated_concept]
-
-
-def test_concepts_to_dataframe__parquet_schema_stable_across_files(
-    mock_concepts, fully_populated_concept, tmp_path
-):
-    """Parquet files with empty and populated fields share one schema (ENRI-1505)."""
-    concepts_to_dataframe(mock_concepts).write_parquet(tmp_path / "empty.parquet")
-    concepts_to_dataframe([fully_populated_concept]).write_parquet(
-        tmp_path / "populated.parquet"
+    assert len(recovered) == 1
+    assert recovered[0].model_dump(exclude={"classifier_ids"}) == (
+        fully_populated_concept.model_dump(exclude={"classifier_ids"})
     )
-
-    combined = pl.read_parquet(tmp_path / "*.parquet")
-
-    assert len(combined) == len(mock_concepts) + 1
-    recovered = dataframe_to_concepts(combined)
-    assert fully_populated_concept in recovered
 
 
 @pytest.mark.asyncio

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -98,6 +98,30 @@ def test_dataframe_to_concepts__empty_dataframe():
     assert [] == dataframe_to_concepts(df)
 
 
+def test_dataframe_to_concepts__roundtrip_full_equality(fully_populated_concept):
+    """Test roundtrip with every field populated (ENRI-1505 regression)."""
+    df = concepts_to_dataframe([fully_populated_concept])
+    recovered = dataframe_to_concepts(df)
+
+    assert recovered == [fully_populated_concept]
+
+
+def test_concepts_to_dataframe__parquet_schema_stable_across_files(
+    mock_concepts, fully_populated_concept, tmp_path
+):
+    """Parquet files with empty and populated fields share one schema (ENRI-1505)."""
+    concepts_to_dataframe(mock_concepts).write_parquet(tmp_path / "empty.parquet")
+    concepts_to_dataframe([fully_populated_concept]).write_parquet(
+        tmp_path / "populated.parquet"
+    )
+
+    combined = pl.read_parquet(tmp_path / "*.parquet")
+
+    assert len(combined) == len(mock_concepts) + 1
+    recovered = dataframe_to_concepts(combined)
+    assert fully_populated_concept in recovered
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "existing_count,expected_new",


### PR DESCRIPTION
concepts_to_dataframe let Polars infer the schema from model_dump() output. A populated classifier_ids (list[tuple[StatementRank, ClassifierID]]) crashed inference and took down the whole sync flow.

- dump concepts with mode="json" so enums and custom types flatten to primitives Polars can handle
- cast every nullable/list column to an explicit dtype so empty and populated concepts produce one stable schema across Parquet files
- add regression tests: a roundtrip on a fully populated concept, and a cross-file Parquet schema-stability check