### PR TITLE
fix: tolerate legacy schema drift when scanning the concept sync archive

### DIFF
--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -251,6 +251,32 @@ async def s3_prefix_has_objects(s3_uri: S3Uri, region: str, aws_env: AwsEnv) -> 
         return "Contents" in response and len(response["Contents"]) > 0
 
 
+def load_existing_ids(
+    parquet_pattern: str,
+    credential_provider: pl.CredentialProvider | None,
+    storage_options: dict[str, str] | None,
+) -> pl.LazyFrame:
+    """
+    Load concept IDs from the archive's Parquet files.
+
+    Only `id` is needed here, so schema drift between files written by
+    different versions of concepts_to_dataframe (e.g. a column that's since
+    been excluded, like classifier_ids) is tolerated rather than treated as
+    a fatal error.
+    """
+    return (
+        pl.scan_parquet(
+            parquet_pattern,
+            credential_provider=credential_provider,
+            storage_options=storage_options,
+            extra_columns="ignore",
+            missing_columns="insert",
+        )
+        .select("id")
+        .unique()
+    )
+
+
 @task(cache_policy=NONE)
 async def get_new_versions(
     current_df: pl.LazyFrame,
@@ -983,14 +1009,10 @@ async def sync_concepts(
     if archives_exist:
         logger.info("loading existing ID(s) from archive(s)")
         parquet_pattern = f"{concepts_archive_path}/*.parquet"
-        existing_ids = (
-            pl.scan_parquet(
-                parquet_pattern,
-                credential_provider=credential_provider,
-                storage_options=storage_options,
-            )
-            .select("id")
-            .unique()
+        existing_ids = load_existing_ids(
+            parquet_pattern,
+            credential_provider,
+            storage_options,
         )
 
     logger.info("getting new versions")

--- a/flows/sync_concepts.py
+++ b/flows/sync_concepts.py
@@ -251,32 +251,6 @@ async def s3_prefix_has_objects(s3_uri: S3Uri, region: str, aws_env: AwsEnv) -> 
         return "Contents" in response and len(response["Contents"]) > 0
 
 
-def load_existing_ids(
-    parquet_pattern: str,
-    credential_provider: pl.CredentialProvider | None,
-    storage_options: dict[str, str] | None,
-) -> pl.LazyFrame:
-    """
-    Load concept IDs from the archive's Parquet files.
-
-    Only `id` is needed here, so schema drift between files written by
-    different versions of concepts_to_dataframe (e.g. a column that's since
-    been excluded, like classifier_ids) is tolerated rather than treated as
-    a fatal error.
-    """
-    return (
-        pl.scan_parquet(
-            parquet_pattern,
-            credential_provider=credential_provider,
-            storage_options=storage_options,
-            extra_columns="ignore",
-            missing_columns="insert",
-        )
-        .select("id")
-        .unique()
-    )
-
-
 @task(cache_policy=NONE)
 async def get_new_versions(
     current_df: pl.LazyFrame,
@@ -1009,10 +983,20 @@ async def sync_concepts(
     if archives_exist:
         logger.info("loading existing ID(s) from archive(s)")
         parquet_pattern = f"{concepts_archive_path}/*.parquet"
-        existing_ids = load_existing_ids(
-            parquet_pattern,
-            credential_provider,
-            storage_options,
+        existing_ids = (
+            pl.scan_parquet(
+                parquet_pattern,
+                credential_provider=credential_provider,
+                storage_options=storage_options,
+                # Only `id` is needed here, so tolerate schema drift between
+                # archive files written by different versions of
+                # concepts_to_dataframe (e.g. a column that's since been
+                # excluded, like classifier_ids) instead of failing the scan.
+                extra_columns="ignore",
+                missing_columns="insert",
+            )
+            .select("id")
+            .unique()
         )
 
     logger.info("getting new versions")

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -13,7 +13,6 @@ from flows.sync_concepts import (
     dataframe_to_concepts,
     get_new_versions,
     load_concepts,
-    load_existing_ids,
     s3_prefix_has_objects,
     send_concept_validation_alert,
     update_concept_in_vespa,
@@ -222,25 +221,6 @@ async def test_get_new_versions__no_archive(mock_concepts, tmp_path):
         .sort("id")
         .equals(expected_df.select(cols_to_compare).sort("id"))
     )
-
-
-def test_load_existing_ids__tolerates_extra_column_in_legacy_file(tmp_path):
-    """
-    A legacy archive file with a since-dropped column must not break the scan.
-
-    Reproduces the production incident where an older run's Parquet file
-    still had a `classifier_ids` column that later versions of
-    concepts_to_dataframe stopped writing, which made Polars' default
-    strict schema-matching fail the entire scan across the archive.
-    """
-    pl.DataFrame({"id": ["a", "b"]}).write_parquet(tmp_path / "current.parquet")
-    pl.DataFrame(
-        {"id": ["c"], "classifier_ids": [[["ok", "Q1"]]]}
-    ).write_parquet(tmp_path / "legacy_with_extra_column.parquet")
-
-    existing_ids = load_existing_ids(f"{tmp_path}/*.parquet", None, None).collect()
-
-    assert set(existing_ids["id"]) == {"a", "b", "c"}
 
 
 @pytest.mark.asyncio

--- a/tests/flows/test_sync_concepts.py
+++ b/tests/flows/test_sync_concepts.py
@@ -13,6 +13,7 @@ from flows.sync_concepts import (
     dataframe_to_concepts,
     get_new_versions,
     load_concepts,
+    load_existing_ids,
     s3_prefix_has_objects,
     send_concept_validation_alert,
     update_concept_in_vespa,
@@ -221,6 +222,25 @@ async def test_get_new_versions__no_archive(mock_concepts, tmp_path):
         .sort("id")
         .equals(expected_df.select(cols_to_compare).sort("id"))
     )
+
+
+def test_load_existing_ids__tolerates_extra_column_in_legacy_file(tmp_path):
+    """
+    A legacy archive file with a since-dropped column must not break the scan.
+
+    Reproduces the production incident where an older run's Parquet file
+    still had a `classifier_ids` column that later versions of
+    concepts_to_dataframe stopped writing, which made Polars' default
+    strict schema-matching fail the entire scan across the archive.
+    """
+    pl.DataFrame({"id": ["a", "b"]}).write_parquet(tmp_path / "current.parquet")
+    pl.DataFrame(
+        {"id": ["c"], "classifier_ids": [[["ok", "Q1"]]]}
+    ).write_parquet(tmp_path / "legacy_with_extra_column.parquet")
+
+    existing_ids = load_existing_ids(f"{tmp_path}/*.parquet", None, None).collect()
+
+    assert set(existing_ids["id"]) == {"a", "b", "c"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `sync_concepts` was crashing every run because `pl.scan_parquet` enforces one identical schema across every file it globs in the archive, and one legacy file (`concepts_20260715_080922.parquet`) still has a `classifier_ids` column that later versions of `concepts_to_dataframe` stopped writing.
- Since the archive scan only ever needs the `id` column, extract it into `load_existing_ids()` and pass `extra_columns="ignore"` / `missing_columns="insert"` so schema drift between old and new archive files no longer fails the whole scan.
- This fixes the failure without deleting or rewriting any existing S3 archive data, and without losing sync history (see Slack thread on `sync-concepts/true-skylark`).
- Staging run [here](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/06a676e2-7da2-7333-8000-7d926d6820e4?preview=true&tab=logs).

## Test plan
- [x] Added `test_load_existing_ids__tolerates_extra_column_in_legacy_file`, which reproduces the incident (one archive file with an extra column) and asserts the scan succeeds. This is now removed as I didn't feel we needed it going forwards. 
- [x] `pytest tests/flows/test_sync_concepts.py -k "load_existing_ids or get_new_versions or concepts_to_dataframe or dataframe_to_concepts"` — 11 passed.
- [x] CI
- [x] Staging deployment and run 

🤖 Generated with [Claude Code](https://claude.com/claude-code)