### PR TITLE
vibe checker trains concepts with no wandb project

### DIFF
--- a/knowledge_graph/operations/train.py
+++ b/knowledge_graph/operations/train.py
@@ -274,6 +274,17 @@ def create_and_link_model_artifact(
     return artifact
 
 
+def _latest_artifact_path(namespace: Namespace, target_path: ModelPath) -> str:
+    """
+    Build the W&B path to the latest version of a classifier artifact.
+
+    :param namespace: The W&B configuration containing project and entity.
+    :param target_path: The path to the classifier in W&B.
+    :return: The fully qualified artifact path, e.g. 'my_entity/Q123/v4prnc54:latest'.
+    """
+    return f"{namespace.entity}/{target_path}:latest"
+
+
 def classifier_exists_in_wandb(
     namespace: Namespace,
     target_path: ModelPath,
@@ -287,7 +298,7 @@ def classifier_exists_in_wandb(
     """
 
     api = wandb.Api()
-    return api.artifact_exists(f"{namespace.entity}/{target_path}:latest")
+    return api.artifact_exists(_latest_artifact_path(namespace, target_path))
 
 
 def get_next_version(
@@ -309,7 +320,7 @@ def get_next_version(
     """
 
     api = wandb.Api()
-    artifact_path = f"{namespace.entity}/{target_path}:latest"
+    artifact_path = _latest_artifact_path(namespace, target_path)
 
     if api.artifact_exists(artifact_path):
         artifact = api.artifact(artifact_path)

--- a/knowledge_graph/operations/train.py
+++ b/knowledge_graph/operations/train.py
@@ -8,7 +8,6 @@ nothing about Prefect; it is imported directly by the training flows and CLI wra
 
 import os
 import random
-import re
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, overload
@@ -17,7 +16,6 @@ import torch
 import typer
 import wandb
 from pydantic import BaseModel, Field
-from wandb.errors.errors import CommError
 from wandb.sdk.wandb_run import Run
 
 from knowledge_graph.classifier import (
@@ -287,19 +285,9 @@ def classifier_exists_in_wandb(
     :param target_path: The path to the classifier in W&B.
     :return: True if the artifact exists, False otherwise.
     """
-    try:
-        api = wandb.Api()
-        api.artifact(f"{namespace.entity}/{target_path}:latest")
-        return True
-    except CommError as e:
-        error_message = str(e)
-        # Check if the error is because the artifact doesn't exist
-        # Error format: "artifact membership '...' not found in '{entity}/{wikibase_id}'"
-        pattern = rf"artifact membership '.*?' not found in '{namespace.entity}/{target_path.wikibase_id}'"
-        if re.search(pattern, error_message):
-            return False
-        # Re-raise if it's a different error (e.g., network issue)
-        raise
+
+    api = wandb.Api()
+    return api.artifact_exists(f"{namespace.entity}/{target_path}:latest")
 
 
 def get_next_version(
@@ -319,21 +307,18 @@ def get_next_version(
     :return: The next version string.
     :rtype: str
     """
-    try:
-        api = wandb.Api()
-        artifact = api.artifact(f"{namespace.entity}/{target_path}:latest")
+
+    api = wandb.Api()
+    artifact_path = f"{namespace.entity}/{target_path}:latest"
+
+    if api.artifact_exists(artifact_path):
+        artifact = api.artifact(artifact_path)
         next_version = Version(artifact._version).increment()  # type: ignore[reportArgumentType]
-    except CommError as e:
-        error_message = str(e)
-        wikibase_id = classifier.concept.wikibase_id
-        pattern = rf"artifact membership '.*?' not found in '{namespace.entity}/{wikibase_id}'"
-        if re.search(pattern, error_message):
-            get_logger().info(
-                f"No previous wandb version found, '{target_path}' will be at v0"
-            )
-            next_version = Version("v0")
-        else:
-            raise
+    else:
+        get_logger().info(
+            f"No previous wandb version found, '{target_path}' will be at v0"
+        )
+        next_version = Version("v0")
 
     return str(next_version)
 

--- a/tests/operations/test_train.py
+++ b/tests/operations/test_train.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 import pytest
 from wandb.errors.errors import CommError
 
+from knowledge_graph.classifier import ModelPath
 from knowledge_graph.classifier.targets import TargetClassifier
 from knowledge_graph.cloud import AwsEnv, Namespace
 from knowledge_graph.config import wandb_model_artifact_filename
@@ -13,6 +14,7 @@ from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.operations.train import (
     StorageLink,
     StorageUpload,
+    classifier_exists_in_wandb,
     create_and_link_model_artifact,
     deduplicate_training_data,
     get_next_version,
@@ -244,6 +246,7 @@ def test_create_and_link_model_artifact():
 def test_get_next_version_with_existing(mock_api):
     mock_artifact = Mock()
     mock_artifact._version = "v2"
+    mock_api.return_value.artifact_exists.return_value = True
     mock_api.return_value.artifact.return_value = mock_artifact
 
     namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
@@ -258,17 +261,74 @@ def test_get_next_version_with_existing(mock_api):
 
 @patch("wandb.Api")
 def test_get_next_version_with_default(mock_api):
+    """A concept with no existing artifact starts at v0."""
     namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
     mock_classifier = Mock()
     mock_classifier.concept.wikibase_id = "Q123"
 
-    mock_api.side_effect = CommError(
-        "artifact membership 'test_classifier:latest' not found in 'test_entity/Q123'"
-    )
+    # False covers both a missing artifact and a project that doesn't exist yet
+    mock_api.return_value.artifact_exists.return_value = False
+
     wandb_target_entity = f"{namespace.project}/{mock_classifier.id}"
     next_version = get_next_version(namespace, wandb_target_entity, mock_classifier)
 
     assert next_version == "v0"
+    # The artifact itself must not be fetched when it doesn't exist
+    mock_api.return_value.artifact.assert_not_called()
+
+
+@patch("wandb.Api")
+def test_get_next_version_propagates_transport_errors(mock_api):
+    """A network failure must not be mistaken for a missing artifact."""
+    namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
+    mock_classifier = Mock()
+    mock_classifier.concept.wikibase_id = "Q123"
+
+    mock_api.return_value.artifact_exists.side_effect = CommError("connection failed")
+
+    target_path = ModelPath(
+        wikibase_id=WikibaseID("Q123"), classifier_id=ClassifierID("v4prnc54")
+    )
+    with pytest.raises(CommError):
+        get_next_version(namespace, target_path, mock_classifier)
+
+
+@pytest.mark.parametrize("exists", [True, False])
+@patch("wandb.Api")
+def test_classifier_exists_in_wandb(mock_api, exists):
+    """
+    Existence is delegated to W&B rather than inferred from error messages.
+
+    `artifact_exists` reports False both when the artifact is missing and when the
+    project doesn't exist at all, which is the case for a never-before-trained concept.
+    """
+    mock_api.return_value.artifact_exists.return_value = exists
+
+    namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
+    target_path = ModelPath(
+        wikibase_id=WikibaseID("Q123"), classifier_id=ClassifierID("v4prnc54")
+    )
+
+    assert classifier_exists_in_wandb(namespace=namespace, target_path=target_path) is (
+        exists
+    )
+    mock_api.return_value.artifact_exists.assert_called_once_with(
+        "test_entity/Q123/v4prnc54:latest"
+    )
+
+
+@patch("wandb.Api")
+def test_classifier_exists_in_wandb_propagates_transport_errors(mock_api):
+    """A network failure must not be reported as a missing classifier."""
+    mock_api.return_value.artifact_exists.side_effect = CommError("connection failed")
+
+    namespace = Namespace(project=WikibaseID("Q123"), entity="test_entity")
+    target_path = ModelPath(
+        wikibase_id=WikibaseID("Q123"), classifier_id=ClassifierID("v4prnc54")
+    )
+
+    with pytest.raises(CommError):
+        classifier_exists_in_wandb(namespace=namespace, target_path=target_path)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When we've never trained a classifier for a concept before, there's no W&B project. The old `classifier_exists_in_wandb` logic was super brittle and raised when the project didn't exist.

In this PR:

- defer to W&B to tell us whether an artifact exists, and update the tests
- small refactoring out of finding the latest artifact path. I initially wanted to use `classifier_exists_in_wandb` in `get_next_version` but that feels too coupled, given both are used by different tasks with different owners

This is now fixed – run successfully locally on the 8 mitigation concepts which had never been trained before (note the screenshot contains 3 more concepts).  

<img width="1325" height="986" alt="image" src="https://github.com/user-attachments/assets/8f9c24c4-b24c-43d0-863b-3e814ad44dba" />
