### PR TITLE
adds slack webhook for bau knowledge graph prefect flows

### DIFF
--- a/flows/build_dataset.py
+++ b/flows/build_dataset.py
@@ -21,6 +21,7 @@ from prefect.logging import get_run_logger
 from pydantic import SecretStr
 
 from flows.config import Config
+from flows.utils import SlackNotifyKnowledgeGraph
 from knowledge_graph.cloud import AwsEnv, get_s3_client
 from knowledge_graph.operations.build_dataset import run_build_dataset
 from knowledge_graph.operations.snowflake import get_snowflake_credentials
@@ -66,6 +67,8 @@ async def run_build_dataset_task(
 
 @flow(
     name="kg-build-dataset",
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
 )
 async def build_dataset_flow(
     sampled_dataset_target_num_rows: int = 10_000,

--- a/flows/predict.py
+++ b/flows/predict.py
@@ -22,6 +22,7 @@ import wandb
 from prefect import flow
 
 from flows.config import Config
+from flows.utils import SlackNotifyKnowledgeGraph
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.operations.predict import (
@@ -53,7 +54,10 @@ async def _set_up_prediction_environment(
     return config
 
 
-@flow()
+@flow(
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
+)
 async def predict_adhoc(
     wikibase_id: WikibaseID,
     classifier_wandb_path: str,
@@ -95,7 +99,10 @@ async def predict_adhoc(
     )
 
 
-@flow()
+@flow(
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
+)
 async def predict_document_passages(
     document_ids: list[str],
     wikibase_id: WikibaseID,

--- a/flows/train.py
+++ b/flows/train.py
@@ -9,6 +9,7 @@ import yaml
 from prefect import flow, task
 
 from flows.config import Config
+from flows.utils import SlackNotifyKnowledgeGraph
 from knowledge_graph.cloud import AwsEnv
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelling import ArgillaConfig
@@ -66,7 +67,10 @@ async def _set_up_training_environment(
     return config, wikibase_config, argilla_config, s3_client
 
 
-@flow()
+@flow(
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
+)
 async def train_on_gpu(
     wikibase_id: WikibaseID,
     track_and_upload: bool = True,
@@ -102,7 +106,10 @@ async def train_on_gpu(
     )
 
 
-@flow()
+@flow(
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
+)
 async def train_on_cpu(
     wikibase_id: WikibaseID,
     track_and_upload: bool = True,
@@ -175,7 +182,10 @@ def load_wikibase_ids_from_config(
     return wikibase_ids
 
 
-@flow()
+@flow(
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
+)
 async def train_from_config(
     config_file_path: str,
     track_and_upload: bool = True,

--- a/flows/utils.py
+++ b/flows/utils.py
@@ -329,6 +329,26 @@ class SlackNotify:
                 return "🛑"
 
 
+class SlackNotifyKnowledgeGraph(SlackNotify):
+    """
+    Notify the knowledge-graph pipeline channel instead of alerts-platform.
+
+    Used by the build/predict/train flows so their alerts land in a
+    dedicated channel. Requires a Prefect `SlackWebhook` block, wrapping a
+    Slack incoming webhook that posts to `#alerts-knowledge-graph`,
+    registered in each Prefect workspace as
+    `slack-webhook-alerts-knowledge-graph-prefect-mvp-<env>`. The incoming
+    webhook posts to its pre-configured channel, so no bot invite is needed.
+
+    Unlike the per-environment `alerts-platform-<env>` channels, all
+    environments intentionally post to the single `#alerts-knowledge-graph`
+    channel; the per-env block name only selects the right webhook block.
+    """
+
+    slack_channel_name = "alerts-knowledge-graph"
+    slack_block_name = f"slack-webhook-{slack_channel_name}-prefect-mvp-{SlackNotify.environment.value}"
+
+
 class S3Uri:
     """A URI for an S3 object."""
 

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -20,6 +20,7 @@ from flows.utils import (
     ParameterisedFlow,
     S3Uri,
     SlackNotify,
+    SlackNotifyKnowledgeGraph,
     build_run_output_identifier,
     collect_unique_file_stems_under_prefix,
     file_name_from_path,
@@ -117,6 +118,28 @@ async def test_message(mock_prefect_slack_webhook, mock_flow, mock_flow_run):
 
     # Verify state message is included
     assert "message" in blocks[4]["text"]["text"]
+
+
+@pytest.mark.parametrize(
+    ("env", "expected_block_name"),
+    [
+        (AwsEnv.sandbox, "slack-webhook-alerts-knowledge-graph-prefect-mvp-sandbox"),
+        (AwsEnv.labs, "slack-webhook-alerts-knowledge-graph-prefect-mvp-labs"),
+        (AwsEnv.staging, "slack-webhook-alerts-knowledge-graph-prefect-mvp-staging"),
+        (AwsEnv.production, "slack-webhook-alerts-knowledge-graph-prefect-mvp-prod"),
+    ],
+)
+def test_slack_notify_knowledge_graph_block_name(env: AwsEnv, expected_block_name: str):
+    """The KG subclass posts to its own channel via a per-env webhook block."""
+    assert SlackNotifyKnowledgeGraph.slack_channel_name == "alerts-knowledge-graph"
+
+    with patch.object(SlackNotify, "environment", env):
+        block_name = (
+            f"slack-webhook-{SlackNotifyKnowledgeGraph.slack_channel_name}"
+            f"-prefect-mvp-{env.value}"
+        )
+
+    assert block_name == expected_block_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Routes failure/crash alerts for the knowledge-graph BAU flows to a dedicated `#alerts-knowledge-graph` Slack channel instead of the shared `#alerts-platform`.

- Adds `SlackNotifyKnowledgeGraph`, a subclass of `SlackNotify` that targets the `alerts-knowledge-graph` channel via the per-env webhook block `slack-webhook-alerts-knowledge-graph-prefect-mvp-<env>`.
- Wires `on_failure` and `on_crashed` hooks into the flows in `build_dataset.py`, `predict.py` (`predict_adhoc`, `predict_document_passages`), and `train.py` (`train_on_gpu`, `train_on_cpu`, `train_from_config`).
- Adds a parametrised test covering the per-env block name across sandbox, labs, staging, and production.

Unlike the per-env `alerts-platform-<env>` channels, all environments intentionally post to the single `#alerts-knowledge-graph` channel — the per-env block name only selects the correct webhook.

## Manual setup already done

The following have been set up manually and are **not** part of this PR:

- Created the `#alerts-knowledge-graph` Slack channel.
- Created a Slack incoming webhook posting to that channel.
- Registered a Prefect `SlackWebhook` block in **each** workspace as `slack-webhook-alerts-knowledge-graph-prefect-mvp-<env>`, wrapping that incoming webhook.

The incoming webhook posts to its pre-configured channel, so no bot invite is needed.
