### PR TITLE
fixes for span metrics and merging

### DIFF
--- a/knowledge_graph/metrics.py
+++ b/knowledge_graph/metrics.py
@@ -129,7 +129,6 @@ def count_span_level_metrics(
                     break
             if not found:
                 cm.false_negatives += 1
-                break
 
         for predicted_span in predicted_passage.spans:
             found = False
@@ -139,7 +138,6 @@ def count_span_level_metrics(
                     break
             if not found:
                 cm.false_positives += 1
-                break
 
     return cm
 

--- a/knowledge_graph/span.py
+++ b/knowledge_graph/span.py
@@ -2,7 +2,7 @@ import re
 from collections import OrderedDict
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import Optional, Sequence
+from typing import Optional, Sequence, cast
 
 from pydantic import BaseModel, Field, computed_field, model_validator
 from typing_extensions import Self
@@ -145,6 +145,40 @@ class Span(BaseModel):
         if len(spans) == 0:
             raise ValueError("Cannot merge an empty list of spans")
 
+    @staticmethod
+    def _merge_labellers_and_timestamps(
+        spans: list["Span"],
+    ) -> tuple[list[str], list[datetime]]:
+        """
+        Combine the unique labellers of a set of spans, keeping them ordered.
+
+        Timestamps are only carried over if every labeller has one, since the two lists
+        must stay aligned. `timestamps` is optional on a Span, so a span can legitimately
+        have labellers and no timestamps.
+
+        :param list[Span] spans: The spans being merged
+        :return tuple[list[str], list[datetime]]: the merged labellers, and their
+            timestamps if all of them are known
+        """
+        labeller_to_timestamp: OrderedDict[str, datetime | None] = OrderedDict()
+
+        # Assume labellers and timestamps are ordered to match each other already.
+        for span in spans:
+            for i, labeller in enumerate(span.labellers):
+                # Prefer the first seen timestamp for each labeller
+                if labeller not in labeller_to_timestamp:
+                    labeller_to_timestamp[labeller] = (
+                        span.timestamps[i] if i < len(span.timestamps) else None
+                    )
+
+        labellers = list(labeller_to_timestamp.keys())
+        timestamps = list(labeller_to_timestamp.values())
+
+        if any(timestamp is None for timestamp in timestamps):
+            return labellers, []
+
+        return labellers, cast(list[datetime], timestamps)
+
     @classmethod
     def union(cls, spans: list["Span"]) -> "Span":
         """
@@ -162,24 +196,15 @@ class Span(BaseModel):
         if len(spans) == 1:
             return spans[0]
         else:
-            # Combine unique labellers and their timestamps
-            labeller_to_timestamp: OrderedDict[str, datetime] = OrderedDict()
-
-            # Assume labellers and timestamps are ordered to match
-            # each other already.
-            for span in spans:
-                for i, labeller in enumerate(span.labellers):
-                    # Prefer the first seen timestamp for each labeller
-                    if labeller not in labeller_to_timestamp:
-                        labeller_to_timestamp[labeller] = span.timestamps[i]
+            labellers, timestamps = cls._merge_labellers_and_timestamps(spans)
 
             return Span(
                 text=spans[0].text,
                 start_index=min(span.start_index for span in spans),
                 end_index=max(span.end_index for span in spans),
                 concept_id=spans[0].concept_id,
-                labellers=list(labeller_to_timestamp.keys()),
-                timestamps=list(labeller_to_timestamp.values()),
+                labellers=labellers,
+                timestamps=timestamps,
             )
 
     @classmethod
@@ -199,24 +224,15 @@ class Span(BaseModel):
         if len(spans) == 1:
             return spans[0]
         else:
-            # Combine unique labellers and their timestamps
-            labeller_to_timestamp: OrderedDict[str, datetime] = OrderedDict()
-
-            # Assume labellers and timestamps are ordered to match
-            # each other already.
-            for span in spans:
-                for i, labeller in enumerate(span.labellers):
-                    # Prefer the first seen timestamp for each labeller
-                    if labeller not in labeller_to_timestamp:
-                        labeller_to_timestamp[labeller] = span.timestamps[i]
+            labellers, timestamps = cls._merge_labellers_and_timestamps(spans)
 
             return Span(
                 text=spans[0].text,
                 start_index=max(span.start_index for span in spans),
                 end_index=min(span.end_index for span in spans),
                 concept_id=spans[0].concept_id,
-                labellers=list(labeller_to_timestamp.keys()),
-                timestamps=list(labeller_to_timestamp.values()),
+                labellers=labellers,
+                timestamps=timestamps,
             )
 
     def overlaps(self, other: "Span") -> bool:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,87 @@
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.metrics import (
+    count_passage_level_metrics,
+    count_span_level_metrics,
+)
+from knowledge_graph.span import Span
+
+TEXT = "Solar power, wind power and coal power are all sources of electricity."
+CONCEPT_ID = WikibaseID("Q42")
+
+
+def span(start: int, end: int) -> Span:
+    """Build a span over the shared test text."""
+    return Span(
+        text=TEXT,
+        start_index=start,
+        end_index=end,
+        concept_id=CONCEPT_ID,
+        labellers=["labeller"],
+    )
+
+
+def passage(spans: list[Span], passage_id: str = "passage-1") -> LabelledPassage:
+    """Build a labelled passage over the shared test text."""
+    return LabelledPassage(id=passage_id, text=TEXT, spans=spans)
+
+
+def test_whether_every_unmatched_gold_span_counts_as_a_false_negative():
+    """Each missed gold span is its own false negative, not one per passage."""
+    gold = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+    predicted = [passage([])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.false_negatives == 3
+    assert cm.true_positives == 0
+
+
+def test_whether_every_unmatched_predicted_span_counts_as_a_false_positive():
+    """Each spurious predicted span is its own false positive."""
+    gold = [passage([])]
+    predicted = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.false_positives == 3
+    assert cm.true_negatives == 0
+
+
+def test_whether_matches_are_still_counted_after_an_earlier_miss():
+    """A missed gold span must not stop the remaining gold spans being scored."""
+    gold = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+    # Matches the second and third gold spans, misses the first
+    predicted = [passage([span(13, 23), span(28, 38)])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.true_positives == 2
+    assert cm.false_negatives == 1
+    assert cm.false_positives == 0
+
+
+def test_whether_a_passage_with_no_spans_either_side_is_a_true_negative():
+    """Agreement that a passage contains nothing is a true negative."""
+    cm = count_span_level_metrics([passage([])], [passage([])], threshold=0)
+
+    assert cm.true_negatives == 1
+    assert cm.support() == 1
+
+
+def test_whether_passage_level_metrics_count_passages_not_spans():
+    """Passage-level scoring collapses however many spans a passage has into one label."""
+    gold = [
+        passage([span(0, 11), span(13, 23)], passage_id="a"),
+        passage([], passage_id="b"),
+    ]
+    predicted = [
+        passage([span(0, 11)], passage_id="a"),
+        passage([span(0, 11)], passage_id="b"),
+    ]
+
+    cm = count_passage_level_metrics(gold, predicted)
+
+    assert cm.true_positives == 1
+    assert cm.false_positives == 1
+    assert cm.support() == 2

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -543,6 +543,59 @@ def test_span_union_with_duplicate_labellers():
     assert merged_span.timestamps[0] == time1
 
 
+def test_span_union_with_unpopulated_timestamps():
+    """`timestamps` is optional, so union must not assume it's aligned with labellers."""
+
+    span_a = Span(
+        text="This is test text",
+        start_index=0,
+        end_index=4,
+        concept_id=WikibaseID("Q123"),
+        labellers=["alice"],
+    )
+
+    span_b = Span(
+        text="This is test text",
+        start_index=2,
+        end_index=6,
+        concept_id=WikibaseID("Q123"),
+        labellers=["bob"],
+    )
+
+    merged_span = Span.union(spans=[span_a, span_b])
+
+    assert merged_span.labellers == ["alice", "bob"]
+    # Timestamps are dropped rather than partially filled, so they stay aligned
+    assert merged_span.timestamps == []
+
+
+def test_span_union_drops_timestamps_when_only_some_are_known():
+    """A half-populated timestamp list can't stay aligned, so it's dropped entirely."""
+    from datetime import datetime, timezone
+
+    span_with_timestamp = Span(
+        text="This is test text",
+        start_index=0,
+        end_index=4,
+        concept_id=WikibaseID("Q123"),
+        labellers=["alice"],
+        timestamps=[datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
+    )
+
+    span_without_timestamp = Span(
+        text="This is test text",
+        start_index=2,
+        end_index=6,
+        concept_id=WikibaseID("Q123"),
+        labellers=["bob"],
+    )
+
+    merged_span = Span.union(spans=[span_with_timestamp, span_without_timestamp])
+
+    assert merged_span.labellers == ["alice", "bob"]
+    assert merged_span.timestamps == []
+
+
 def test_span_intersection_preserves_timestamps():
     from datetime import datetime, timezone
 


### PR DESCRIPTION
two fixes that Claude found while I was doing something else:

- misused `break`s meant that FP and FN spans were undercounted
- `Span.timestamp` is optional, and span merging crashed when timestamps were missing (fixing the robustness of the code rather than worrying about the root cause for now, as `Span` is used everywhere)