### PR TITLE
run LLM ensemble as eval set labeller experiment

### DIFF
--- a/knowledge_graph/ensemble/aggregation.py
+++ b/knowledge_graph/ensemble/aggregation.py
@@ -1,0 +1,81 @@
+"""
+Aggregation of an ensemble's per-classifier spans into a single set of spans.
+
+`Ensemble.predict` returns one list of spans per classifier, which is what the
+`EnsembleMetric`s in `knowledge_graph.ensemble.metrics` consume. Span-level
+evaluation (`knowledge_graph.metrics.count_span_level_metrics`) instead needs a
+single set of spans per passage, as if the ensemble were one classifier. The
+aggregators here perform that reduction.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from knowledge_graph.ensemble.metrics import MajorityVote
+from knowledge_graph.span import Span, merge_overlapping_spans
+
+
+class SpanAggregator(ABC):
+    """Reduces an ensemble's per-classifier spans to a single list of spans."""
+
+    @abstractmethod
+    def __call__(self, spans_per_classifier: Sequence[Sequence[Span]]) -> list[Span]:
+        """
+        Aggregate spans produced by an ensemble of classifiers.
+
+        :param Sequence[Sequence[Span]] spans_per_classifier: the spans output by
+            each classifier predicting on one piece of text
+        :return list[Span]: the aggregated, non-overlapping spans
+        """
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        """Return the name of the aggregator."""
+        return self.__class__.__name__
+
+
+class UnionAggregator(SpanAggregator):
+    """
+    Takes the union of all spans predicted by the ensemble's classifiers.
+
+    If passage-level results are derived from spans, this means that a passage is
+    positive if *any of the ensemble's classifiers* predicted a span on it.
+    """
+
+    def __init__(self, jaccard_threshold: float = 0):
+        self.jaccard_threshold = jaccard_threshold
+
+    def __call__(self, spans_per_classifier: Sequence[Sequence[Span]]) -> list[Span]:
+        """Merge all classifiers' spans into a list of non-overlapping spans."""
+
+        all_spans = [span for spans in spans_per_classifier for span in spans]
+
+        if not all_spans:
+            return []
+
+        return merge_overlapping_spans(all_spans, self.jaccard_threshold)
+
+
+class MajorityVoteAggregator(SpanAggregator):
+    """
+    The union of spans, but only if a majority of classifiers predicted anything at all.
+
+    Note the vote does not require the classifiers to agree on *where* the mention is:
+    five classifiers each flagging a different part of a passage are unanimous here, even
+    though they agree on no single span.
+
+    A 50/50 split counts as positive, matching `MajorityVote`.
+    """
+
+    def __init__(self, jaccard_threshold: float = 0):
+        self.jaccard_threshold = jaccard_threshold
+        self._majority_vote = MajorityVote()
+
+    def __call__(self, spans_per_classifier: Sequence[Sequence[Span]]) -> list[Span]:
+        """Merge all classifiers' spans, or return none if the vote fails."""
+
+        if self._majority_vote(spans_per_classifier) < 0.5:
+            return []
+
+        return UnionAggregator(self.jaccard_threshold)(spans_per_classifier)

--- a/knowledge_graph/metrics.py
+++ b/knowledge_graph/metrics.py
@@ -36,6 +36,28 @@ class ConfusionMatrix:
         except ZeroDivisionError:
             return 0
 
+    def negative_predictive_value(self) -> float:
+        """
+        The precision of a negative label.
+
+        https://en.wikipedia.org/wiki/Positive_and_negative_predictive_values
+        """
+        try:
+            return self.true_negatives / (self.true_negatives + self.false_negatives)
+        except ZeroDivisionError:
+            return 0
+
+    def specificity(self) -> float:
+        """
+        The recall of the negative class.
+
+        https://en.wikipedia.org/wiki/Sensitivity_and_specificity
+        """
+        try:
+            return self.true_negatives / (self.true_negatives + self.false_positives)
+        except ZeroDivisionError:
+            return 0
+
     def accuracy(self) -> float:
         """https://en.wikipedia.org/wiki/Accuracy_and_precision"""
         try:

--- a/knowledge_graph/metrics.py
+++ b/knowledge_graph/metrics.py
@@ -129,7 +129,6 @@ def count_span_level_metrics(
                     break
             if not found:
                 cm.false_negatives += 1
-                break
 
         for predicted_span in predicted_passage.spans:
             found = False
@@ -139,7 +138,6 @@ def count_span_level_metrics(
                     break
             if not found:
                 cm.false_positives += 1
-                break
 
     return cm
 

--- a/knowledge_graph/span.py
+++ b/knowledge_graph/span.py
@@ -2,7 +2,7 @@ import re
 from collections import OrderedDict
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import Optional, Sequence
+from typing import Optional, Sequence, cast
 
 from pydantic import BaseModel, Field, computed_field, model_validator
 from typing_extensions import Self
@@ -145,6 +145,40 @@ class Span(BaseModel):
         if len(spans) == 0:
             raise ValueError("Cannot merge an empty list of spans")
 
+    @staticmethod
+    def _merge_labellers_and_timestamps(
+        spans: list["Span"],
+    ) -> tuple[list[str], list[datetime]]:
+        """
+        Combine the unique labellers of a set of spans, keeping them ordered.
+
+        Timestamps are only carried over if every labeller has one, since the two lists
+        must stay aligned. `timestamps` is optional on a Span, so a span can legitimately
+        have labellers and no timestamps.
+
+        :param list[Span] spans: The spans being merged
+        :return tuple[list[str], list[datetime]]: the merged labellers, and their
+            timestamps if all of them are known
+        """
+        labeller_to_timestamp: OrderedDict[str, datetime | None] = OrderedDict()
+
+        # Assume labellers and timestamps are ordered to match each other already.
+        for span in spans:
+            for i, labeller in enumerate(span.labellers):
+                # Prefer the first seen timestamp for each labeller
+                if labeller not in labeller_to_timestamp:
+                    labeller_to_timestamp[labeller] = (
+                        span.timestamps[i] if i < len(span.timestamps) else None
+                    )
+
+        labellers = list(labeller_to_timestamp.keys())
+        timestamps = list(labeller_to_timestamp.values())
+
+        if any(timestamp is None for timestamp in timestamps):
+            return labellers, []
+
+        return labellers, cast(list[datetime], timestamps)
+
     @classmethod
     def union(cls, spans: list["Span"]) -> "Span":
         """
@@ -162,24 +196,15 @@ class Span(BaseModel):
         if len(spans) == 1:
             return spans[0]
         else:
-            # Combine unique labellers and their timestamps
-            labeller_to_timestamp: OrderedDict[str, datetime] = OrderedDict()
-
-            # Assume labellers and timestamps are ordered to match
-            # each other already.
-            for span in spans:
-                for i, labeller in enumerate(span.labellers):
-                    # Prefer the first seen timestamp for each labeller
-                    if labeller not in labeller_to_timestamp:
-                        labeller_to_timestamp[labeller] = span.timestamps[i]
+            labellers, timestamps = cls._merge_labellers_and_timestamps(spans)
 
             return Span(
                 text=spans[0].text,
                 start_index=min(span.start_index for span in spans),
                 end_index=max(span.end_index for span in spans),
                 concept_id=spans[0].concept_id,
-                labellers=list(labeller_to_timestamp.keys()),
-                timestamps=list(labeller_to_timestamp.values()),
+                labellers=labellers,
+                timestamps=timestamps,
             )
 
     @classmethod
@@ -199,24 +224,15 @@ class Span(BaseModel):
         if len(spans) == 1:
             return spans[0]
         else:
-            # Combine unique labellers and their timestamps
-            labeller_to_timestamp: OrderedDict[str, datetime] = OrderedDict()
-
-            # Assume labellers and timestamps are ordered to match
-            # each other already.
-            for span in spans:
-                for i, labeller in enumerate(span.labellers):
-                    # Prefer the first seen timestamp for each labeller
-                    if labeller not in labeller_to_timestamp:
-                        labeller_to_timestamp[labeller] = span.timestamps[i]
+            labellers, timestamps = cls._merge_labellers_and_timestamps(spans)
 
             return Span(
                 text=spans[0].text,
                 start_index=max(span.start_index for span in spans),
                 end_index=min(span.end_index for span in spans),
                 concept_id=spans[0].concept_id,
-                labellers=list(labeller_to_timestamp.keys()),
-                timestamps=list(labeller_to_timestamp.values()),
+                labellers=labellers,
+                timestamps=timestamps,
             )
 
     def overlaps(self, other: "Span") -> bool:

--- a/scripts/benchmarks/eval_set_autolabelling_experiment/analysis.py
+++ b/scripts/benchmarks/eval_set_autolabelling_experiment/analysis.py
@@ -1,0 +1,1219 @@
+"""Turning cached predictions into scores, policies, tables and plots."""
+
+import math
+from pathlib import Path
+from typing import Any, Callable, Iterable, cast
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from rich import box
+from rich.table import Table
+
+from knowledge_graph.ensemble.aggregation import MajorityVoteAggregator, UnionAggregator
+from knowledge_graph.ensemble.metrics import Disagreement, MajorityVote
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.metrics import (
+    ConfusionMatrix,
+    count_passage_level_metrics,
+    count_span_level_metrics,
+)
+from knowledge_graph.span import Span
+from scripts.benchmarks.eval_set_autolabelling_experiment.config import (
+    AGREEMENT_CURVE_COLUMNS,
+    AUTOMATE_COVERAGE,
+    AUTOMATE_F1,
+    AUTOMATE_VERDICT,
+    BELOW_BAR_VERDICT,
+    COST_COLUMN,
+    HEADLINE_ENSEMBLE,
+    NOT_APPLICABLE,
+    PASSAGE_LEVEL,
+    SEMI_AUTOMATE_F1,
+    SEMI_AUTOMATE_VERDICT,
+    SPAN_AGREEMENT_THRESHOLDS,
+    TOTAL_COST_COLUMN,
+    UNANIMOUS_NEGATIVE_POLICY,
+    UNANIMOUS_POSITIVE_POLICY,
+    console,
+)
+from scripts.benchmarks.eval_set_autolabelling_experiment.ensembles import (
+    EnsembleMember,
+    NamedEnsemble,
+    family_of,
+)
+
+
+def align_passages(
+    gold: list[LabelledPassage],
+    predictions_by_member: dict[EnsembleMember, dict[str, LabelledPassage]],
+    members: Iterable[EnsembleMember],
+) -> tuple[list[LabelledPassage], list[list[list[Span]]]]:
+    """
+    Line up gold passages with each member's spans, dropping any passage a member lacks.
+
+    The metrics functions zip gold and predicted lists positionally, so alignment has to
+    happen by passage id first.
+
+    "A member" here means a member of *this ensemble*, which on its own would let two
+    ensembles of the same concept be scored on different passages whenever a call
+    failed. `analyse` closes that gap upstream rather than here: it hands in a gold list
+    already restricted to the passages every member of the experiment holds, so this loop
+    drops nothing and every ensemble sees the same passages. The drop stays in as a
+    guard, not as the mechanism.
+
+    :return: the gold passages retained, and per passage the spans from each member
+    """
+
+    members = list(members)
+    aligned_gold: list[LabelledPassage] = []
+    spans_per_passage: list[list[list[Span]]] = []
+
+    for passage in gold:
+        if any(passage.id not in predictions_by_member[m] for m in members):
+            continue
+        aligned_gold.append(passage)
+        spans_per_passage.append(
+            [predictions_by_member[m][passage.id].spans for m in members]
+        )
+
+    return aligned_gold, spans_per_passage
+
+
+def build_predicted_passages(
+    gold: list[LabelledPassage],
+    spans_per_passage: list[list[list[Span]]],
+) -> tuple[list[LabelledPassage], list[LabelledPassage]]:
+    """
+    Reduce each passage's per-member spans to the ensemble's prediction.
+
+    Returns two views, because the two levels use different decision rules:
+
+    - passage level: the union spans, but only if a majority of members found anything
+    - span level: the union of every member's spans, however few members found them
+
+    :return: (passage-level predictions, span-level predictions)
+    """
+
+    passage_aggregator = MajorityVoteAggregator()
+    span_aggregator = UnionAggregator()
+
+    passage_level: list[LabelledPassage] = []
+    span_level: list[LabelledPassage] = []
+
+    for passage, spans_per_member in zip(gold, spans_per_passage):
+        passage_level.append(
+            passage.model_copy(
+                update={"spans": passage_aggregator(spans_per_member)}, deep=True
+            )
+        )
+        span_level.append(
+            passage.model_copy(
+                update={"spans": span_aggregator(spans_per_member)}, deep=True
+            )
+        )
+
+    return passage_level, span_level
+
+
+def metrics_row(
+    confusion_matrix: ConfusionMatrix,
+    score_negative_class: bool = True,
+    **identifiers: Any,
+) -> dict[str, Any]:
+    """
+    Turn a confusion matrix into a results row.
+
+    :param score_negative_class: whether `npv` and `specificity` mean anything for this
+        matrix. False for the span level, where `count_span_level_metrics` counts false
+        negatives per gold *span* but true negatives per empty *passage* — so both rates
+        would divide one unit by another. P/R/F1 are unaffected: they never touch `TN`.
+    """
+    return {
+        **identifiers,
+        "precision": confusion_matrix.precision(),
+        "recall": confusion_matrix.recall(),
+        "f1": confusion_matrix.f1_score(),
+        # the negative-class counterparts: how much a "no mention here" label can be
+        # trusted, and how many of the genuine negatives it catches
+        "npv": confusion_matrix.negative_predictive_value()
+        if score_negative_class
+        else math.nan,
+        "specificity": confusion_matrix.specificity()
+        if score_negative_class
+        else math.nan,
+        "support": confusion_matrix.support(),
+        "true_positives": confusion_matrix.true_positives,
+        "false_positives": confusion_matrix.false_positives,
+        "true_negatives": confusion_matrix.true_negatives,
+        "false_negatives": confusion_matrix.false_negatives,
+    }
+
+
+def score_ensemble(
+    wikibase_id: str,
+    ensemble: NamedEnsemble,
+    gold: list[LabelledPassage],
+    predictions_by_member: dict[EnsembleMember, dict[str, LabelledPassage]],
+) -> list[dict[str, Any]]:
+    """Score one ensemble on one concept, at passage and span level."""
+
+    aligned_gold, spans_per_passage = align_passages(
+        gold, predictions_by_member, ensemble.members
+    )
+    if not aligned_gold:
+        return []
+
+    passage_level, span_level = build_predicted_passages(
+        aligned_gold, spans_per_passage
+    )
+
+    identifiers = {
+        "concept": wikibase_id,
+        "ensemble": ensemble.name,
+        "n_members": ensemble.size,
+    }
+
+    rows = [
+        metrics_row(
+            count_passage_level_metrics(aligned_gold, passage_level),
+            level=PASSAGE_LEVEL,
+            **identifiers,
+        )
+    ]
+    rows.extend(
+        metrics_row(
+            count_span_level_metrics(aligned_gold, span_level, threshold=threshold),
+            score_negative_class=False,
+            level=f"span@{threshold}",
+            **identifiers,
+        )
+        for threshold in SPAN_AGREEMENT_THRESHOLDS
+    )
+
+    return rows
+
+
+def disagreement_rows(
+    wikibase_id: str,
+    ensemble: NamedEnsemble,
+    gold: list[LabelledPassage],
+    predictions_by_member: dict[EnsembleMember, dict[str, LabelledPassage]],
+) -> list[dict[str, Any]]:
+    """
+    Per-passage disagreement and correctness for one ensemble.
+
+    This is what the automation recommendation rests on: how good the ensemble's labels
+    are, as a function of how much its members disagreed.
+    """
+
+    aligned_gold, spans_per_passage = align_passages(
+        gold, predictions_by_member, ensemble.members
+    )
+
+    disagreement = Disagreement()
+    majority_vote = MajorityVote()
+
+    rows = []
+    for passage, spans_per_member in zip(aligned_gold, spans_per_passage):
+        predicted_positive = majority_vote(spans_per_member) >= 0.5
+        ground_truth_positive = bool(passage.spans)
+        rows.append(
+            {
+                "concept": wikibase_id,
+                "ensemble": ensemble.name,
+                "n_members": ensemble.size,
+                "passage_id": passage.id,
+                "disagreement": float(disagreement(spans_per_member)),
+                "n_positive_votes": sum(1 for s in spans_per_member if s),
+                "predicted_positive": predicted_positive,
+                "ground_truth_positive": ground_truth_positive,
+            }
+        )
+
+    return rows
+
+
+def confusion_matrix_for(passages: pd.DataFrame) -> ConfusionMatrix:
+    """Build a passage-level confusion matrix from rows of the per-passage dataframe."""
+
+    predicted = passages["predicted_positive"]
+    gold = passages["ground_truth_positive"]
+
+    return ConfusionMatrix(
+        true_positives=int((predicted & gold).sum()),
+        false_positives=int((predicted & ~gold).sum()),
+        true_negatives=int((~predicted & ~gold).sum()),
+        false_negatives=int((~predicted & gold).sum()),
+    )
+
+
+def assigns_positive_labels(confusion_matrix: ConfusionMatrix) -> bool:
+    """
+    Whether a subset contains any positive prediction at all.
+
+    `ConfusionMatrix.precision` returns 0 rather than raising when nothing was predicted
+    positive, so without this check a policy that assigns no positive labels would report
+    F1 = 0.000 as though it had been scored and failed.
+    """
+    return (confusion_matrix.true_positives + confusion_matrix.false_positives) > 0
+
+
+def assigns_negative_labels(confusion_matrix: ConfusionMatrix) -> bool:
+    """
+    Whether a subset contains any negative prediction at all.
+
+    The mirror of `assigns_positive_labels`: `negative_predictive_value` also returns 0
+    rather than raising, so without this check a subset that labels everything positive
+    would report NPV = 0.000 as though its negatives had been scored and found wrong.
+    """
+    return (confusion_matrix.true_negatives + confusion_matrix.false_negatives) > 0
+
+
+def macro(
+    matrices: list[ConfusionMatrix], metric: Callable[[ConfusionMatrix], float]
+) -> float:
+    """
+    Mean of one metric over the concepts whose matrices can define it.
+
+    Callers filter `matrices` with `assigns_positive_labels` or `assigns_negative_labels`
+    first, so a concept whose subset assigns no labels on the relevant side is left out of
+    the mean rather than folded in as a zero — a concept that was never scored is not a
+    concept that scored badly. If no concept can define the metric the result is `nan`,
+    which is the honest answer and renders as `NOT_APPLICABLE`.
+    """
+    return sum(metric(cm) for cm in matrices) / len(matrices) if matrices else math.nan
+
+
+def wilson_interval(successes: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """
+    Wilson score interval for a binomial proportion.
+
+    Used to calculate confidence intervals for specific vote splits, as these have
+    wildly varying sample sizes.
+    """
+
+    if n == 0:
+        return (math.nan, math.nan)
+
+    proportion = successes / n
+    denominator = 1 + z**2 / n
+    centre = (proportion + z**2 / (2 * n)) / denominator
+    margin = (
+        z * math.sqrt(proportion * (1 - proportion) / n + z**2 / (4 * n**2))
+    ) / denominator
+
+    return (max(0.0, centre - margin), min(1.0, centre + margin))
+
+
+def summarise_vote_splits(
+    disagreement_df: pd.DataFrame, n_members: int
+) -> pd.DataFrame:
+    """
+    What each vote split buys, in precision and false negatives.
+
+    Every passage in a bucket gets the same label, so only one of the two sides of the
+    confusion matrix is informative, and which one depends on the side of the vote:
+
+    - buckets the ensemble calls **positive** assign a positive label to everything, so
+      recall within the bucket is trivially 1.0 and precision is the whole story;
+    - buckets it calls **negative** assign no positive labels, so precision and F1 are
+      undefined; what matters is the real mentions they discard.
+
+    Both rates are reported with Wilson intervals, and every bucket from 0 to
+    ``n_members`` gets a row even when empty — an absent bucket in an earlier version was
+    indistinguishable from one that had been dropped.
+    """
+
+    total = len(disagreement_df)
+    rows = []
+
+    for votes in range(n_members + 1):
+        bucket = disagreement_df[disagreement_df["n_positive_votes"] == votes]
+        n_passages = len(bucket)
+
+        # ties count as positive, matching `MajorityVote` and `MajorityVoteAggregator`
+        ensemble_positive = 2 * votes >= n_members
+        n_gold_positive = (
+            int(bucket["ground_truth_positive"].sum()) if n_passages else 0
+        )
+
+        row: dict[str, Any] = {
+            "votes": f"{votes}/{n_members}",
+            "ensemble_label": ("positive" if ensemble_positive else "negative")
+            if n_passages
+            else None,
+            "disagreement": 2 * min(votes, n_members - votes) / n_members,
+            "n_passages": n_passages,
+            "coverage": n_passages / total if total else math.nan,
+            "precision": math.nan,
+            "precision_ci_low": math.nan,
+            "precision_ci_high": math.nan,
+            "false_negatives": pd.NA,
+            "missed_mention_rate": math.nan,
+            "missed_ci_low": math.nan,
+            "missed_ci_high": math.nan,
+        }
+
+        if n_passages and ensemble_positive:
+            row["precision"] = n_gold_positive / n_passages
+            row["precision_ci_low"], row["precision_ci_high"] = wilson_interval(
+                n_gold_positive, n_passages
+            )
+        elif n_passages:
+            row["false_negatives"] = n_gold_positive
+            row["missed_mention_rate"] = n_gold_positive / n_passages
+            row["missed_ci_low"], row["missed_ci_high"] = wilson_interval(
+                n_gold_positive, n_passages
+            )
+
+        rows.append(row)
+
+    vote_splits = pd.DataFrame(rows)
+    vote_splits["false_negatives"] = vote_splits["false_negatives"].astype("Int64")
+    return vote_splits
+
+
+def automation_policies(
+    disagreement_df: pd.DataFrame,
+) -> list[tuple[str, float, pd.Series]]:
+    """
+    The candidate routing policies, as (name, threshold, mask) over the per-passage frame.
+
+    Each policy auto-labels the passages it selects and routes the rest to a human. The
+    nested ``disagreement <= t`` policies use only the disagreement values that actually
+    occur — for a 9-member ensemble there are five, so resampling them onto a percentile
+    grid (as the active-learning retention curve does) would manufacture ~96 duplicate
+    points and hide how coarse the real axis is.
+
+    The two directional policies split the unanimous subset, which otherwise averages an
+    all-positive population together with an all-negative one. They are not points on the
+    disagreement axis — both sit at disagreement 0 — so their threshold is ``nan``.
+    """
+
+    policies: list[tuple[str, float, pd.Series]] = [
+        (
+            f"disagreement <= {threshold:.3f}",
+            float(threshold),
+            disagreement_df["disagreement"] <= threshold,
+        )
+        for threshold in sorted(disagreement_df["disagreement"].unique())
+    ]
+
+    unanimous = disagreement_df["disagreement"] == 0
+    predicted_positive = disagreement_df["predicted_positive"]
+    policies.append(
+        (UNANIMOUS_POSITIVE_POLICY, math.nan, unanimous & predicted_positive)
+    )
+    policies.append(
+        (UNANIMOUS_NEGATIVE_POLICY, math.nan, unanimous & ~predicted_positive)
+    )
+
+    return policies
+
+
+def policy_verdict(macro_f1: float, macro_coverage: float) -> str:
+    """Apply the automation gates to one policy's macro numbers."""
+
+    if pd.isna(macro_f1):
+        return NOT_APPLICABLE
+    if macro_f1 >= AUTOMATE_F1 and macro_coverage >= AUTOMATE_COVERAGE:
+        return AUTOMATE_VERDICT
+    if macro_f1 >= SEMI_AUTOMATE_F1:
+        return SEMI_AUTOMATE_VERDICT
+    return BELOW_BAR_VERDICT
+
+
+def policy_table(disagreement_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Score every candidate automation policy — the table the decision is read from.
+
+    P/R/F1 are macro-averaged over concepts by `macro`, matching the headline per-concept
+    tables, so one large evaluation set can't carry the verdict on its own. The pooled
+    (micro) F1 sits alongside for comparison. If no concept assigns any positive label,
+    the policy's P/R/F1 are undefined and `false_negatives` is what to read.
+
+    `macro_npv` is the same treatment applied to the other side of the vote: how much a
+    "no mention here" label from this policy can be trusted. It is what scores
+    `unanimous negative only`, which by construction has no F1 at all.
+    """
+
+    passages_per_concept = disagreement_df.groupby("concept").size()
+    total_passages = len(disagreement_df)
+
+    rows = []
+    for name, threshold, mask in automation_policies(disagreement_df):
+        selected = cast(pd.DataFrame, disagreement_df[mask])
+
+        coverages = []
+        scored: list[ConfusionMatrix] = []
+        scored_negative: list[ConfusionMatrix] = []
+        for concept, group in selected.groupby("concept"):
+            coverages.append(len(group) / passages_per_concept[concept])
+            confusion_matrix = confusion_matrix_for(group)
+            if assigns_positive_labels(confusion_matrix):
+                scored.append(confusion_matrix)
+            if assigns_negative_labels(confusion_matrix):
+                scored_negative.append(confusion_matrix)
+
+        # concepts with no selected passages still count as zero coverage
+        missing_concepts = len(passages_per_concept) - len(coverages)
+        coverages.extend([0.0] * missing_concepts)
+
+        pooled = confusion_matrix_for(selected) if len(selected) else ConfusionMatrix()
+        macro_coverage = sum(coverages) / len(coverages) if coverages else math.nan
+        macro_f1 = macro(scored, ConfusionMatrix.f1_score)
+
+        rows.append(
+            {
+                "policy": name,
+                "disagreement_threshold": threshold,
+                "n_passages": len(selected),
+                "macro_coverage": macro_coverage,
+                "macro_precision": macro(scored, ConfusionMatrix.precision),
+                "macro_recall": macro(scored, ConfusionMatrix.recall),
+                "macro_f1": macro_f1,
+                "micro_f1": pooled.f1_score()
+                if assigns_positive_labels(pooled)
+                else math.nan,
+                # the missed-mention rate is this subtracted from 1, so it isn't a column
+                "macro_npv": macro(
+                    scored_negative, ConfusionMatrix.negative_predictive_value
+                ),
+                "false_negatives": pooled.false_negatives,
+                "n_human_remaining": total_passages - len(selected),
+                "n_concepts": len(passages_per_concept),
+                # false where the policy only ever labels positively, which makes its
+                # recall 1.0 by construction rather than by merit
+                "assigns_negatives": assigns_negative_labels(pooled),
+                "verdict": policy_verdict(macro_f1, macro_coverage),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def policy_table_by_ensemble(disagreement_df: pd.DataFrame) -> pd.DataFrame:
+    """Score every policy for every ensemble, so each size can be read off."""
+
+    frames = []
+    for name, group in disagreement_df.groupby("ensemble", sort=False):
+        table = policy_table(cast(pd.DataFrame, group))
+        table.insert(0, "ensemble", str(name))
+        table.insert(1, "n_members", int(group["n_members"].iloc[0]))
+        table.insert(2, "family", family_of(str(name)))
+        frames.append(table)
+
+    return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+
+def automation_by_ensemble(
+    policies: pd.DataFrame, costs_per_passage: dict[str, float] | None = None
+) -> pd.DataFrame:
+    """
+    One row per ensemble: the best policy it achieves, and whether that automates.
+
+    This is the "can N classifiers do the job, and how few will do?" view. Each ensemble
+    is judged on its own best policy by macro F1, so a bigger ensemble is never penalised
+    for a policy that happens to suit a smaller one.
+
+    Only policies that label **both** classes are eligible. A positives-only policy cannot
+    contain a false negative, so its recall is 1.0 by construction and its F1 beats any
+    both-class policy of the same precision — it would win at every size and the table
+    would rank an artefact. It also isn't automation of this task: it hands every negative
+    passage back to a human, which is most of them. Those rows are dropped here rather than
+    written anywhere, so `policy_table_by_ensemble` is where to look for them if the
+    exclusion ever needs checking.
+
+    :param costs_per_passage: per-passage USD cost keyed by ensemble name, from
+        `ensemble_costs_per_passage`. Adds `TOTAL_COST_COLUMN`, which is what makes
+        this a sizing table rather than a ranking: two ensembles can share a verdict and
+        differ several-fold in price. `None` drops the column, for when pricing couldn't
+        be fetched.
+    """
+
+    if policies.empty:
+        return pd.DataFrame()
+
+    scored = cast(
+        pd.DataFrame,
+        policies[policies["macro_f1"].notna() & policies["assigns_negatives"]],
+    )
+    if scored.empty:
+        return pd.DataFrame()
+
+    rows = []
+    for _, group in scored.groupby("ensemble", sort=False):
+        best = group.sort_values(["macro_f1", "macro_coverage"], ascending=False).iloc[
+            0
+        ]
+        row = {
+            "ensemble": best["ensemble"],
+            "n_members": int(best["n_members"]),
+            "family": best["family"],
+            "n_concepts": int(best["n_concepts"]),
+            "best_policy": best["policy"],
+            "macro_coverage": best["macro_coverage"],
+            "macro_precision": best["macro_precision"],
+            "macro_recall": best["macro_recall"],
+            "macro_f1": best["macro_f1"],
+            "assigns_negatives": bool(best["assigns_negatives"]),
+            "verdict": best["verdict"],
+        }
+        if costs_per_passage is not None:
+            # every policy is a way of *reading* one full run of the ensemble, so the cost
+            # is the whole evaluation set either way: the passages the policy auto-labels
+            # plus the ones it hands to a human were all sent to every member. Routing
+            # saves human time, not LLM spend.
+            passages = int(best["n_passages"]) + int(best["n_human_remaining"])
+            row[TOTAL_COST_COLUMN] = passages * costs_per_passage.get(
+                str(best["ensemble"]), math.nan
+            )
+        rows.append(row)
+
+    # best first, so the ensemble to beat is the top row. The sizing question is read off
+    # `n_members` within it — `smallest_automating_size` re-sorts by size per family, so
+    # the prose answer is unaffected by this ordering.
+    # stable, so ensembles that tie on F1 stay in ensemble order rather than being
+    # shuffled by the sort — several sizes scoring identically is a common outcome here
+    return pd.DataFrame(rows).sort_values(
+        "macro_f1", ascending=False, kind="stable", ignore_index=True
+    )
+
+
+def agreement_f1_curves(policies: pd.DataFrame) -> pd.DataFrame:
+    """
+    The agreement-vs-F1 curve for every ensemble, as tidy rows.
+
+    Keeps only the nested ``disagreement <= t`` policies, which are the points of a curve:
+    each one auto-labels everything its members agreed on to within ``t`` and hands the
+    rest to a human, so the curve runs from the unanimous subset at ``t = 0`` to
+    auto-labelling everything at the largest ``t``. The two directional unanimous policies
+    are dropped — they both sit at disagreement 0, so they are a split of the leftmost
+    point rather than points of their own.
+
+    :param policies: the output of `policy_table_by_ensemble`
+    """
+
+    if policies.empty or "disagreement_threshold" not in policies.columns:
+        return pd.DataFrame()
+
+    curves = policies[policies["disagreement_threshold"].notna()]
+    columns = [column for column in AGREEMENT_CURVE_COLUMNS if column in curves.columns]
+    selected = cast(pd.DataFrame, curves[columns].copy())
+
+    return selected.sort_values(
+        by=["n_members", "ensemble", "disagreement_threshold"]
+    ).reset_index(drop=True)
+
+
+def passages_scored_per_concept(
+    per_concept: pd.DataFrame, ensemble: str
+) -> dict[str, int]:
+    """
+    How many gold passages each concept contributed to one ensemble's score.
+
+    Read off the passage-level rows, where `support` *is* the passage count. It is not the
+    same as the concept's gold set: `align_passages` drops any passage a member of this
+    ensemble failed on, and the whole point of costing is to price what was actually
+    sent to the models. Span-level rows can't supply it — their support counts gold spans.
+    """
+
+    rows = per_concept[
+        (per_concept["ensemble"] == ensemble) & (per_concept["level"] == PASSAGE_LEVEL)
+    ]
+    return {
+        str(concept): int(support)
+        for concept, support in zip(rows["concept"], rows["support"])
+    }
+
+
+def headline_table(
+    per_concept: pd.DataFrame,
+    level: str,
+    ensemble: str,
+    cost_per_passage: float | None = None,
+) -> pd.DataFrame:
+    """
+    Per-concept P/R/F1/support for one ensemble, with a macro row.
+
+    :param cost_per_passage: what this ensemble costs to run over one passage, in USD,
+        from `ensemble_cost_per_passage`. `None` drops the cost column entirely —
+        pricing was unavailable, and a column of zeros would read as "this is free".
+    """
+
+    table = cast(
+        pd.DataFrame,
+        per_concept[
+            (per_concept["ensemble"] == ensemble) & (per_concept["level"] == level)
+        ][["concept", "precision", "recall", "f1", "support"]].copy(),
+    )
+
+    if table.empty:
+        return table
+
+    if cost_per_passage is not None:
+        passages = passages_scored_per_concept(per_concept, ensemble)
+        table[COST_COLUMN] = [
+            passages.get(str(concept), math.nan) * cost_per_passage
+            for concept in table["concept"]
+        ]
+
+    # name the row with its concept count, so a macro average over a partial set of
+    # concepts can't be mistaken for one over all of them
+    n_concepts = len(table)
+    macro: dict[str, Any] = {
+        "concept": f"macro average ({n_concepts} concepts)",
+        "precision": table["precision"].mean(),
+        "recall": table["recall"].mean(),
+        "f1": table["f1"].mean(),
+        "support": int(table["support"].sum()),
+    }
+    if COST_COLUMN in table.columns:
+        # a mean, like every other cell in this row. `skipna=False`, because pandas would
+        # otherwise average over just the priced concepts and present that as the figure
+        # for all of them — a partial mean is not this row's mean. The whole-run budget is
+        # `TOTAL_COST_COLUMN` in the sizing table.
+        macro[COST_COLUMN] = table[COST_COLUMN].mean(skipna=False)
+
+    return pd.concat([table, pd.DataFrame([macro])], ignore_index=True)
+
+
+def negative_side_table(
+    per_concept: pd.DataFrame, level: str, ensemble: str
+) -> pd.DataFrame:
+    """
+    Per-concept reliability of the ensemble's *negative* labels, with a macro row.
+
+    The mirror of `headline_table`, and the answer to "how many passages get no span
+    prediction, and how much can that be trusted?". Recall doesn't answer it: recall is
+    measured over gold positives, whereas what a labeller needs to know is what share of
+    the passages handed back as empty actually contain a mention — `1 - npv`.
+
+    A concept that assigns no negative labels at all is left out of the macro means, for
+    the reason given on `macro`.
+    """
+
+    rows = cast(
+        pd.DataFrame,
+        per_concept[
+            (per_concept["ensemble"] == ensemble) & (per_concept["level"] == level)
+        ],
+    )
+
+    if rows.empty:
+        return pd.DataFrame()
+
+    predicted_negative = rows["true_negatives"] + rows["false_negatives"]
+    table = pd.DataFrame(
+        {
+            "concept": rows["concept"],
+            "predicted_negative": predicted_negative,
+            "negative_share": predicted_negative / rows["support"],
+            "npv": rows["npv"],
+            "missed_mentions": rows["false_negatives"],
+            "specificity": rows["specificity"],
+        }
+    )
+    # undefined rather than 0.000 where the ensemble labelled nothing negative
+    table.loc[predicted_negative.to_numpy() == 0, "npv"] = math.nan
+
+    n_concepts = len(table)
+    defined = table["npv"].notna()
+    macro = pd.DataFrame(
+        [
+            {
+                "concept": f"macro average ({n_concepts} concepts)",
+                "predicted_negative": int(table["predicted_negative"].sum()),
+                "negative_share": table["negative_share"].mean(),
+                "npv": table.loc[defined, "npv"].mean()
+                if bool(defined.any())
+                else math.nan,
+                "missed_mentions": int(table["missed_mentions"].sum()),
+                "specificity": table["specificity"].mean(),
+            }
+        ]
+    )
+
+    return pd.concat([table, macro], ignore_index=True)
+
+
+def cell_renderer(column: str, values: pd.Series) -> Callable[[Any], str]:
+    """
+    How one column's cells should be stringified for the console.
+
+    Floats go to 3dp. Integer counts are left alone, so a count of 3 passages doesn't
+    render as "3.000".
+
+    Money is the exception to the 3dp rule, because dollars and scores don't share a
+    scale: the same column holds a whole-experiment total in the hundreds and a single
+    cheap ensemble's cost in cents, and 3dp would print the second as a rounding artefact
+    of the first. Anything under a dollar keeps four decimal places so that "cheap" and
+    "free" stay distinguishable. Matched on a substring rather than a suffix, because
+    `for_console` renames the column to something shorter and the rule has to survive the
+    rename.
+    """
+
+    if "usd" in column.lower():
+        return lambda value: (
+            f"${value:,.2f}" if abs(float(value)) >= 1 else f"${float(value):.4f}"
+        )
+    if pd.api.types.is_float_dtype(values):
+        return lambda value: f"{value:.3f}"
+    if pd.api.types.is_integer_dtype(values):
+        return lambda value: str(int(value))
+    return str
+
+
+def format_for_display(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Stringify a dataframe for the console, one renderer per column.
+
+    Anything missing becomes ``n/a`` — an undefined precision or F1 has to read as
+    undefined rather than as a sentinel 0.000. `cell_renderer` decides the rest.
+    """
+
+    formatted = df.copy()
+    for column in formatted.columns:
+        values = cast(pd.Series, formatted[column])
+        render = cell_renderer(str(column), values)
+        # iterate the series rather than `.map`, which coerces a nullable Int64 column to
+        # float to carry its missing values and would render 3 passages as "3.0"
+        formatted[column] = [
+            NOT_APPLICABLE if bool(pd.isna(value)) else render(value)
+            for value in values
+        ]
+
+    return formatted
+
+
+def vote_splits_for_display(vote_splits: pd.DataFrame) -> pd.DataFrame:
+    """
+    Collapse the vote-split table's interval bounds into one column each.
+
+    The CSV keeps the bounds as separate numeric columns for plotting; a reader wants
+    "0.755–0.913" in a single cell.
+    """
+
+    def interval(low: str, high: str) -> pd.Series:
+        return pd.Series(
+            [
+                NOT_APPLICABLE
+                if bool(pd.isna(lo)) or bool(pd.isna(hi))
+                else f"{lo:.3f}–{hi:.3f}"
+                for lo, hi in zip(vote_splits[low], vote_splits[high])
+            ],
+            index=vote_splits.index,
+        )
+
+    display = cast(
+        pd.DataFrame,
+        vote_splits[
+            [
+                "votes",
+                "ensemble_label",
+                "disagreement",
+                "n_passages",
+                "coverage",
+                "precision",
+            ]
+        ].copy(),
+    )
+    display["precision_95_ci"] = interval("precision_ci_low", "precision_ci_high")
+    display["false_negatives"] = vote_splits["false_negatives"]
+    display["missed_mention_rate"] = vote_splits["missed_mention_rate"]
+    display["missed_95_ci"] = interval("missed_ci_low", "missed_ci_high")
+
+    return display
+
+
+def for_console(df: pd.DataFrame, columns: dict[str, str]) -> pd.DataFrame:
+    """
+    Narrow and rename a table so it survives an 80-column terminal.
+
+    Rich shrinks columns to fit the terminal, which turns a ten-column table into a grid of
+    ellipses. The CSVs keep every column; the console gets the ones the decision turns
+    on, under short headers.
+    """
+
+    available = {
+        column: label for column, label in columns.items() if column in df.columns
+    }
+    narrowed = cast(pd.DataFrame, df[list(available)].copy())
+
+    for column in ("policy", "best_policy"):
+        if column in narrowed.columns:
+            narrowed[column] = [
+                str(policy).replace("disagreement <= ", "≤ ").replace(" only", "")
+                for policy in narrowed[column]
+            ]
+
+    return cast(pd.DataFrame, narrowed.rename(columns=available))
+
+
+def print_table(df: pd.DataFrame, title: str) -> None:
+    """Print a dataframe to the console."""
+    table = Table(title=title, box=box.SIMPLE, show_header=True)
+    for column in df.columns:
+        table.add_column(str(column))
+    for row in format_for_display(df).itertuples(index=False):
+        table.add_row(*[str(value) for value in row])
+    console.print(table)
+
+
+def plot_agreement_vs_f1(curves: pd.DataFrame, output_dir: Path) -> None:
+    """
+    One panel per ensemble: F1 against how much member disagreement is tolerated.
+
+    The same reading as the active-learning ensemble plot
+    (`scripts.active_learning.plot_ensemble_metrics.create_plots`) — F1 against the
+    disagreement threshold, with the share of passages that buys on a secondary axis — but
+    scored on this experiment's terms: macro F1 over concepts, on the labels the policy
+    assigns.
+
+    The x-axis carries only the disagreement values an ensemble can actually produce
+    (``⌊n/2⌋ + 1`` of them), not a percentile grid, so a coarse curve looks coarse. An
+    ``n=1`` ensemble has a single point at 0: it always agrees with itself, so there is no
+    curve to read.
+    """
+
+    if curves.empty:
+        return
+
+    ensembles = list(dict.fromkeys(curves["ensemble"]))
+    n_cols = min(3, len(ensembles))
+    n_rows = math.ceil(len(ensembles) / n_cols)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(5.0 * n_cols, 4.2 * n_rows), squeeze=False
+    )
+
+    # a shared, zoomed y-range: on a 0–1 axis every curve here is a flat line, because the
+    # whole population sits inside a few F1 points. Shared so the panels stay comparable —
+    # a per-panel range would rescale each ensemble's noise to look like the same movement.
+    scores = [value for value in curves["macro_f1"] if not bool(pd.isna(value))]
+    y_limits = (min(scores) - 0.02, max(scores) + 0.02) if scores else (0.0, 1.0)
+
+    for ax, ensemble in zip(axes.flat, ensembles):
+        panel = cast(pd.DataFrame, curves[curves["ensemble"] == ensemble]).sort_values(
+            "disagreement_threshold"
+        )
+        thresholds = panel["disagreement_threshold"].tolist()
+        f1_scores = panel["macro_f1"].tolist()
+        coverages = panel["macro_coverage"].tolist()
+
+        ax.plot(
+            thresholds,
+            f1_scores,
+            "b-",
+            linewidth=2,
+            marker="o",
+            markersize=5,
+            label="Macro F1",
+        )
+
+        # the rightmost point is "auto-label everything": the do-nothing baseline the rest
+        # of the curve has to beat to be worth any human review at all
+        baseline_f1 = f1_scores[-1]
+        if not bool(pd.isna(baseline_f1)):
+            ax.axhline(
+                y=baseline_f1,
+                color="r",
+                linestyle="--",
+                alpha=0.7,
+                label=f"No review = {baseline_f1:.3f}",
+            )
+
+        if bool(panel["macro_f1"].notna().any()):
+            best = panel.loc[panel["macro_f1"].idxmax()]
+            ax.scatter(
+                best["disagreement_threshold"],
+                best["macro_f1"],
+                color="red",
+                s=100,
+                zorder=5,
+                label=(
+                    f"Best: {best['macro_f1']:.3f} "
+                    f"(≤ {best['disagreement_threshold']:.2f}, "
+                    f"covers {best['macro_coverage']:.0%})"
+                ),
+            )
+
+        # coverage is monotonic in the threshold, so it maps onto the same axis; a single
+        # point (n=1) has nothing to span, and matplotlib would collapse the limits
+        finite_coverages = [value for value in coverages if not bool(pd.isna(value))]
+        if len(set(finite_coverages)) > 1:
+            coverage_axis = ax.twiny()
+            coverage_axis.plot(coverages, f1_scores, alpha=0)
+            coverage_axis.set_xlim(min(finite_coverages), max(finite_coverages))
+            coverage_axis.set_xlabel("Coverage (share auto-labelled)", color="green")
+            coverage_axis.tick_params(axis="x", labelcolor="green")
+
+        n_members = int(panel["n_members"].iloc[0])
+        ax.set_title(f"{ensemble} ({n_members} classifier(s))")
+        ax.set_xlabel("Max member disagreement auto-labelled", color="blue")
+        ax.set_ylabel("Macro F1 of the labels assigned")
+        ax.tick_params(axis="x", labelcolor="blue")
+        ax.set_ylim(*y_limits)
+        ax.grid(True, alpha=0.3)
+        ax.legend(fontsize=7, loc="lower right")
+
+    for ax in axes.flat[len(ensembles) :]:
+        ax.axis("off")
+
+    fig.tight_layout()
+    fig.savefig(output_dir / "agreement_vs_f1.png", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_automation_by_size(by_ensemble: pd.DataFrame, output_dir: Path) -> None:
+    """
+    Plot the best achievable macro F1 against ensemble size, one line per family.
+
+    This is the sizing figure: where a family's line crosses a gate is the smallest N that
+    can automate, and where the line goes flat is the point past which extra classifiers
+    change nothing.
+    """
+
+    if by_ensemble.empty:
+        return
+
+    fig, ax = plt.subplots(figsize=(7.5, 5))
+
+    for family, group in by_ensemble.groupby("family", sort=True):
+        ordered = group.sort_values("n_members")
+        ax.plot(
+            ordered["n_members"],
+            ordered["macro_f1"],
+            marker="o",
+            label=str(family),
+        )
+        for _, row in ordered.iterrows():
+            if row["verdict"] == AUTOMATE_VERDICT:
+                ax.scatter(
+                    row["n_members"],
+                    row["macro_f1"],
+                    marker="o",
+                    s=160,
+                    facecolors="none",
+                    edgecolors="green",
+                    zorder=5,
+                )
+
+    ax.axhline(
+        AUTOMATE_F1,
+        color="green",
+        linestyle="--",
+        alpha=0.7,
+        label=f"automate ≥ {AUTOMATE_F1:.0%}",
+    )
+    ax.axhline(
+        SEMI_AUTOMATE_F1,
+        color="orange",
+        linestyle="--",
+        alpha=0.7,
+        label=f"semi-automate ≥ {SEMI_AUTOMATE_F1:.0%}",
+    )
+
+    plotted = by_ensemble["macro_f1"].tolist() + [AUTOMATE_F1, SEMI_AUTOMATE_F1]
+    finite = [value for value in plotted if not pd.isna(value)]
+    ax.set_ylim(min(finite) - 0.04, max(finite) + 0.03)
+    ax.set_xticks(sorted(set(by_ensemble["n_members"].tolist())))
+    ax.set_xlabel("Ensemble size (number of classifiers)")
+    ax.set_ylabel("Macro F1 of the best policy at that size")
+    automating = (by_ensemble["verdict"] == AUTOMATE_VERDICT).any()
+    ax.set_title(
+        "How many classifiers does automation need?"
+        + (
+            "\n(ringed = clears the automate gate)"
+            if automating
+            else "\n(nothing reaches the automate gate on a both-class policy)"
+        )
+    )
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=8)
+
+    fig.tight_layout()
+    fig.savefig(output_dir / "automation_by_size.png", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+
+
+def find_policy(policies: pd.DataFrame, name: str) -> pd.Series | None:
+    """Return one policy's row by name, or None if it isn't in the table."""
+    matches = policies[policies["policy"] == name]
+    return None if matches.empty else cast(pd.Series, matches.iloc[0])
+
+
+def smallest_automating_size(by_ensemble: pd.DataFrame) -> str:
+    """
+    Report the fewest classifiers per family that reach each level of automation.
+
+    Answers the sizing question directly: rather than ranking ensembles against each other,
+    it asks of each family "at what point does adding classifiers stop changing the
+    verdict?" — because the cheapest ensemble that clears the bar is the one to ship.
+    """
+
+    if by_ensemble.empty:
+        return "No scored ensembles — cannot size one."
+
+    lines = []
+    for family, group in by_ensemble.groupby("family", sort=True):
+        ordered = group.sort_values("n_members")
+        parts = []
+        for verdict in (AUTOMATE_VERDICT, SEMI_AUTOMATE_VERDICT):
+            reaching = ordered[ordered["verdict"] == verdict]
+            if not reaching.empty:
+                first = reaching.iloc[0]
+                parts.append(
+                    f"**{verdict} from n={first['n_members']}** "
+                    f"(macro F1 {first['macro_f1']:.3f} on `{first['best_policy']}`, "
+                    f"covering {first['macro_coverage']:.1%})"
+                )
+        best = ordered.sort_values("macro_f1", ascending=False).iloc[0]
+        if not parts:
+            parts.append(
+                f"never clears the bar — best is n={best['n_members']} at macro F1 "
+                f"{best['macro_f1']:.3f}"
+            )
+
+        sizes = ordered["n_members"].tolist()
+        f1s = ordered["macro_f1"].tolist()
+        flat = len(set(round(value, 6) for value in f1s)) == 1 and len(f1s) > 1
+        suffix = (
+            f". Macro F1 is identical across n={min(sizes)}–{max(sizes)}, so the extra "
+            "members change no majority vote"
+            if flat
+            else ""
+        )
+        lines.append(f"- `{family}`: {'; '.join(parts)}{suffix}")
+
+    return "\n".join(lines)
+
+
+def recommendation(
+    policies: pd.DataFrame,
+    n_concepts: int,
+    headline_name: str = HEADLINE_ENSEMBLE,
+) -> str:
+    """
+    Turn the policy table into the automate / semi-automate / don't verdict.
+
+    Picks the best-scoring policy that clears a gate rather than assuming the unanimous
+    subset is the only candidate — a looser threshold can score higher, because the
+    passages it adds are not uniformly harder.
+
+    Thresholds are fixed in this module's constants rather than chosen after seeing the
+    results.
+
+    :param headline_name: the ensemble the policies were scored on, named only so the
+        no-results message can point at the one the caller actually asked for.
+    """
+
+    if policies.empty:
+        return (
+            f"No `{headline_name}` results — cannot assess automation. "
+            "Run `predict` for every member first."
+        )
+
+    # both-class policies only, matching `automation_by_ensemble`: a positives-only
+    # policy has recall 1.0 by construction, so ranking on F1 would always crown it, and it
+    # leaves every negative passage to a human. Its numbers still appear in the asymmetry
+    # bullet below and in the policy table.
+    scored = cast(
+        pd.DataFrame,
+        policies[policies["macro_f1"].notna() & policies["assigns_negatives"]],
+    )
+    if scored.empty:
+        return "No policy labels both classes — cannot assess automation of the whole task."
+
+    for tier in (AUTOMATE_VERDICT, SEMI_AUTOMATE_VERDICT):
+        candidates = cast(pd.DataFrame, scored[scored["verdict"] == tier])
+        if not candidates.empty:
+            break
+    else:
+        best = scored.sort_values("macro_f1", ascending=False).iloc[0]
+        return (
+            "**Don't automate**: no policy reaches the bar.\n\n"
+            f"- Best was `{best['policy']}` at macro F1 {best['macro_f1']:.3f} "
+            f"(semi-automate ≥ {SEMI_AUTOMATE_F1:.0%}), covering "
+            f"{best['macro_coverage']:.1%} of passages\n"
+            f"- Macro-averaged over {n_concepts} concept(s)"
+        )
+
+    best = candidates.sort_values(["macro_f1", "macro_coverage"], ascending=False).iloc[
+        0
+    ]
+    # the widest policy that still routes something to a human. Without the filter this is
+    # always "auto-label everything", which belongs below as the no-review baseline rather
+    # than as a trade-off against it.
+    reviewed = cast(pd.DataFrame, candidates[candidates["n_human_remaining"] > 0])
+    widest = (
+        reviewed.sort_values(["macro_coverage", "macro_f1"], ascending=False).iloc[0]
+        if not reviewed.empty
+        else None
+    )
+
+    if tier == AUTOMATE_VERDICT:
+        verdict = f"**Automate** the `{best['policy']}` subset."
+    else:
+        verdict = (
+            f"**Semi-automate**: pre-label the `{best['policy']}` subset in Argilla for "
+            "human confirmation."
+        )
+
+    binds = "precision" if best["macro_precision"] <= best["macro_recall"] else "recall"
+    lines = [
+        f"{verdict}\n",
+        f"- Macro F1 {best['macro_f1']:.3f} on the labels it assigns "
+        f"(automate ≥ {AUTOMATE_F1:.0%}, semi-automate ≥ {SEMI_AUTOMATE_F1:.0%})",
+        f"- Covers {best['macro_coverage']:.1%} of passages "
+        f"(threshold for automating: {AUTOMATE_COVERAGE:.0%}), leaving "
+        f"{best['n_human_remaining']} for a human",
+        f"- **{binds.title()} binds**: precision {best['macro_precision']:.3f} vs recall "
+        f"{best['macro_recall']:.3f}",
+    ]
+
+    if widest is not None and widest["policy"] != best["policy"]:
+        lines.append(
+            f"- Trade-off: `{widest['policy']}` also clears the bar and covers more "
+            f"({widest['macro_coverage']:.1%}) at macro F1 {widest['macro_f1']:.3f}, "
+            f"leaving only {widest['n_human_remaining']} for a human"
+        )
+
+    # auto-labelling everything is the do-nothing baseline: it is what the ensemble scores
+    # with no human review at all, and the difference is what the review actually buys
+    baseline = cast(pd.DataFrame, scored[scored["n_human_remaining"] == 0])
+    if not baseline.empty:
+        no_review = baseline.iloc[0]
+        lines.append(
+            f"- For comparison, auto-labelling *everything* scores macro F1 "
+            f"{no_review['macro_f1']:.3f}, so routing the "
+            f"{best['n_human_remaining']} most-disagreed-on passages to a human is worth "
+            f"{best['macro_f1'] - no_review['macro_f1']:+.3f} F1"
+        )
+
+    unanimous_positive = find_policy(policies, UNANIMOUS_POSITIVE_POLICY)
+    unanimous_negative = find_policy(policies, UNANIMOUS_NEGATIVE_POLICY)
+    if unanimous_positive is not None and unanimous_negative is not None:
+        lines.append(
+            f"- The unanimous subset is asymmetric: unanimous *positive* scores macro F1 "
+            f"{unanimous_positive['macro_f1']:.3f}, while unanimous *negative* assigns no "
+            f"positive labels at all and discards "
+            f"{unanimous_negative['false_negatives']} real mention(s), so F1 cannot "
+            "score it"
+        )
+        # the negative side needs its own number, or the read is that F1 says nothing
+        # about it and it therefore costs nothing
+        if not bool(pd.isna(unanimous_negative["macro_npv"])):
+            lines.append(
+                f"- Those unanimous negatives are right {unanimous_negative['macro_npv']:.1%} "
+                f"of the time (macro NPV), against macro precision "
+                f"{best['macro_precision']:.3f} on the positives — so an empty passage is "
+                + (
+                    "the *less* trustworthy of the two labels"
+                    if unanimous_negative["macro_npv"] < best["macro_precision"]
+                    else "the more trustworthy of the two labels"
+                )
+            )
+
+    lines.append(f"- Macro-averaged over {n_concepts} concept(s)")
+
+    return "\n".join(lines)

--- a/scripts/benchmarks/eval_set_autolabelling_experiment/cli.py
+++ b/scripts/benchmarks/eval_set_autolabelling_experiment/cli.py
@@ -1,0 +1,440 @@
+"""
+Can an LLM ensemble auto-label our classifier evaluation sets? (FUS-164)
+
+Runs a cross-family LLM ensemble over the gold-standard evaluation passages of the
+concepts listed on FUS-163, and reports precision/recall/F1/support per concept plus a
+macro average — at both passage and span level — so we can decide whether eval-set
+labelling can be automated, semi-automated, or not automated.
+
+Two families at opus-level sizing, five seeds each at ``temperature=0.7``. Every member's
+predictions are cached to disk *per passage*, so we can compose ensembles later.
+
+Concepts get ``DEFAULT_SYSTEM_PROMPT`` plus whatever is in the concept store — the tuned
+labelling guidelines in ``scripts/custom_concept_training/configs/`` are not applied,
+because eval-set labelling happens before prompt development.
+
+Different ensembling methods are used at the passage- and span-level:
+
+- passage level — the ensemble is positive if a majority of members are.
+- span level — the ensemble's spans are the union of all members' spans, with
+  overlapping spans merged
+
+Two senses of "agreement" are deliberately kept apart, because conflating them is what
+made an earlier version of this analysis unreadable:
+
+- ``disagreement`` is between ensemble *members* (`Disagreement` in
+  ``knowledge_graph.ensemble.metrics``). Gold is not involved. It is the axis along which
+  passages are routed to a human.
+- precision/recall/F1 are against *gold*. They score the labels a routing policy would
+  assign, and they are the only metrics reported: on a negative-skewed task a
+  true-negative-crediting metric lets a policy that assigns no positive labels at all
+  score well while quietly discarding real mentions.
+
+Usage::
+
+    # check both families resolve on OpenRouter before spending 20k calls
+    uv run python -m scripts.benchmarks.eval_set_autolabelling_experiment.cli probe
+
+    # smoke test on the smallest concept, then the full sweep
+    uv run python -m scripts.benchmarks.eval_set_autolabelling_experiment.cli predict \
+        --concepts Q32
+    uv run python -m scripts.benchmarks.eval_set_autolabelling_experiment.cli analyse \
+        --concepts Q32
+
+    # break the detailed views down by a different ensemble than the default
+    uv run python -m scripts.benchmarks.eval_set_autolabelling_experiment.cli analyse \
+        --headline mixed_n5
+
+``predict`` skips members it has already cached, so it is safe to interrupt and rerun.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Annotated, Any, cast
+
+import pandas as pd
+import typer
+
+from knowledge_graph.identifiers import WikibaseID
+from scripts.benchmarks.eval_set_autolabelling_experiment.analysis import (
+    agreement_f1_curves,
+    automation_by_ensemble,
+    disagreement_rows,
+    for_console,
+    headline_table,
+    negative_side_table,
+    plot_agreement_vs_f1,
+    plot_automation_by_size,
+    policy_table,
+    policy_table_by_ensemble,
+    print_table,
+    recommendation,
+    score_ensemble,
+    smallest_automating_size,
+    summarise_vote_splits,
+    vote_splits_for_display,
+)
+from scripts.benchmarks.eval_set_autolabelling_experiment.config import (
+    BY_ENSEMBLE_CONSOLE_COLUMNS,
+    COMPLETENESS_COLUMNS,
+    DEFAULT_CONCEPTS,
+    DEFAULT_OUTPUT_DIR,
+    FAMILIES,
+    HEADLINE_ENSEMBLE,
+    HEADLINE_SPAN_THRESHOLDS,
+    NEGATIVE_SIDE_CONSOLE_COLUMNS,
+    PASSAGE_LEVEL,
+    POLICY_CONSOLE_COLUMNS,
+    SEEDS,
+    VOTE_SPLIT_CONSOLE_COLUMNS,
+    console,
+)
+from scripts.benchmarks.eval_set_autolabelling_experiment.ensembles import (
+    EnsembleMember,
+    all_members,
+    build_member_classifier,
+    compose_possible_ensembles,
+    concept_output_dir,
+    ensemble_costs_per_passage,
+    fetch_concept_and_gold,
+    load_model_pricing,
+    load_usable_concepts,
+    run_member_with_caching,
+    write_passages,
+)
+
+app = typer.Typer()
+
+
+def parse_concepts(value: str) -> list[str]:
+    """Parse a comma-separated list of Wikibase IDs."""
+    ids = [v.strip() for v in value.split(",") if v.strip()]
+    for wikibase_id in ids:
+        WikibaseID(wikibase_id)
+    return ids
+
+
+@app.command()
+def probe(
+    wikibase_id: Annotated[
+        str,
+        typer.Option("--wikibase-id", help="Concept to probe with."),
+    ] = "Q32",
+):
+    """
+    Check that both model families resolve, on one passage each.
+
+    Worth doing first: a model name that 404s would otherwise only surface part-way
+    through a 20,000-call run.
+    """
+
+    fetched = asyncio.run(fetch_concept_and_gold(WikibaseID(wikibase_id)))
+    if fetched is None:
+        raise typer.Exit(1)
+    concept, gold = fetched
+
+    failures = []
+    for family in FAMILIES:
+        member: EnsembleMember = (family, SEEDS[0])
+        try:
+            classifier = build_member_classifier(concept, member)
+            spans = classifier.predict(gold[0].text)
+            console.log(f"✅ {FAMILIES[family]} responded ({len(spans)} spans)")
+        except Exception as e:
+            console.log(f"❌ {FAMILIES[family]} failed: {e}")
+            failures.append(family)
+
+    if failures:
+        console.log(
+            f"❌ Unavailable families: {failures}. Fix before running `predict`."
+        )
+        raise typer.Exit(1)
+
+    console.log("✅ All families available")
+
+
+@app.command()
+def predict(
+    concepts: Annotated[
+        str,
+        typer.Option(
+            "--concepts",
+            help="Comma-separated Wikibase IDs. Defaults to the FUS-163 concept list.",
+        ),
+    ] = ",".join(DEFAULT_CONCEPTS),
+    output_dir: Annotated[
+        Path,
+        typer.Option("--output-dir", help="Where to cache per-member predictions."),
+    ] = DEFAULT_OUTPUT_DIR,
+    batch_size: Annotated[
+        int,
+        typer.Option("--batch-size", help="Async fan-out width per member."),
+    ] = 16,
+    max_passages: Annotated[
+        int | None,
+        typer.Option(
+            "--max-passages",
+            help="Cap passages per concept. For smoke tests only — the experiment uses "
+            "every gold passage.",
+        ),
+    ] = None,
+):
+    """
+    Run every ensemble member over every concept's gold passages, caching as it goes.
+
+    Safe to interrupt and rerun: each member caches per passage, so a rerun only requests
+    the passages still missing.
+    """
+
+    wikibase_ids = parse_concepts(concepts)
+    members: list[EnsembleMember] = all_members()
+
+    console.log(
+        f"Running {len(members)} members over {len(wikibase_ids)} concepts "
+        f"({', '.join(FAMILIES.values())})"
+    )
+
+    for wikibase_id in wikibase_ids:
+        console.rule(f"{wikibase_id}")
+        concept_dir = concept_output_dir(output_dir, wikibase_id)
+        gold_path = concept_dir / "gold.jsonl"
+
+        fetched = asyncio.run(fetch_concept_and_gold(WikibaseID(wikibase_id)))
+        if fetched is None:
+            continue
+        concept, gold = fetched
+
+        if max_passages is not None:
+            gold = gold[:max_passages]
+            console.log(f"✂️  Capped to {len(gold)} passages")
+
+        write_passages(gold_path, gold)
+
+        for i, member in enumerate(members, start=1):
+            family, seed = member
+            run_member_with_caching(
+                concept=concept,
+                member=member,
+                gold=gold,
+                concept_dir=concept_dir,
+                batch_size=batch_size,
+                position=f"Member {i}/{len(members)}: {family} seed={seed}",
+            )
+
+    console.log(f"✅ Predictions cached under {output_dir}")
+
+
+@app.command()
+def analyse(
+    concepts: Annotated[
+        str,
+        typer.Option(
+            "--concepts",
+            help="Comma-separated Wikibase IDs. Defaults to the FUS-163 concept list.",
+        ),
+    ] = ",".join(DEFAULT_CONCEPTS),
+    output_dir: Annotated[
+        Path,
+        typer.Option("--output-dir", help="Directory holding the cached predictions."),
+    ] = DEFAULT_OUTPUT_DIR,
+    max_members: Annotated[
+        int | None,
+        typer.Option(
+            "--max-members",
+            help="Only consider ensembles of at most this many classifiers",
+        ),
+    ] = 5,
+    headline_ensemble: Annotated[
+        str,
+        typer.Option(
+            "--headline",
+            help="Which ensemble the detailed per-concept, negative-side and vote-split "
+            "views describe, by name (e.g. 'mixed_n5'). Every ensemble is scored and "
+            "ranked regardless — this only picks the one the detailed views break down. "
+            "An ensemble that the size cap excludes, or that has no cached predictions, "
+            "is an error rather than grounds for substituting another.",
+        ),
+    ] = HEADLINE_ENSEMBLE,
+):
+    """Score every ensemble from the cached predictions."""
+
+    wikibase_ids = parse_concepts(concepts)
+    ensembles = compose_possible_ensembles(max_members)
+    if not ensembles:
+        console.log(f"❌ No ensembles with at most {max_members} members.")
+        raise typer.Exit(1)
+
+    within_cap = [c.name for c in ensembles]
+    if headline_ensemble not in within_cap:
+        composable = {c.name: c.size for c in compose_possible_ensembles()}
+        if headline_ensemble in composable:
+            console.log(
+                f"❌ `{headline_ensemble}` needs {composable[headline_ensemble]} "
+                f"classifiers but --max-members is {max_members}. Raise the cap, or pass "
+                f"--headline naming one of: {', '.join(within_cap)}"
+            )
+        else:
+            console.log(
+                f"❌ `{headline_ensemble}` is not an ensemble this experiment composes. "
+                f"Choose one of: {', '.join(composable)}"
+            )
+        raise typer.Exit(1)
+
+    console.log(
+        f"Scoring {len(ensembles)} ensembles over {len(wikibase_ids)} concepts"
+        + (f", capped at {max_members} members" if max_members is not None else "")
+    )
+
+    # the only thing here that can touch the network, and only on the first run: after that
+    # it is read from the cache alongside the predictions, so `analyse` stays offline
+    prices_by_family = load_model_pricing(output_dir)
+    costs_per_passage = (
+        ensemble_costs_per_passage(ensembles, prices_by_family)
+        if prices_by_family
+        else None
+    )
+    if costs_per_passage is None:
+        console.log("⚠️ No model pricing available — cost columns will be omitted")
+
+    per_concept_path = output_dir / "per_concept_metrics.csv"
+
+    all_rows: list[dict[str, Any]] = []
+    all_disagreement: list[dict[str, Any]] = []
+
+    usable, concept_completeness = load_usable_concepts(output_dir, wikibase_ids)
+    if not usable:
+        console.log(
+            f"❌ No concept has all {len(all_members())} members cached, so there is "
+            "no common set to score on. Finish `predict` and rerun."
+        )
+        raise typer.Exit(1)
+
+    console.log(
+        f"Scoring {len(usable)} of {len(wikibase_ids)} concepts: {', '.join(usable)}"
+    )
+
+    for wikibase_id, (gold, predictions_by_member) in usable.items():
+        # every ensemble draws its members from the same (family, seed) grid every
+        # concept in `usable` has cached, so there is nothing here to skip
+        for ensemble in ensembles:
+            all_rows.extend(
+                score_ensemble(wikibase_id, ensemble, gold, predictions_by_member)
+            )
+
+            # every ensemble, not just the headline: the sizing question needs a
+            # verdict per ensemble size, and re-aggregating cached spans costs no LLM calls
+            all_disagreement.extend(
+                disagreement_rows(wikibase_id, ensemble, gold, predictions_by_member)
+            )
+
+        # write after each concept so an interrupted analysis keeps its progress
+        pd.DataFrame(all_rows).to_csv(per_concept_path, index=False)
+
+    if not all_rows:
+        console.log("❌ No cached predictions found. Run `predict` first.")
+        raise typer.Exit(1)
+
+    per_concept = pd.DataFrame(all_rows)
+
+    # the headline has to have been scored, or the detailed views below would describe an
+    # ensemble with no numbers. Reported as an error naming what *was* scored, so the fix
+    # is a deliberate `--headline` rather than a silent substitution
+    scored_names = set(per_concept["ensemble"])
+    if headline_ensemble not in scored_names:
+        console.log(
+            f"❌ `{headline_ensemble}` was not scored on any concept — its members are "
+            "missing from the cache. Run `predict` to fill them, or pass --headline naming "
+            f"one of: {', '.join(sorted(scored_names))}"
+        )
+        raise typer.Exit(1)
+    headline = next(c for c in ensembles if c.name == headline_ensemble)
+
+    disagreement_df = pd.DataFrame(all_disagreement)
+    by_ensemble = pd.DataFrame()
+    curves = pd.DataFrame()
+    if disagreement_df.empty:
+        console.log("⚠️ No per-passage results — skipping the automation analysis")
+        policies = pd.DataFrame()
+        vote_splits = pd.DataFrame()
+        n_decision_concepts = 0
+    else:
+        all_policies = policy_table_by_ensemble(disagreement_df)
+        by_ensemble = automation_by_ensemble(all_policies, costs_per_passage)
+        by_ensemble.to_csv(output_dir / "automation_by_ensemble.csv", index=False)
+        plot_automation_by_size(by_ensemble, output_dir)
+
+        curves = agreement_f1_curves(all_policies)
+        curves.to_csv(output_dir / "agreement_vs_f1.csv", index=False)
+        plot_agreement_vs_f1(curves, output_dir)
+
+        headline_passages = cast(
+            pd.DataFrame, disagreement_df[disagreement_df["ensemble"] == headline.name]
+        )
+        n_decision_concepts = int(cast(int, headline_passages["concept"].nunique()))
+        vote_splits = summarise_vote_splits(headline_passages, headline.size)
+        vote_splits.to_csv(output_dir / "vote_splits.csv", index=False)
+        policies = policy_table(headline_passages)
+        policies.to_csv(output_dir / "policy_table.csv", index=False)
+
+    # reindexed rather than left to whatever keys the rows carry, so that a run excluding
+    # nothing still has `excluded` and `exclusion_reason` columns — visibly empty
+    completeness = pd.DataFrame(concept_completeness).reindex(
+        columns=COMPLETENESS_COLUMNS
+    )
+    completeness.to_csv(output_dir / "data_completeness.csv", index=False)
+
+    # the headline's own per-passage cost, which every per-concept table below is priced on
+    headline_cost_per_passage = (
+        costs_per_passage.get(headline.name) if costs_per_passage else None
+    )
+
+    if not by_ensemble.empty:
+        print_table(
+            for_console(by_ensemble, BY_ENSEMBLE_CONSOLE_COLUMNS),
+            "Smallest ensemble that can automate",
+        )
+        console.print(smallest_automating_size(by_ensemble))
+
+    print_table(
+        headline_table(
+            per_concept, PASSAGE_LEVEL, headline.name, headline_cost_per_passage
+        ),
+        f"Passage level ({headline.name})",
+    )
+    for threshold in HEADLINE_SPAN_THRESHOLDS:
+        print_table(
+            headline_table(
+                per_concept,
+                f"span@{threshold}",
+                headline.name,
+                headline_cost_per_passage,
+            ),
+            f"Span level (Jaccard ≥ {threshold}, {headline.name})",
+        )
+
+    negative_side = negative_side_table(per_concept, PASSAGE_LEVEL, headline.name)
+    if not negative_side.empty:
+        negative_side.to_csv(output_dir / "negative_side.csv", index=False)
+        print_table(
+            for_console(negative_side, NEGATIVE_SIDE_CONSOLE_COLUMNS),
+            f"How much to trust a negative ({headline.name})",
+        )
+
+    if not policies.empty:
+        print_table(
+            for_console(policies, POLICY_CONSOLE_COLUMNS),
+            f"Automation policies ({headline.name})",
+        )
+        print_table(
+            for_console(
+                vote_splits_for_display(vote_splits), VOTE_SPLIT_CONSOLE_COLUMNS
+            ),
+            "What each vote split buys",
+        )
+        console.print(recommendation(policies, n_decision_concepts, headline.name))
+
+    console.log(f"💾 Results written to {output_dir}")
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/benchmarks/eval_set_autolabelling_experiment/config.py
+++ b/scripts/benchmarks/eval_set_autolabelling_experiment/config.py
@@ -1,0 +1,181 @@
+"""Everything tunable about the experiment, and the console every module logs to."""
+
+from rich.console import Console
+
+from knowledge_graph.config import ensemble_metrics_dir
+
+console = Console()
+
+# The concepts from FUS-163, spanning easy/medium/hard. Q704 is deliberately absent:
+# keywords and negative labels were added to it after its evaluation set was labelled,
+# so it no longer reflects the concept the human labellers saw.
+DEFAULT_CONCEPTS = [
+    "Q618",
+    "Q661",
+    "Q2029",
+    "Q47",
+    "Q1277",
+    "Q557",
+    "Q1837",
+    "Q912",
+    "Q1829",
+    "Q32",
+]
+
+FAMILY_A = "opus"
+
+FAMILY_B = "gemini"
+
+FAMILIES = {
+    FAMILY_A: "openrouter:anthropic/claude-opus-5",
+    FAMILY_B: "openrouter:google/gemini-3.1-pro-preview",
+}
+
+SEEDS = [1, 2, 3, 4, 5]
+
+TEMPERATURE = 0.7
+
+OPENROUTER_MODELS_PRICING_URL = "https://openrouter.ai/api/v1/models"
+
+OPENROUTER_PRICING_CACHE_FILENAME = "model_pricing.json"
+
+ESTIMATED_PROMPT_TOKENS_PER_PASSAGE = 4_300
+"""Estimated prompt tokens in one classification call. An estimate, not a measurement.
+
+Each call carries `DEFAULT_SYSTEM_PROMPT` formatted with the concept's markdown, plus the
+passage. Over the ten FUS-163 concepts and their 2,015 gold passages that is a
+passage-weighted mean of ~16,800 characters of system prompt and ~335 of passage text,
+so ~17,100 characters ≈ 4,300 tokens.
+
+The distribution behind that mean is very skewed: eight of the ten concepts sit between
+2,300 and 6,400 characters, while `Q47` (2,982 alternative labels) and `Q557` (4,363) run
+to 96,000 and 119,000. A single flat constant therefore overstates a small concept's cost
+several-fold and understates those two.
+"""
+
+ESTIMATED_COMPLETION_TOKENS_PER_PASSAGE = 180
+"""Estimated completion tokens in one classification call. An estimate, not a measurement."""
+
+HEADLINE_SPAN_THRESHOLDS = [0, 0.25, 0.5]
+"""The span-overlap thresholds the headline tables report, loosest first.
+
+More than one, because a single threshold can't tell "the ensemble missed the mention"
+apart from "it found the mention but drew the span differently": 0 credits any overlap at
+all, and the drop from 0 to 0.5 is how much of the span-level score is boundary
+disagreement rather than detection.
+"""
+
+SPAN_AGREEMENT_THRESHOLDS = HEADLINE_SPAN_THRESHOLDS + [0.9, 0.99]
+
+PASSAGE_LEVEL = "passage"
+
+HEADLINE_ENSEMBLE = "mixed_n5"
+
+DEFAULT_OUTPUT_DIR = ensemble_metrics_dir / "eval_set_autolabelling"
+
+AUTOMATE_F1 = 0.95
+SEMI_AUTOMATE_F1 = 0.85
+AUTOMATE_COVERAGE = 0.50
+
+UNANIMOUS_POSITIVE_POLICY = "unanimous positive only"
+
+UNANIMOUS_NEGATIVE_POLICY = "unanimous negative only"
+
+AUTOMATE_VERDICT = "automate"
+SEMI_AUTOMATE_VERDICT = "semi-automate"
+BELOW_BAR_VERDICT = "below bar"
+
+NOT_APPLICABLE = "n/a"
+"""Rendered where precision/recall/F1 are undefined, so a sentinel 0.0 can't read as a score."""
+
+COST_COLUMN = "cost_usd"
+"""Estimated OpenRouter spend on one concept, in USD.
+
+The per-concept tables' cost column, summed over that concept's passages. Its macro row
+is a **mean**, like every other cell in that row — a row labelled "macro average" whose
+cost cell was a sum read as though the ensemble were eight times cheaper than it is.
+
+What the whole exercise costs is `TOTAL_COST_COLUMN` in the sizing table, where a total is
+what the column is for and is named as such.
+
+Any column with `usd` in its name gets currency formatting in `format_for_display`.
+"""
+
+TOTAL_COST_COLUMN = "total_cost_usd"
+"""Estimated OpenRouter spend for one ensemble across every concept, in USD.
+
+The sizing table's cost column, and a genuine total: it is the budget for running that
+ensemble over the whole evaluation set, which is the number the sizing decision turns on.
+Distinct from `COST_COLUMN` precisely so neither has to be read off a row label.
+"""
+
+AGREEMENT_CURVE_COLUMNS = [
+    "ensemble",
+    "n_members",
+    "family",
+    "disagreement_threshold",
+    "n_passages",
+    "macro_coverage",
+    "macro_precision",
+    "macro_recall",
+    "macro_f1",
+    "micro_f1",
+    "false_negatives",
+    "n_human_remaining",
+]
+
+COMPLETENESS_COLUMNS = [
+    "concept",
+    "gold_passages",
+    "members_expected",
+    "members_cached",
+    "members_complete",
+    "worst_member_passages",
+    "missing_members",
+    "scored_passages",
+    "excluded",
+    "exclusion_reason",
+]
+"""The columns of `data_completeness.csv`, in reading order."""
+
+POLICY_CONSOLE_COLUMNS = {
+    "policy": "policy",
+    "macro_coverage": "coverage",
+    "macro_precision": "prec",
+    "macro_recall": "rec",
+    "macro_f1": "f1",
+    "macro_npv": "npv",
+    "false_negatives": "missed",
+    "verdict": "verdict",
+}
+
+BY_ENSEMBLE_CONSOLE_COLUMNS = {
+    "ensemble": "ensemble",
+    "n_members": "n",
+    "n_concepts": "concepts",
+    "best_policy": "best policy",
+    "macro_coverage": "coverage",
+    "macro_precision": "prec",
+    "macro_f1": "f1",
+    "verdict": "verdict",
+    TOTAL_COST_COLUMN: "USD total",
+}
+
+NEGATIVE_SIDE_CONSOLE_COLUMNS = {
+    "concept": "concept",
+    "predicted_negative": "no span",
+    "negative_share": "share",
+    "npv": "npv",
+    "missed_mentions": "missed",
+    "specificity": "spec",
+}
+
+VOTE_SPLIT_CONSOLE_COLUMNS = {
+    "votes": "votes",
+    "ensemble_label": "label",
+    "n_passages": "n",
+    "precision": "prec",
+    "precision_95_ci": "prec 95% CI",
+    "false_negatives": "missed",
+    "missed_mention_rate": "missed rate",
+}

--- a/scripts/benchmarks/eval_set_autolabelling_experiment/ensembles.py
+++ b/scripts/benchmarks/eval_set_autolabelling_experiment/ensembles.py
@@ -1,0 +1,569 @@
+"""What an ensemble is, what it costs, and how its predictions are run and cached."""
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+
+from knowledge_graph.classifier.large_language_model import (
+    DEFAULT_SYSTEM_PROMPT,
+    LLMClassifier,
+    LLMClassifierPrompt,
+)
+from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.labelling import label_passages_with_classifier
+from knowledge_graph.operations.evaluate import create_gold_standard_labelled_passages
+from knowledge_graph.operations.get_concept import get_concept_async
+from scripts.benchmarks.eval_set_autolabelling_experiment.config import (
+    ESTIMATED_COMPLETION_TOKENS_PER_PASSAGE,
+    ESTIMATED_PROMPT_TOKENS_PER_PASSAGE,
+    FAMILIES,
+    FAMILY_A,
+    FAMILY_B,
+    NOT_APPLICABLE,
+    OPENROUTER_MODELS_PRICING_URL,
+    OPENROUTER_PRICING_CACHE_FILENAME,
+    SEEDS,
+    TEMPERATURE,
+    console,
+)
+
+EnsembleMember = tuple[str, int]
+"""A single ensemble member, identified by (family key, random seed)."""
+
+
+@dataclass(frozen=True)
+class NamedEnsemble:
+    """A named ensemble, built from a subset of the cached members."""
+
+    name: str
+    members: tuple[EnsembleMember, ...]
+
+    @property
+    def size(self) -> int:
+        """Number of classifiers in the ensemble."""
+        return len(self.members)
+
+
+def compose_possible_ensembles(max_members: int | None = None) -> list[NamedEnsemble]:
+    """
+    Build every ensemble we can compose from 5 members per family.
+
+    Family-only ensembles answer "does stacking one model on itself help?"; mixed ones
+    answer "is cross-family diversity worth the plumbing?". ``n1`` is the status quo: a
+    single LLM classifier.
+
+    Every ensemble is odd-sized, so `MajorityVote` can never tie and the whole
+    experiment runs on one unambiguous decision rule. A balanced mixed ensemble is
+    necessarily even, so the mixed splits are deliberately lopsided by one member: the
+    price of avoiding ties is that one family gets the extra vote.
+
+    :param max_members: drop ensembles larger than this. Answers "what is the smallest
+        ensemble that can do the job?" — with a cap of 3, the analysis reports only what
+        3 classifiers can achieve, so the verdict cannot lean on members you won't pay for.
+    """
+
+    ensembles = [
+        NamedEnsemble(
+            name=f"{family}_n{n}",
+            members=tuple((family, seed) for seed in SEEDS[:n]),
+        )
+        for family in FAMILIES
+        for n in (1, 3, 5)
+    ]
+
+    mixed_splits = [(2, 1), (3, 2), (4, 3), (5, 4)]
+    ensembles.extend(
+        NamedEnsemble(
+            name=f"mixed_n{n_a + n_b}",
+            members=tuple(
+                [(FAMILY_A, seed) for seed in SEEDS[:n_a]]
+                + [(FAMILY_B, seed) for seed in SEEDS[:n_b]]
+            ),
+        )
+        for n_a, n_b in mixed_splits
+    )
+
+    if max_members is not None:
+        ensembles = [ensemble for ensemble in ensembles if ensemble.size <= max_members]
+
+    return ensembles
+
+
+def family_of(ensemble_name: str) -> str:
+    """The family an ensemble belongs to, read off its name."""
+    return str(ensemble_name).split("_n")[0]
+
+
+def all_members() -> list[EnsembleMember]:
+    """
+    Every member the experiment runs: one per (family, seed) pair.
+
+    Deliberately the *full* set rather than the union of whichever ensembles survive
+    ``--max-members``. It is the yardstick `analyse` filters concepts against, and that
+    yardstick has to be independent of the cap: otherwise raising the cap would change
+    which concepts are in scope, and two runs of the same data would not be comparable.
+    """
+    return [(family, seed) for family in FAMILIES for seed in SEEDS]
+
+
+def describe_members(members: Iterable[EnsembleMember]) -> str:
+    """Render members as ``family seed=N``, for a log line or a CSV cell."""
+    return ", ".join(f"{family} seed={seed}" for family, seed in members)
+
+
+@dataclass(frozen=True)
+class TokenPrices:
+    """Per-token USD prices for one model, as OpenRouter reports them."""
+
+    prompt: float
+    completion: float
+
+
+def model_slug(model_name: str) -> str:
+    """The bare OpenRouter model slug for one of `FAMILIES`' values."""
+    return model_name.split(":", maxsplit=1)[-1]
+
+
+def fetch_model_pricing() -> dict[str, TokenPrices]:
+    """
+    Fetch each family's per-token prices from OpenRouter, keyed by family.
+
+    A family whose slug OpenRouter doesn't list is left out rather than defaulted, so that
+    an unknown price stays distinguishable from a free one downstream.
+    """
+
+    response = httpx.get(OPENROUTER_MODELS_PRICING_URL, timeout=30.0)
+    response.raise_for_status()
+
+    pricing_by_slug = {
+        str(model.get("id")): model.get("pricing") or {}
+        for model in response.json().get("data", [])
+    }
+
+    prices: dict[str, TokenPrices] = {}
+    for family, model_name in FAMILIES.items():
+        pricing = pricing_by_slug.get(model_slug(model_name))
+        if not pricing or "prompt" not in pricing or "completion" not in pricing:
+            console.log(
+                f"⚠️ OpenRouter lists no prompt/completion price for "
+                f"{model_slug(model_name)} — `{family}` costs will read "
+                f"`{NOT_APPLICABLE}`"
+            )
+            continue
+        prices[family] = TokenPrices(
+            prompt=float(pricing["prompt"]), completion=float(pricing["completion"])
+        )
+
+    return prices
+
+
+def read_pricing_cache(path: Path) -> dict[str, TokenPrices]:
+    """Read cached prices, returning nothing at all if the file can't be parsed."""
+
+    try:
+        cached = json.loads(path.read_text())
+        return {
+            family: TokenPrices(
+                prompt=float(prices["prompt"]), completion=float(prices["completion"])
+            )
+            for family, prices in cached.items()
+            if family in FAMILIES
+        }
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        console.log(f"⚠️ Couldn't read cached pricing from {path}: {e}")
+        return {}
+
+
+def write_pricing_cache(path: Path, prices: dict[str, TokenPrices]) -> None:
+    """Cache the fetched prices, recording which slug each family was priced from."""
+
+    path.write_text(
+        json.dumps(
+            {
+                family: {
+                    "model": model_slug(FAMILIES[family]),
+                    "prompt": token_prices.prompt,
+                    "completion": token_prices.completion,
+                }
+                for family, token_prices in prices.items()
+            },
+            indent=2,
+        )
+    )
+
+
+def load_model_pricing(output_dir: Path) -> dict[str, TokenPrices]:
+    """
+    Per-token prices for every family, from the cache if it exists and the API if not.
+
+    Fails soft: if there is no cache and the fetch doesn't work, this returns nothing and
+    the cost columns are dropped rather than filled with zeros. A cost of $0 and an
+    unknown cost are very different claims about an ensemble.
+    """
+
+    if (path := output_dir / OPENROUTER_PRICING_CACHE_FILENAME).exists():
+        cached = read_pricing_cache(path)
+        if cached:
+            return cached
+
+    try:
+        prices = fetch_model_pricing()
+    except Exception as e:
+        console.log(
+            f"⚠️ Couldn't fetch OpenRouter pricing ({e}) and no usable cache at "
+            f"{path} — costs will be omitted"
+        )
+        return {}
+
+    if prices:
+        write_pricing_cache(path, prices)
+    return prices
+
+
+def member_cost_per_passage(prices: TokenPrices) -> float:
+    """What one classifier costs to run over one passage, in USD."""
+    return (
+        ESTIMATED_PROMPT_TOKENS_PER_PASSAGE * prices.prompt
+        + ESTIMATED_COMPLETION_TOKENS_PER_PASSAGE * prices.completion
+    )
+
+
+def ensemble_cost_per_passage(
+    ensemble: NamedEnsemble, prices_by_family: dict[str, TokenPrices]
+) -> float:
+    """
+    What one ensemble costs per passage: the sum over its members, in USD.
+
+    Every member sees every passage, so an ``n=5`` same-family ensemble is five times a
+    single classifier and a mixed one is the sum of its members' families. No prompt
+    caching is assumed — members differ only by seed, so a provider that did cache the
+    shared system prompt across them would make this an over-estimate.
+
+    Returns `nan` if any member's family has no price, so an unpriced ensemble renders as
+    `NOT_APPLICABLE` rather than as a suspiciously cheap one.
+    """
+
+    if any(family not in prices_by_family for family, _ in ensemble.members):
+        return math.nan
+
+    return sum(
+        member_cost_per_passage(prices_by_family[family])
+        for family, _ in ensemble.members
+    )
+
+
+def ensemble_costs_per_passage(
+    ensembles: Iterable[NamedEnsemble], prices_by_family: dict[str, TokenPrices]
+) -> dict[str, float]:
+    """Per-passage cost for every ensemble, keyed by ensemble name."""
+    return {
+        ensemble.name: ensemble_cost_per_passage(ensemble, prices_by_family)
+        for ensemble in ensembles
+    }
+
+
+def concept_output_dir(output_dir: Path, wikibase_id: str) -> Path:
+    """Return (and create) the directory holding one concept's cached predictions."""
+    path = output_dir / str(wikibase_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def member_path(concept_dir: Path, member: EnsembleMember) -> Path:
+    """Return the cache path for one ensemble member's predictions."""
+    family, seed = member
+    return concept_dir / f"member_{family}_seed{seed}.jsonl"
+
+
+def write_passages(path: Path, passages: Iterable[LabelledPassage]) -> None:
+    """
+    Write labelled passages to a JSONL file, one per line.
+
+    Writes to a temporary file and renames on success, so an interrupted run never
+    leaves behind a truncated file that a later run would mistake for a complete one.
+    """
+
+    partial_path = path.with_suffix(".jsonl.partial")
+    with open(partial_path, "w") as f:
+        for passage in passages:
+            f.write(passage.model_dump_json() + "\n")
+    partial_path.rename(path)
+
+
+def read_passages(path: Path) -> list[LabelledPassage]:
+    """Read labelled passages from a JSONL file."""
+    with open(path) as f:
+        return [LabelledPassage.model_validate(json.loads(line)) for line in f if line]
+
+
+def read_member_cache(
+    concept_dir: Path, member: EnsembleMember
+) -> dict[str, LabelledPassage]:
+    """Load a member's already-predicted passages, keyed by passage id."""
+    path = member_path(concept_dir, member)
+    if not path.exists():
+        return {}
+    return {passage.id: passage for passage in read_passages(path)}
+
+
+def load_cached_predictions(
+    concept_dir: Path,
+) -> (
+    tuple[list[LabelledPassage], dict[EnsembleMember, dict[str, LabelledPassage]]]
+    | None
+):
+    """
+    Load one concept's gold passages and every cached member's predictions.
+
+    Members are keyed by passage id rather than kept in list order: the gold set is
+    refetched live on every `predict` run, so a cached member can hold a slightly
+    different set of passages than the current gold file.
+    """
+
+    gold_path = concept_dir / "gold.jsonl"
+    if not gold_path.exists():
+        console.log(f"⚠️ No gold.jsonl in {concept_dir} — run `predict` first")
+        return None
+
+    gold = read_passages(gold_path)
+
+    predictions_by_member: dict[EnsembleMember, dict[str, LabelledPassage]] = {}
+    for family in FAMILIES:
+        for seed in SEEDS:
+            member: EnsembleMember = (family, seed)
+            path = member_path(concept_dir, member)
+            if not path.exists():
+                continue
+            predictions_by_member[member] = {p.id: p for p in read_passages(path)}
+
+    if not predictions_by_member:
+        console.log(f"⚠️ No cached members in {concept_dir}")
+        return None
+
+    return gold, predictions_by_member
+
+
+UsableConcepts = dict[
+    str, tuple[list[LabelledPassage], dict[EnsembleMember, dict[str, LabelledPassage]]]
+]
+"""Per concept, the gold passages to score on and every cached member's predictions."""
+
+
+def load_usable_concepts(
+    output_dir: Path, wikibase_ids: Iterable[str]
+) -> tuple[UsableConcepts, list[dict[str, Any]]]:
+    """
+    Work out which concepts can be scored, and on which passages.
+
+    Whether a concept is in scope is a property of the whole cache for that concept rather
+    than of any one ensemble, so this runs once up front instead of per ensemble. A concept
+    is excluded outright if a member was never run, and otherwise its gold set is
+    restricted to the passages *every* member holds: `align_passages` drops a passage any
+    member of that ensemble lacks, so without this a failed call would leave two ensembles
+    within one concept scored on different passages.
+
+    :return: the scorable concepts, and one completeness row per requested concept —
+        including the excluded ones, since an absent row would be indistinguishable from a
+        concept that was scored, which is the bug this filter exists to fix
+    """
+
+    expected_members = all_members()
+    usable: UsableConcepts = {}
+    completeness: list[dict[str, Any]] = []
+
+    for wikibase_id in wikibase_ids:
+        concept_dir = output_dir / wikibase_id
+        loaded = load_cached_predictions(concept_dir)
+        if loaded is None:
+            completeness.append(
+                {
+                    "concept": wikibase_id,
+                    "gold_passages": 0,
+                    "members_expected": len(expected_members),
+                    "members_cached": 0,
+                    "members_complete": 0,
+                    "worst_member_passages": 0,
+                    "missing_members": describe_members(expected_members),
+                    "scored_passages": 0,
+                    "excluded": True,
+                    "exclusion_reason": "nothing cached — run `predict`",
+                }
+            )
+            continue
+        gold, predictions_by_member = loaded
+
+        console.log(
+            f"{wikibase_id}: {len(gold)} gold passages, "
+            f"{len(predictions_by_member)} cached members"
+        )
+
+        # a member holding fewer passages than gold had calls fail; those passages are
+        # dropped from that member rather than scored as negatives
+        passages_per_member = {
+            member: len(predictions)
+            for member, predictions in predictions_by_member.items()
+        }
+        incomplete = {
+            member: count
+            for member, count in passages_per_member.items()
+            if count < len(gold)
+        }
+        for member, count in incomplete.items():
+            console.log(
+                f"  ⚠️ {member[0]} seed={member[1]} has {count}/{len(gold)} passages — "
+                f"{len(gold) - count} failed and are excluded"
+            )
+
+        missing = [
+            member for member in expected_members if member not in predictions_by_member
+        ]
+        common_ids = {
+            passage.id
+            for passage in gold
+            if all(
+                passage.id in predictions
+                for predictions in predictions_by_member.values()
+            )
+        }
+
+        exclusion_reason: str | None = None
+        if missing:
+            exclusion_reason = (
+                f"{len(missing)} member(s) never run: {describe_members(missing)}"
+            )
+        elif not common_ids:
+            exclusion_reason = "no passage is held by every member"
+
+        completeness.append(
+            {
+                "concept": wikibase_id,
+                "gold_passages": len(gold),
+                "members_expected": len(expected_members),
+                "members_cached": len(predictions_by_member),
+                "members_complete": len(predictions_by_member) - len(incomplete),
+                "worst_member_passages": min(passages_per_member.values(), default=0),
+                "missing_members": describe_members(missing) if missing else None,
+                "scored_passages": 0 if exclusion_reason else len(common_ids),
+                "excluded": exclusion_reason is not None,
+                "exclusion_reason": exclusion_reason,
+            }
+        )
+
+        if exclusion_reason is not None:
+            console.log(
+                f"  🚫 Excluding {wikibase_id} from every table: {exclusion_reason}"
+            )
+            continue
+
+        scored_gold = [passage for passage in gold if passage.id in common_ids]
+        if len(scored_gold) < len(gold):
+            console.log(
+                f"  ✂️  Scoring {len(scored_gold)}/{len(gold)} passages — the rest are "
+                "missing from at least one member, so scoring them would put different "
+                "ensembles on different passages"
+            )
+        usable[wikibase_id] = (scored_gold, predictions_by_member)
+
+    return usable, completeness
+
+
+def build_member_classifier(concept: Concept, member: EnsembleMember) -> LLMClassifier:
+    """
+    Build the LLM classifier for one ensemble member.
+
+    Uses the default system prompt with no concept-specific labelling guidelines, so the
+    only thing describing the concept is what's in the concept store.
+    """
+    family, seed = member
+    return LLMClassifier(
+        concept=concept,
+        model_name=FAMILIES[family],
+        system_prompt_template=LLMClassifierPrompt(
+            system_prompt_template=DEFAULT_SYSTEM_PROMPT
+        ),
+        random_seed=seed,
+        temperature=TEMPERATURE,
+    )
+
+
+async def fetch_concept_and_gold(
+    wikibase_id: WikibaseID,
+) -> tuple[Concept, list[LabelledPassage]] | None:
+    """Fetch a concept and its gold-standard passages live from Wikibase and Argilla."""
+
+    concept = await get_concept_async(
+        wikibase_id=wikibase_id,
+        include_recursive_has_subconcept=True,
+        include_labels_from_subconcepts=True,
+    )
+
+    if not concept.labelled_passages:
+        console.log(f"⚠️ {wikibase_id} has no labelled passages — skipping")
+        return None
+
+    gold = create_gold_standard_labelled_passages(concept.labelled_passages)
+    n_positive = sum(1 for passage in gold if passage.spans)
+    console.log(
+        f"📥 {wikibase_id}: fetched {len(gold)} gold passages, "
+        f"{n_positive} positive ({n_positive / len(gold):.1%})"
+    )
+
+    return concept, gold
+
+
+def run_member_with_caching(
+    concept: Concept,
+    member: EnsembleMember,
+    gold: list[LabelledPassage],
+    concept_dir: Path,
+    batch_size: int,
+    position: str,
+) -> None:
+    """
+    Predict one member's passages, reusing whatever it has already cached.
+
+    Only the passages missing from the member's cache are sent to the LLM, so a rerun
+    picks up any that a previous run didn't cover — for instance if the gold set grew
+    between runs.
+    """
+
+    family, seed = member
+    cached = read_member_cache(concept_dir, member)
+    pending = [passage for passage in gold if passage.id not in cached]
+
+    if not pending:
+        console.log(f"{position}: ⏭️  all {len(gold)} passages cached")
+        return
+
+    console.log(
+        f"{position} (T={TEMPERATURE}): {len(pending)} to predict"
+        + (f", {len(cached)} reused from cache" if cached else "")
+    )
+
+    try:
+        predictions = label_passages_with_classifier(
+            classifier=build_member_classifier(concept, member),
+            labelled_passages=pending,
+            batch_size=batch_size,
+            show_progress=True,
+        )
+    except Exception as e:
+        console.log(f"  ⚠️ {family} seed={seed} aborted: {e}. Rerun to resume.")
+        return
+
+    # merge with the cache and write back in gold order
+    merged = {**cached, **{passage.id: passage for passage in predictions}}
+    ordered = [merged[passage.id] for passage in gold if passage.id in merged]
+    write_passages(member_path(concept_dir, member), ordered)
+
+    n_positive = sum(1 for passage in ordered if passage.spans)
+    console.log(
+        f"  ✅ {family} seed={seed}: {len(ordered)}/{len(gold)} passages cached, "
+        f"{n_positive} positive ({n_positive / len(ordered):.1%})"
+    )

--- a/scripts/benchmarks/eval_set_autolabelling_experiment/ensembles.py
+++ b/scripts/benchmarks/eval_set_autolabelling_experiment/ensembles.py
@@ -208,8 +208,7 @@ def load_model_pricing(output_dir: Path) -> dict[str, TokenPrices]:
     """
 
     if (path := output_dir / OPENROUTER_PRICING_CACHE_FILENAME).exists():
-        cached = read_pricing_cache(path)
-        if cached:
+        if cached := read_pricing_cache(path):
             return cached
 
     try:

--- a/tests/scripts/test_eval_set_autolabelling_experiment.py
+++ b/tests/scripts/test_eval_set_autolabelling_experiment.py
@@ -1,0 +1,886 @@
+import pandas as pd
+import pytest
+import typer
+
+from knowledge_graph.concept import Concept
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.metrics import ConfusionMatrix
+from knowledge_graph.span import Span
+from scripts.benchmarks.eval_set_autolabelling_experiment import cli, ensembles
+from scripts.benchmarks.eval_set_autolabelling_experiment.analysis import (
+    agreement_f1_curves,
+    automation_by_ensemble,
+    format_for_display,
+    headline_table,
+    metrics_row,
+    negative_side_table,
+    policy_table,
+    policy_table_by_ensemble,
+    policy_verdict,
+    summarise_vote_splits,
+    wilson_interval,
+)
+from scripts.benchmarks.eval_set_autolabelling_experiment.config import (
+    AUTOMATE_F1,
+    AUTOMATE_VERDICT,
+    BELOW_BAR_VERDICT,
+    COST_COLUMN,
+    ESTIMATED_COMPLETION_TOKENS_PER_PASSAGE,
+    ESTIMATED_PROMPT_TOKENS_PER_PASSAGE,
+    FAMILY_A,
+    FAMILY_B,
+    HEADLINE_ENSEMBLE,
+    NOT_APPLICABLE,
+    OPENROUTER_PRICING_CACHE_FILENAME,
+    PASSAGE_LEVEL,
+    SEMI_AUTOMATE_F1,
+    SEMI_AUTOMATE_VERDICT,
+    UNANIMOUS_NEGATIVE_POLICY,
+    UNANIMOUS_POSITIVE_POLICY,
+)
+from scripts.benchmarks.eval_set_autolabelling_experiment.ensembles import (
+    NamedEnsemble,
+    TokenPrices,
+    compose_possible_ensembles,
+    ensemble_cost_per_passage,
+    load_model_pricing,
+    read_member_cache,
+    run_member_with_caching,
+)
+
+CONCEPT_ID = WikibaseID("Q42")
+
+
+@pytest.fixture
+def gold() -> list[LabelledPassage]:
+    return [
+        LabelledPassage(id=f"p{i}", text=f"passage number {i}", spans=[])
+        for i in range(4)
+    ]
+
+
+@pytest.fixture
+def concept() -> Concept:
+    return Concept(wikibase_id=CONCEPT_ID, preferred_label="just transition")
+
+
+def stub_labelling(monkeypatch) -> list[list[str]]:
+    """
+    Replace the classifier and the labelling call with a stub.
+
+    Returns a list that accumulates the texts the stub was asked to predict, one entry per
+    call, so a test can assert which passages actually reached the LLM.
+    """
+    requested: list[list[str]] = []
+
+    monkeypatch.setattr(
+        ensembles, "build_member_classifier", lambda concept, member: object()
+    )
+
+    def fake_label(classifier, labelled_passages, batch_size, show_progress):
+        requested.append([p.text for p in labelled_passages])
+        return [
+            passage.model_copy(
+                update={
+                    "spans": [
+                        Span(
+                            text=passage.text,
+                            start_index=0,
+                            end_index=7,
+                            concept_id=CONCEPT_ID,
+                            labellers=["stub"],
+                        )
+                    ]
+                },
+                deep=True,
+            )
+            for passage in labelled_passages
+        ]
+
+    monkeypatch.setattr(ensembles, "label_passages_with_classifier", fake_label)
+    return requested
+
+
+def test_whether_an_empty_cache_predicts_every_passage(
+    monkeypatch, tmp_path, gold, concept
+):
+    """With nothing cached, the whole gold set goes to the LLM."""
+    requested = stub_labelling(monkeypatch)
+
+    run_member_with_caching(
+        concept=concept,
+        member=("opus", 1),
+        gold=gold,
+        concept_dir=tmp_path,
+        batch_size=4,
+        position="Member 1/1",
+    )
+
+    assert requested == [[p.text for p in gold]]
+    assert set(read_member_cache(tmp_path, ("opus", 1))) == {"p0", "p1", "p2", "p3"}
+
+
+def test_whether_a_rerun_only_requests_passages_missing_from_the_cache(
+    monkeypatch, tmp_path, gold, concept
+):
+    """
+    The point of caching per passage: a rerun covers only the gaps.
+
+    Modelled here by the gold set growing between runs, which is the realistic case now
+    that a failed call is cached as a negative rather than left out.
+    """
+    stub_labelling(monkeypatch)
+    run_member_with_caching(
+        concept=concept,
+        member=("opus", 1),
+        gold=gold[:2],
+        concept_dir=tmp_path,
+        batch_size=4,
+        position="first run",
+    )
+
+    requested = stub_labelling(monkeypatch)
+    run_member_with_caching(
+        concept=concept,
+        member=("opus", 1),
+        gold=gold,
+        concept_dir=tmp_path,
+        batch_size=4,
+        position="rerun with more gold",
+    )
+
+    assert requested == [["passage number 2", "passage number 3"]]
+    assert set(read_member_cache(tmp_path, ("opus", 1))) == {"p0", "p1", "p2", "p3"}
+
+
+def test_whether_a_complete_member_makes_no_further_calls(
+    monkeypatch, tmp_path, gold, concept
+):
+    """A fully cached member is skipped, so reruns are cheap."""
+    stub_labelling(monkeypatch)
+    run_member_with_caching(
+        concept=concept,
+        member=("opus", 1),
+        gold=gold,
+        concept_dir=tmp_path,
+        batch_size=4,
+        position="first run",
+    )
+
+    requested = stub_labelling(monkeypatch)
+    run_member_with_caching(
+        concept=concept,
+        member=("opus", 1),
+        gold=gold,
+        concept_dir=tmp_path,
+        batch_size=4,
+        position="rerun",
+    )
+
+    assert requested == []
+
+
+def passages(
+    concept: str, n_members: int, *splits: tuple[int, int, int]
+) -> list[dict[str, object]]:
+    """
+    Build per-passage rows for the automation analysis.
+
+    Each split is ``(positive votes, gold positives, gold negatives)``, which is enough to
+    pin down every confusion-matrix cell: the vote count fixes the ensemble's label and the
+    disagreement, and the two counts fix what gold said.
+    """
+
+    rows: list[dict[str, object]] = []
+    for votes, gold_positives, gold_negatives in splits:
+        for index in range(gold_positives + gold_negatives):
+            rows.append(
+                {
+                    "concept": concept,
+                    "passage_id": f"{concept}-{votes}-{index}",
+                    "disagreement": 2 * min(votes, n_members - votes) / n_members,
+                    "n_positive_votes": votes,
+                    "predicted_positive": 2 * votes >= n_members,
+                    "ground_truth_positive": index < gold_positives,
+                }
+            )
+    return rows
+
+
+def test_whether_a_policy_scores_its_subset_as_hand_computed():
+    """
+    Anchors the policy table against arithmetic done by hand.
+
+    Unanimous: 3 passages labelled positive of which 2 are gold (TP=2, FP=1), plus one
+    labelled negative that was gold (FN=1) — so P=R=2/3. Widening to every passage adds two
+    false positives, dropping precision to 2/5.
+    """
+    df = pd.DataFrame(
+        passages("Q1", 3, (3, 2, 1), (0, 1, 0), (2, 0, 2)),
+    )
+
+    policies = policy_table(df).set_index("policy")
+
+    unanimous = policies.loc["disagreement <= 0.000"]
+    assert unanimous["n_passages"] == 4
+    assert unanimous["macro_precision"] == pytest.approx(2 / 3)
+    assert unanimous["macro_recall"] == pytest.approx(2 / 3)
+    assert unanimous["macro_f1"] == pytest.approx(2 / 3)
+    assert unanimous["false_negatives"] == 1
+    assert unanimous["n_human_remaining"] == 2
+
+    everything = policies.loc["disagreement <= 0.667"]
+    assert everything["macro_precision"] == pytest.approx(0.4)
+    assert everything["macro_recall"] == pytest.approx(2 / 3)
+    assert everything["n_human_remaining"] == 0
+
+
+def test_whether_coverage_grows_with_the_disagreement_threshold():
+    """The threshold policies are nested, so each one can only add passages."""
+    df = pd.DataFrame(passages("Q1", 3, (3, 2, 1), (0, 1, 0), (2, 0, 2), (1, 1, 1)))
+
+    thresholds = policy_table(df).sort_values(by=["policy"])
+    nested = thresholds[thresholds["policy"].str.startswith("disagreement <=")]
+
+    coverages = nested["macro_coverage"].tolist()
+    assert coverages == sorted(coverages)
+    assert coverages[-1] == pytest.approx(1.0)
+
+
+def test_whether_a_policy_assigning_no_positive_labels_scores_as_undefined():
+    """
+    F1 cannot score a policy that never says positive, and 0.0 would be a lie.
+
+    `ConfusionMatrix.precision` returns 0 rather than raising on an empty denominator, so
+    without an explicit check this policy would read as a scored, failing 0.000 — and could
+    then be compared against a gate.
+    """
+    df = pd.DataFrame(passages("Q1", 3, (3, 2, 1), (0, 3, 2)))
+
+    negatives = policy_table(df).set_index("policy").loc[UNANIMOUS_NEGATIVE_POLICY]
+
+    assert pd.isna(negatives["macro_precision"])
+    assert pd.isna(negatives["macro_recall"])
+    assert pd.isna(negatives["macro_f1"])
+    assert pd.isna(negatives["micro_f1"])
+    # the real mentions it would silently discard are what's left to read
+    assert negatives["false_negatives"] == 3
+    assert negatives["verdict"] == "n/a"
+
+
+def test_whether_the_macro_average_differs_from_the_pooled_one():
+    """
+    The regression that motivated macro-averaging the verdict.
+
+    A 10-passage concept at F1 0.947 and a 2-passage one at F1 0.667 must not be reported
+    as the pooled 0.909, which is almost entirely the big concept's score.
+    """
+    df = pd.DataFrame(
+        passages("Q1", 3, (3, 9, 1)) + passages("Q2", 3, (3, 1, 1)),
+    )
+
+    unanimous = policy_table(df).set_index("policy").loc["disagreement <= 0.000"]
+
+    assert unanimous["macro_f1"] == pytest.approx((0.9473684 + 2 / 3) / 2, abs=1e-6)
+    assert unanimous["micro_f1"] == pytest.approx(10 / 11, abs=1e-6)
+    assert unanimous["macro_f1"] != pytest.approx(unanimous["micro_f1"])
+
+
+def test_whether_empty_vote_splits_still_get_a_row():
+    """An absent split must be visibly empty rather than silently missing."""
+    df = pd.DataFrame(passages("Q1", 3, (3, 2, 1), (0, 1, 0)))
+
+    vote_splits = summarise_vote_splits(df, 3).set_index("votes")
+
+    assert list(vote_splits.index) == ["0/3", "1/3", "2/3", "3/3"]
+    assert vote_splits.loc["1/3", "n_passages"] == 0
+    assert vote_splits.loc["2/3", "n_passages"] == 0
+
+
+def test_whether_each_vote_split_reports_only_its_informative_side():
+    """
+    Precision where the ensemble commits to a label, missed mentions where it doesn't.
+
+    Recall inside a positive split is trivially 1.0 and precision inside a negative one is
+    undefined, so reporting both everywhere would print numbers that mean nothing.
+    """
+    df = pd.DataFrame(passages("Q1", 3, (3, 2, 1), (0, 1, 3)))
+
+    vote_splits = summarise_vote_splits(df, 3).set_index("votes")
+
+    positive = vote_splits.loc["3/3"]
+    assert positive["ensemble_label"] == "positive"
+    assert positive["precision"] == pytest.approx(2 / 3)
+    assert pd.isna(positive["false_negatives"])
+    assert pd.isna(positive["missed_mention_rate"])
+
+    negative = vote_splits.loc["0/3"]
+    assert negative["ensemble_label"] == "negative"
+    assert pd.isna(negative["precision"])
+    assert negative["false_negatives"] == 1
+    assert negative["missed_mention_rate"] == pytest.approx(0.25)
+
+
+def test_whether_a_single_passage_split_gets_an_uninformative_interval():
+    """The whole point of the intervals: a bare 1.000 off one passage must not look solid."""
+    low, high = wilson_interval(1, 1)
+
+    assert high == pytest.approx(1.0)
+    assert low < 0.5
+
+    for successes, n in [(0, 1), (1, 1), (3, 8), (67, 67), (0, 0)]:
+        low, high = wilson_interval(successes, n)
+        if n:
+            assert 0.0 <= low <= high <= 1.0
+
+
+@pytest.mark.parametrize(
+    "macro_f1, macro_coverage, expected",
+    [
+        (AUTOMATE_F1 + 0.001, 0.9, AUTOMATE_VERDICT),
+        (AUTOMATE_F1, 0.9, AUTOMATE_VERDICT),
+        # clears the F1 gate but not the coverage one, so it can only be semi-automated
+        (AUTOMATE_F1 + 0.001, 0.1, SEMI_AUTOMATE_VERDICT),
+        (AUTOMATE_F1 - 0.001, 0.9, SEMI_AUTOMATE_VERDICT),
+        (SEMI_AUTOMATE_F1, 0.9, SEMI_AUTOMATE_VERDICT),
+        (SEMI_AUTOMATE_F1 - 0.001, 0.9, BELOW_BAR_VERDICT),
+    ],
+)
+def test_whether_the_verdict_gates_are_applied_at_their_boundaries(
+    macro_f1, macro_coverage, expected
+):
+    """Both gates are inclusive, and coverage only ever blocks full automation."""
+    assert policy_verdict(macro_f1, macro_coverage) == expected
+
+
+def test_whether_the_default_headline_survives_the_default_cap():
+    """
+    The advertised default has to be reachable, or the script picks the headline instead.
+
+    An earlier pairing defaulted `--headline` to `mixed_n9` while `--max-members` defaulted
+    to 5, so the request was unmeetable on every run and a fallback rule chose the headline
+    — which is exactly the choice that should sit on the command line.
+    """
+    assert HEADLINE_ENSEMBLE in {c.name for c in compose_possible_ensembles(5)}
+
+
+def test_whether_a_positives_only_policy_cannot_win_the_sizing_table():
+    """
+    The artefact this guard exists for.
+
+    A policy that only labels positively has recall 1.0 by construction, so its F1 beats any
+    both-class policy of equal precision and it would win at every ensemble size. Here the
+    positives-only subset is perfect while the both-class one is not, so an unguarded search
+    would pick it.
+    """
+    df = pd.DataFrame(
+        passages("Q1", 3, (3, 4, 0), (0, 2, 2)),
+    )
+    df["ensemble"] = "opus_n3"
+    df["n_members"] = 3
+
+    policies = policy_table_by_ensemble(df)
+    positives_only = policies.set_index("policy").loc[UNANIMOUS_POSITIVE_POLICY]
+    assert positives_only["macro_f1"] == pytest.approx(1.0)
+    assert not positives_only["assigns_negatives"]
+
+    by_ensemble = automation_by_ensemble(policies)
+
+    assert len(by_ensemble) == 1
+    assert by_ensemble.iloc[0]["best_policy"] != UNANIMOUS_POSITIVE_POLICY
+    assert by_ensemble.iloc[0]["assigns_negatives"]
+    # the both-class policy misses the 2 real mentions the negative side discards
+    assert by_ensemble.iloc[0]["macro_f1"] < 1.0
+
+
+def test_whether_each_ensemble_gets_its_own_row_and_size():
+    """The sizing question needs a verdict per ensemble size, not one for the headline."""
+    df = pd.concat(
+        [
+            pd.DataFrame(passages("Q1", 3, (3, 3, 1), (0, 1, 2))).assign(
+                ensemble="opus_n3", n_members=3
+            ),
+            pd.DataFrame(passages("Q1", 5, (5, 3, 1), (0, 1, 2))).assign(
+                ensemble="opus_n5", n_members=5
+            ),
+        ],
+        ignore_index=True,
+    )
+
+    by_ensemble = automation_by_ensemble(policy_table_by_ensemble(df))
+
+    assert list(by_ensemble["ensemble"]) == ["opus_n3", "opus_n5"]
+    assert list(by_ensemble["n_members"]) == [3, 5]
+    assert set(by_ensemble["family"]) == {"opus"}
+
+
+def test_whether_the_agreement_curve_holds_only_the_thresholds_an_ensemble_can_produce():
+    """
+    A curve point has to be a point on the disagreement axis.
+
+    The two directional unanimous policies both sit at disagreement 0, so they are a split
+    of the leftmost point rather than points of their own — plotting them would put two
+    extra values at the same x. What is left is one point per disagreement value the
+    ensemble can actually produce: ``⌊n/2⌋ + 1`` of them, so two for n=3 and three for n=5.
+    """
+    df = pd.concat(
+        [
+            pd.DataFrame(passages("Q1", 3, (3, 3, 1), (1, 1, 2), (0, 1, 2))).assign(
+                ensemble="opus_n3", n_members=3
+            ),
+            pd.DataFrame(
+                passages("Q1", 5, (5, 3, 1), (4, 1, 1), (2, 1, 1), (0, 1, 2))
+            ).assign(ensemble="opus_n5", n_members=5),
+        ],
+        ignore_index=True,
+    )
+
+    curves = agreement_f1_curves(policy_table_by_ensemble(df))
+
+    assert list(curves["ensemble"]) == ["opus_n3"] * 2 + ["opus_n5"] * 3
+    assert bool(curves["disagreement_threshold"].notna().all())
+
+    for _, panel in curves.groupby("ensemble"):
+        thresholds = panel["disagreement_threshold"].tolist()
+        assert thresholds == sorted(thresholds)
+        assert thresholds[0] == pytest.approx(0.0)
+        # the rightmost point is the no-review baseline: every passage auto-labelled
+        assert panel["macro_coverage"].tolist()[-1] == pytest.approx(1.0)
+        assert panel["n_human_remaining"].tolist()[-1] == 0
+
+
+def test_whether_a_single_classifier_has_no_routing_signal():
+    """
+    A one-member ensemble always agrees with itself, so `disagreement` is always 0.
+
+    That makes its unanimous subset the whole eval set at 100% coverage — no passage can be
+    routed to a human. Worth pinning: it is why n=1 reads as maximum coverage rather than as
+    a confident ensemble.
+    """
+    df = pd.DataFrame(passages("Q1", 1, (1, 3, 1), (0, 1, 2)))
+
+    assert (df["disagreement"] == 0).all()
+
+    policies = policy_table(df)
+    unanimous = policies.set_index("policy").loc["disagreement <= 0.000"]
+    assert unanimous["macro_coverage"] == pytest.approx(1.0)
+    assert unanimous["n_human_remaining"] == 0
+
+
+def test_whether_the_sizing_table_is_sorted_by_f1_descending():
+    """The ensemble to beat should be the top row, not whichever family sorts first."""
+    df = pd.concat(
+        [
+            pd.DataFrame(passages("Q1", 3, (3, 1, 3), (0, 1, 2))).assign(
+                ensemble="opus_n3", n_members=3
+            ),
+            pd.DataFrame(passages("Q1", 3, (3, 3, 0), (0, 0, 3))).assign(
+                ensemble="gemini_n3", n_members=3
+            ),
+        ],
+        ignore_index=True,
+    )
+
+    by_ensemble = automation_by_ensemble(policy_table_by_ensemble(df))
+
+    scores = by_ensemble["macro_f1"].tolist()
+    assert scores == sorted(scores, reverse=True)
+    # gemini's subset is perfect, opus' is not — so gemini leads despite sorting later
+    assert by_ensemble.iloc[0]["ensemble"] == "gemini_n3"
+
+
+def negative_side_rows(*concepts: tuple[str, int, int, int, int]) -> pd.DataFrame:
+    """
+    Build a per-concept metrics frame from hand-written confusion matrices.
+
+    Each concept is ``(id, TP, FP, TN, FN)``. Goes through `metrics_row` rather than
+    writing the columns out, so the test breaks if the row's shape drifts from what
+    `negative_side_table` reads.
+    """
+
+    return pd.DataFrame(
+        [
+            metrics_row(
+                ConfusionMatrix(
+                    true_positives=tp,
+                    false_positives=fp,
+                    true_negatives=tn,
+                    false_negatives=fn,
+                ),
+                concept=concept,
+                ensemble="opus_n3",
+                n_members=3,
+                level=PASSAGE_LEVEL,
+            )
+            for concept, tp, fp, tn, fn in concepts
+        ]
+    )
+
+
+def test_whether_predicted_negative_counts_match_the_confusion_matrix():
+    """
+    The "how many passages get no span" answer has to be every negative prediction.
+
+    Reading it off `true_negatives` alone would quietly drop the missed mentions, which
+    are exactly the passages the column exists to warn about.
+    """
+    per_concept = negative_side_rows(("Q1", 4, 2, 10, 4))
+
+    table = negative_side_table(per_concept, PASSAGE_LEVEL, "opus_n3")
+    concept = table.iloc[0]
+
+    assert concept["predicted_negative"] == 14
+    assert concept["negative_share"] == pytest.approx(14 / 20)
+    assert concept["npv"] == pytest.approx(10 / 14)
+    assert concept["missed_mentions"] == 4
+    assert concept["specificity"] == pytest.approx(10 / 12)
+
+
+def test_whether_npv_is_undefined_when_nothing_is_labelled_negative():
+    """
+    A concept the ensemble never calls negative has no negative labels to score.
+
+    `ConfusionMatrix.negative_predictive_value` returns 0 rather than raising on an empty
+    denominator, so without a guard this reads as a scored, maximally untrustworthy 0.000
+    — and would then drag the macro average down.
+    """
+    per_concept = negative_side_rows(("Q1", 6, 4, 0, 0), ("Q2", 3, 1, 8, 2))
+
+    table = negative_side_table(per_concept, PASSAGE_LEVEL, "opus_n3").set_index(
+        "concept"
+    )
+
+    assert table.loc["Q1", "predicted_negative"] == 0
+    assert pd.isna(table.loc["Q1", "npv"])
+    # the macro row averages only the concept that has negatives to score
+    assert table.iloc[-1]["npv"] == pytest.approx(8 / 10)
+
+
+def test_whether_the_negative_side_is_scored_for_every_policy():
+    """
+    `unanimous negative only` has no F1 by construction, so NPV is all it can be judged on.
+
+    Its subset is 2 gold-positive passages among 6 labelled negative, so two thirds of the
+    passages it hands back as empty are genuinely empty.
+    """
+    df = pd.DataFrame(passages("Q1", 3, (3, 2, 1), (0, 2, 4)))
+
+    negatives = policy_table(df).set_index("policy").loc[UNANIMOUS_NEGATIVE_POLICY]
+
+    assert pd.isna(negatives["macro_f1"])
+    assert negatives["macro_npv"] == pytest.approx(4 / 6)
+
+
+def span_at(text: str) -> Span:
+    """A span over the first word of a passage, which is all the metrics need."""
+    return Span(
+        text=text,
+        start_index=0,
+        end_index=7,
+        concept_id=CONCEPT_ID,
+        labellers=["stub"],
+    )
+
+
+def write_fake_cache(output_dir, concept, members, n_passages=12, n_gold_positive=6):
+    """
+    Write one concept's gold set plus a cached prediction file per named member.
+
+    Members are deliberately not identical: every member calls the first
+    ``n_gold_positive - 1`` passages positive, and only the odd seeds also call the last
+    gold-positive one positive. That single split is what gives the ensembles a non-zero
+    disagreement to route on — without it every policy would select every passage and the
+    automation table would collapse to one row per ensemble with nothing to separate
+    them.
+
+    Members not listed get no file at all, which is how a concept the opus runs never
+    reached is modelled.
+    """
+
+    concept_dir = ensembles.concept_output_dir(output_dir, concept)
+    gold = [
+        LabelledPassage(
+            id=f"{concept}-p{index}",
+            text=f"passage number {index} of {concept}",
+            spans=[span_at(f"passage number {index} of {concept}")]
+            if index < n_gold_positive
+            else [],
+        )
+        for index in range(n_passages)
+    ]
+    ensembles.write_passages(concept_dir / "gold.jsonl", gold)
+
+    for family, seed in members:
+        predictions = [
+            passage.model_copy(
+                update={
+                    "spans": [span_at(passage.text)]
+                    if index < n_gold_positive - 1 + seed % 2
+                    else []
+                },
+                deep=True,
+            )
+            for index, passage in enumerate(gold)
+        ]
+        ensembles.write_passages(
+            ensembles.member_path(concept_dir, (family, seed)), predictions
+        )
+
+
+def write_three_concepts(tmp_path):
+    """
+    Two concepts every member covers, and one the opus run didn't finish.
+
+    The shape the credit-limited run left behind, and the reason `analyse` needs a common
+    concept set: `Q3` can be scored by every ensemble except the ones needing opus
+    seeds 4 and 5.
+    """
+
+    every_member = ensembles.all_members()
+    write_fake_cache(tmp_path, "Q1", every_member)
+    write_fake_cache(tmp_path, "Q2", every_member)
+    write_fake_cache(
+        tmp_path,
+        "Q3",
+        [member for member in every_member if member not in {("opus", 4), ("opus", 5)}],
+    )
+
+
+def test_whether_every_ensemble_is_scored_on_the_same_concepts(tmp_path):
+    """
+    The comparison the sizing table exists for: every row over one common concept set.
+
+    `Q3` has only three of opus' five seeds, so under per-ensemble skipping `opus_n5`
+    was macro-averaged over two concepts while everything else got three — and a mean over
+    two concepts cannot be compared with a mean over three, because the smaller row may
+    simply have drawn the easier ones. Every row must now report the same `n_concepts`.
+    """
+    write_three_concepts(tmp_path)
+
+    cli.analyse(concepts="Q1,Q2,Q3", output_dir=tmp_path, max_members=5)
+
+    by_ensemble = pd.read_csv(tmp_path / "automation_by_ensemble.csv")
+    # all eight ensembles under a cap of 5, and every one of them on Q1 and Q2 alone
+    assert len(by_ensemble) == len(ensembles.compose_possible_ensembles(5))
+    assert set(by_ensemble["n_concepts"]) == {2}
+
+    per_concept = pd.read_csv(tmp_path / "per_concept_metrics.csv")
+    assert set(per_concept["concept"]) == {"Q1", "Q2"}
+
+
+def test_whether_every_ensemble_is_scored_on_the_same_passages(tmp_path):
+    """
+    The same bug one level down, at passage rather than concept granularity.
+
+    `align_passages` drops a passage any member of *that ensemble* lacks, so one failed
+    call put two ensembles of the same concept on different passages — `gemini_n3` on
+    all 12 and anything containing the failed member on 11. Restricting gold to the
+    passages every member holds makes it 11 for all of them, which is the only way the
+    supports line up.
+    """
+    write_fake_cache(tmp_path, "Q1", ensembles.all_members())
+
+    # one call failed for opus seed 5, the way a real interrupted run leaves things
+    concept_dir = tmp_path / "Q1"
+    cached = ensembles.read_passages(ensembles.member_path(concept_dir, ("opus", 5)))
+    ensembles.write_passages(
+        ensembles.member_path(concept_dir, ("opus", 5)), cached[:-1]
+    )
+
+    cli.analyse(concepts="Q1", output_dir=tmp_path, max_members=5)
+
+    per_concept = pd.read_csv(tmp_path / "per_concept_metrics.csv")
+    passage_rows = per_concept[per_concept["level"] == PASSAGE_LEVEL]
+    # 12 gold passages, 1 held back by the failed call, so 11 for every ensemble
+    assert set(passage_rows["support"]) == {11}
+
+    completeness = pd.read_csv(tmp_path / "data_completeness.csv").set_index("concept")
+    assert completeness.loc["Q1", "gold_passages"] == 12
+    assert completeness.loc["Q1", "scored_passages"] == 11
+    assert not completeness.loc["Q1", "excluded"]
+
+
+def test_whether_an_excluded_concept_names_the_members_it_is_missing(tmp_path):
+    """
+    A dropped concept has to be loud in `data_completeness.csv`.
+
+    Silently scoring nine concepts where ten were asked for is the failure this whole
+    filter is correcting, so the exclusion and its reason have to be readable without
+    re-running the command and watching the console.
+    """
+    write_three_concepts(tmp_path)
+
+    cli.analyse(concepts="Q1,Q2,Q3", output_dir=tmp_path, max_members=5)
+
+    completeness = pd.read_csv(tmp_path / "data_completeness.csv").set_index("concept")
+    assert list(completeness.index) == ["Q1", "Q2", "Q3"]
+    assert not completeness.loc["Q1", "excluded"]
+    assert completeness.loc["Q3", "excluded"]
+    assert completeness.loc["Q3", "members_cached"] == 8
+    assert completeness.loc["Q3", "members_expected"] == 10
+    for missing in ("opus seed=4", "opus seed=5"):
+        assert missing in completeness.loc["Q3", "missing_members"]
+        assert missing in completeness.loc["Q3", "exclusion_reason"]
+
+
+def test_whether_no_concept_with_every_member_fails_rather_than_scoring_nothing(
+    tmp_path,
+):
+    """
+    With one family missing everywhere there is no common set, and no honest table.
+
+    Falling through to an empty analysis would write out tables that look like a finding,
+    so this exits the same way the "no cached predictions" path does — pointing at
+    `predict` as the fix.
+    """
+    write_fake_cache(tmp_path, "Q1", [("gemini", seed) for seed in (1, 2, 3, 4, 5)])
+
+    with pytest.raises(typer.Exit):
+        cli.analyse(concepts="Q1", output_dir=tmp_path, max_members=5)
+
+
+def test_whether_a_misspelled_headline_fails_instead_of_being_absorbed(tmp_path):
+    """
+    A name that isn't an ensemble at all is a typo, and gets its own message.
+
+    Distinct from a real ensemble the size cap excludes: both exit, but a typo means
+    the whole ensemble list is worth printing, whereas a capped-out request only needs the
+    sizes currently on offer.
+    """
+    write_fake_cache(tmp_path, "Q1", ensembles.all_members())
+
+    with pytest.raises(typer.Exit):
+        cli.analyse(
+            concepts="Q1",
+            output_dir=tmp_path,
+            max_members=5,
+            headline_ensemble="mixed_n4",
+        )
+
+
+def test_whether_a_capped_out_headline_fails_rather_than_substituting(tmp_path):
+    """
+    An unmeetable headline is the caller's to resolve, not the script's to work around.
+
+    `mixed_n9` is an ensemble this experiment can build, so asking for it under a cap of
+    5 is a legitimate request that simply can't be met. Substituting the nearest available
+    ensemble would put a different one under the detailed tables than the one named on the
+    command line, so this exits and says which sizes are on offer instead.
+    """
+    write_fake_cache(tmp_path, "Q1", ensembles.all_members())
+
+    with pytest.raises(typer.Exit):
+        cli.analyse(
+            concepts="Q1",
+            output_dir=tmp_path,
+            max_members=5,
+            headline_ensemble="mixed_n9",
+        )
+
+    # it fails before any scoring, so nothing half-finished is left behind to be read
+    assert not (tmp_path / "vote_splits.csv").exists()
+
+
+# a deliberately round pair of prices, so every cost below can be checked by hand. The
+# real ones are whatever OpenRouter is charging today, which is not something a test
+# should be pinned to.
+OPUS_PRICES = TokenPrices(prompt=1e-6, completion=1e-5)
+GEMINI_PRICES = TokenPrices(prompt=2e-6, completion=2e-5)
+
+PER_PASSAGE_OPUS = (
+    ESTIMATED_PROMPT_TOKENS_PER_PASSAGE * 1e-6
+    + ESTIMATED_COMPLETION_TOKENS_PER_PASSAGE * 1e-5
+)
+PER_PASSAGE_GEMINI = 2 * PER_PASSAGE_OPUS
+
+
+def ensemble(name: str, *members: tuple[str, int]) -> NamedEnsemble:
+    """A named ensemble from bare (family, seed) pairs."""
+    return NamedEnsemble(name=name, members=tuple(members))
+
+
+@pytest.fixture(autouse=True)
+def offline_pricing(monkeypatch):
+    """
+    Keep the whole module off the network, including the end-to-end `analyse` tests.
+
+    `analyse` fetches OpenRouter's price list the first time it runs against an output
+    directory, and a unit test that reaches the internet is slow, flaky, and quietly
+    dependent on what a model costs today. The tests that are *about* pricing set their
+    own stub, which runs after this one and wins.
+    """
+    monkeypatch.setattr(
+        ensembles,
+        "fetch_model_pricing",
+        lambda: {FAMILY_A: OPUS_PRICES, FAMILY_B: GEMINI_PRICES},
+    )
+
+
+def cost_rows(*concepts: tuple[str, int, int]) -> pd.DataFrame:
+    """
+    Per-concept metric rows at passage and span level, from ``(id, passages, gold spans)``.
+
+    Goes through `metrics_row` so the frame has the shape `headline_table` really reads.
+    Only `support` matters here, and it deliberately differs between the two levels: at
+    passage level it counts passages, at span level it counts gold spans.
+    """
+
+    rows = []
+    for concept, passages, gold_spans in concepts:
+        for level, support in ((PASSAGE_LEVEL, passages), ("span@0", gold_spans)):
+            rows.append(
+                metrics_row(
+                    ConfusionMatrix(
+                        true_positives=1,
+                        false_positives=0,
+                        true_negatives=support - 1,
+                        false_negatives=0,
+                    ),
+                    concept=concept,
+                    ensemble="mixed_n5",
+                    n_members=5,
+                    level=level,
+                )
+            )
+    return pd.DataFrame(rows)
+
+
+def test_whether_an_unknown_cost_renders_as_not_applicable_rather_than_zero():
+    """
+    The fail-soft path, end to end: no price for a family means no number, not $0.00.
+
+    A zero cost and an unknown one are opposite claims about an ensemble, and the whole
+    reason `NOT_APPLICABLE` exists in this module is that a sentinel 0 reads as a measured
+    result.
+    """
+    unpriced = ensemble_cost_per_passage(
+        ensemble("mixed_n3", (FAMILY_A, 1), (FAMILY_A, 2), (FAMILY_B, 1)),
+        {FAMILY_A: OPUS_PRICES},
+    )
+
+    table = headline_table(
+        cost_rows(("Q1", 100, 40)), PASSAGE_LEVEL, "mixed_n5", cost_per_passage=unpriced
+    )
+    rendered = format_for_display(table)
+
+    assert list(rendered[COST_COLUMN]) == [NOT_APPLICABLE, NOT_APPLICABLE]
+
+
+def test_whether_a_failed_price_fetch_leaves_the_analysis_runnable(
+    monkeypatch, tmp_path
+):
+    """
+    `analyse` has to survive being run offline with no cached prices.
+
+    It is the re-runnable, no-LLM-calls half of this experiment; a costing feature that
+    could make it exit is a worse trade than losing the column.
+    """
+
+    def fail():
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(ensembles, "fetch_model_pricing", fail)
+
+    assert load_model_pricing(tmp_path) == {}
+    assert not (tmp_path / OPENROUTER_PRICING_CACHE_FILENAME).exists()

--- a/tests/test_ensemble_aggregation.py
+++ b/tests/test_ensemble_aggregation.py
@@ -1,0 +1,96 @@
+from knowledge_graph.ensemble.aggregation import (
+    MajorityVoteAggregator,
+    UnionAggregator,
+)
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.span import Span
+
+TEXT = "The just transition must protect coal workers and their communities."
+CONCEPT_ID = WikibaseID("Q42")
+
+
+def span(start: int, end: int, labeller: str = "classifier") -> Span:
+    """Build a span over the shared test text."""
+    return Span(
+        text=TEXT,
+        start_index=start,
+        end_index=end,
+        concept_id=CONCEPT_ID,
+        labellers=[labeller],
+    )
+
+
+def offsets(spans: list[Span]) -> list[tuple[int, int]]:
+    """Return the sorted (start, end) offsets of a list of spans."""
+    return sorted((s.start_index, s.end_index) for s in spans)
+
+
+def test_whether_union_of_empty_predictions_is_no_spans():
+    """An ensemble where every classifier predicted nothing aggregates to no spans."""
+    assert UnionAggregator()([[], [], []]) == []
+
+
+def test_whether_union_merges_overlapping_spans():
+    """Overlapping spans from different classifiers become one span covering both."""
+    aggregated = UnionAggregator()([[span(4, 20)], [span(9, 32)]])
+
+    assert offsets(aggregated) == [(4, 32)]
+
+
+def test_whether_union_keeps_disjoint_spans_separate():
+    """Non-overlapping spans are all retained, unmerged."""
+    aggregated = UnionAggregator()([[span(4, 20)], [span(33, 37)]])
+
+    assert offsets(aggregated) == [(4, 20), (33, 37)]
+
+
+def test_whether_union_keeps_a_span_only_one_classifier_found():
+    """The union is permissive: a single classifier's span survives aggregation."""
+    aggregated = UnionAggregator()([[span(4, 20)], [], []])
+
+    assert offsets(aggregated) == [(4, 20)]
+
+
+def test_whether_union_preserves_the_labellers_of_merged_spans():
+    """Merging keeps every contributing classifier's labeller, for traceability."""
+    aggregated = UnionAggregator()([[span(4, 20, "opus")], [span(9, 32, "glm")]])
+
+    assert set(aggregated[0].labellers) == {"opus", "glm"}
+
+
+def test_whether_majority_vote_drops_a_span_a_minority_found():
+    """One classifier out of five isn't enough to call the passage positive."""
+    assert MajorityVoteAggregator()([[span(4, 20)], [], [], [], []]) == []
+
+
+def test_whether_majority_vote_keeps_spans_a_majority_found():
+    """Three of five is a majority, so the union of their spans is returned."""
+    aggregated = MajorityVoteAggregator()(
+        [[span(4, 20)], [span(9, 32)], [span(13, 20)], [], []]
+    )
+
+    assert offsets(aggregated) == [(4, 32)]
+
+
+def test_whether_majority_vote_counts_classifiers_that_found_different_spans():
+    """
+    The vote is on whether each classifier found *anything*, not on where.
+
+    Classifiers flagging different parts of a passage are unanimous about the passage,
+    even though they agree on no single span, so every span is kept.
+    """
+    disjoint = [[span(4, 20)], [span(33, 37)], [span(43, 51)]]
+
+    assert offsets(MajorityVoteAggregator()(disjoint)) == [(4, 20), (33, 37), (43, 51)]
+
+
+def test_whether_majority_vote_returns_nothing_when_no_classifier_found_anything():
+    """A unanimous negative is still a negative."""
+    assert MajorityVoteAggregator()([[], [], []]) == []
+
+
+def test_whether_majority_vote_counts_a_tie_as_positive():
+    """Documented behaviour for even-sized ensembles; odd sizes can't tie."""
+    aggregated = MajorityVoteAggregator()([[span(4, 20)], []])
+
+    assert offsets(aggregated) == [(4, 20)]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,9 @@
+import pytest
+
 from knowledge_graph.identifiers import WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.metrics import (
+    ConfusionMatrix,
     count_passage_level_metrics,
     count_span_level_metrics,
 )
@@ -85,3 +88,26 @@ def test_whether_passage_level_metrics_count_passages_not_spans():
     assert cm.true_positives == 1
     assert cm.false_positives == 1
     assert cm.support() == 2
+
+
+def test_whether_the_negative_class_metrics_mirror_the_positive_ones():
+    """NPV and specificity are precision and recall read off the negative class."""
+    cm = ConfusionMatrix(
+        true_positives=4, false_positives=2, true_negatives=10, false_negatives=4
+    )
+
+    assert cm.negative_predictive_value() == pytest.approx(10 / 14)
+    assert cm.specificity() == pytest.approx(10 / 12)
+
+
+def test_whether_the_negative_class_metrics_survive_an_empty_denominator():
+    """
+    Nothing predicted negative and nothing gold-negative, so neither rate is defined.
+
+    They return 0 rather than raising, matching `precision`/`recall` — callers that need
+    to tell "undefined" from "scored zero" have to check the counts themselves.
+    """
+    cm = ConfusionMatrix(true_positives=3, false_positives=0)
+
+    assert cm.negative_predictive_value() == 0
+    assert cm.specificity() == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,87 @@
+from knowledge_graph.identifiers import WikibaseID
+from knowledge_graph.labelled_passage import LabelledPassage
+from knowledge_graph.metrics import (
+    count_passage_level_metrics,
+    count_span_level_metrics,
+)
+from knowledge_graph.span import Span
+
+TEXT = "Solar power, wind power and coal power are all sources of electricity."
+CONCEPT_ID = WikibaseID("Q42")
+
+
+def span(start: int, end: int) -> Span:
+    """Build a span over the shared test text."""
+    return Span(
+        text=TEXT,
+        start_index=start,
+        end_index=end,
+        concept_id=CONCEPT_ID,
+        labellers=["labeller"],
+    )
+
+
+def passage(spans: list[Span], passage_id: str = "passage-1") -> LabelledPassage:
+    """Build a labelled passage over the shared test text."""
+    return LabelledPassage(id=passage_id, text=TEXT, spans=spans)
+
+
+def test_whether_every_unmatched_gold_span_counts_as_a_false_negative():
+    """Each missed gold span is its own false negative, not one per passage."""
+    gold = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+    predicted = [passage([])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.false_negatives == 3
+    assert cm.true_positives == 0
+
+
+def test_whether_every_unmatched_predicted_span_counts_as_a_false_positive():
+    """Each spurious predicted span is its own false positive."""
+    gold = [passage([])]
+    predicted = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.false_positives == 3
+    assert cm.true_negatives == 0
+
+
+def test_whether_matches_are_still_counted_after_an_earlier_miss():
+    """A missed gold span must not stop the remaining gold spans being scored."""
+    gold = [passage([span(0, 11), span(13, 23), span(28, 38)])]
+    # Matches the second and third gold spans, misses the first
+    predicted = [passage([span(13, 23), span(28, 38)])]
+
+    cm = count_span_level_metrics(gold, predicted, threshold=0)
+
+    assert cm.true_positives == 2
+    assert cm.false_negatives == 1
+    assert cm.false_positives == 0
+
+
+def test_whether_a_passage_with_no_spans_either_side_is_a_true_negative():
+    """Agreement that a passage contains nothing is a true negative."""
+    cm = count_span_level_metrics([passage([])], [passage([])], threshold=0)
+
+    assert cm.true_negatives == 1
+    assert cm.support() == 1
+
+
+def test_whether_passage_level_metrics_count_passages_not_spans():
+    """Passage-level scoring collapses however many spans a passage has into one label."""
+    gold = [
+        passage([span(0, 11), span(13, 23)], passage_id="a"),
+        passage([], passage_id="b"),
+    ]
+    predicted = [
+        passage([span(0, 11)], passage_id="a"),
+        passage([span(0, 11)], passage_id="b"),
+    ]
+
+    cm = count_passage_level_metrics(gold, predicted)
+
+    assert cm.true_positives == 1
+    assert cm.false_positives == 1
+    assert cm.support() == 2

--- a/tests/test_span.py
+++ b/tests/test_span.py
@@ -543,6 +543,59 @@ def test_span_union_with_duplicate_labellers():
     assert merged_span.timestamps[0] == time1
 
 
+def test_span_union_with_unpopulated_timestamps():
+    """`timestamps` is optional, so union must not assume it's aligned with labellers."""
+
+    span_a = Span(
+        text="This is test text",
+        start_index=0,
+        end_index=4,
+        concept_id=WikibaseID("Q123"),
+        labellers=["alice"],
+    )
+
+    span_b = Span(
+        text="This is test text",
+        start_index=2,
+        end_index=6,
+        concept_id=WikibaseID("Q123"),
+        labellers=["bob"],
+    )
+
+    merged_span = Span.union(spans=[span_a, span_b])
+
+    assert merged_span.labellers == ["alice", "bob"]
+    # Timestamps are dropped rather than partially filled, so they stay aligned
+    assert merged_span.timestamps == []
+
+
+def test_span_union_drops_timestamps_when_only_some_are_known():
+    """A half-populated timestamp list can't stay aligned, so it's dropped entirely."""
+    from datetime import datetime, timezone
+
+    span_with_timestamp = Span(
+        text="This is test text",
+        start_index=0,
+        end_index=4,
+        concept_id=WikibaseID("Q123"),
+        labellers=["alice"],
+        timestamps=[datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)],
+    )
+
+    span_without_timestamp = Span(
+        text="This is test text",
+        start_index=2,
+        end_index=6,
+        concept_id=WikibaseID("Q123"),
+        labellers=["bob"],
+    )
+
+    merged_span = Span.union(spans=[span_with_timestamp, span_without_timestamp])
+
+    assert merged_span.labellers == ["alice", "bob"]
+    assert merged_span.timestamps == []
+
+
 def test_span_intersection_preserves_timestamps():
     from datetime import datetime, timezone
 


### PR DESCRIPTION
Code to run experiment – see [Notion](https://app.notion.com/p/climatepolicyradar/RFC-Update-classifier-evaluation-set-labelling-3499109609a480978611c17b1e2bec69?source=copy_link#3b49109609a480c38306c4698a2ab237) for results including screenshots from the CLI.

Also: 

- adds span aggregators for ensembles: `knowledge_graph/ensemble/aggregation.py`
- adds negative predictive value (negative precision) and specificity (negative recall) to `ConfusionMatrix`

Sorry for the large PR, but this is experiment code, so no need to look too closely. Next week's implementation of this will be the one to pay closer attention to as it'll touch the pipelines we use for classifier dev!