### PR TITLE
fix vibechecker inference for recursive negative labels

### DIFF
--- a/flows/vibe_check.py
+++ b/flows/vibe_check.py
@@ -148,7 +148,12 @@ def load_embeddings_metadata(
     return json.load(io.BytesIO(bytes_from_s3))
 
 
-@task(retries=2, retry_delay_seconds=10, cache_policy=NO_CACHE)
+@task(
+    retries=2,
+    retry_delay_seconds=10,
+    cache_policy=NO_CACHE,
+    task_run_name="process_single_concept-{wikibase_id}",
+)
 async def process_single_concept(
     wikibase_id: WikibaseID,
     passages_dataset: pd.DataFrame,

--- a/flows/vibe_check.py
+++ b/flows/vibe_check.py
@@ -50,6 +50,11 @@ from knowledge_graph.wikibase import WikibaseConfig, WikibaseSession
 
 aws_region = os.getenv("AWS_REGION", "eu-west-1")
 
+# Bounds to stop a hanging concept from holding a task runner slot, and the whole flow
+# run, forever. A healthy concept takes minutes at most.
+CONCEPT_TIMEOUT_SECONDS = 30 * 60
+FLOW_TIMEOUT_SECONDS = 6 * 60 * 60
+
 
 class LabelledPassageWithMarkup(LabelledPassage):
     """LabelledPassage wrapper including an extra field for text marked up as HTML."""
@@ -153,6 +158,7 @@ def load_embeddings_metadata(
     retry_delay_seconds=10,
     cache_policy=NO_CACHE,
     task_run_name="process_single_concept-{wikibase_id}",
+    timeout_seconds=CONCEPT_TIMEOUT_SECONDS,
 )
 async def process_single_concept(
     wikibase_id: WikibaseID,
@@ -347,7 +353,7 @@ async def process_single_concept(
 
 
 @flow(  # pyright: ignore[reportCallIssue, reportReturnType]
-    timeout_seconds=None,
+    timeout_seconds=FLOW_TIMEOUT_SECONDS,
     task_runner=ThreadPoolTaskRunner(max_workers=3),  # pyright: ignore[reportArgumentType]
 )
 async def vibe_check_inference(
@@ -419,20 +425,29 @@ async def vibe_check_inference(
             aws_env=config.aws_env,
             track_and_upload=True,
         )
-        concept_futures.append(future)
+        concept_futures.append((wikibase_id, future))
 
     logger.info("Waiting for all concept inference tasks to complete...")
-    wait(concept_futures)
+    wait([future for _, future in concept_futures])
 
     # Track completion and collect results
     collected_results = []
-    for future in concept_futures:
+    for wikibase_id, future in concept_futures:
         try:
             result = future.result()
-            collected_results.append(result)
         except Exception as e:
-            logger.error(f"Unexpected error collecting result: {str(e)}")
-            continue
+            # eg the task timed out. Recorded as a failure rather than dropped, so it
+            # shows up in the summary below
+            logger.error(f"Unexpected error collecting result for {wikibase_id}: {e}")
+            result = {
+                "concept_id": wikibase_id,
+                "status": "failed",
+                "error": str(e),
+                "n_passages": 0,
+                "n_positive_passages": 0,
+                "output_prefix": "",
+            }
+        collected_results.append(result)
 
     # Log summary results
     logger.info("Completed processing all concepts")

--- a/flows/vibe_check.py
+++ b/flows/vibe_check.py
@@ -34,6 +34,7 @@ from sentence_transformers import SentenceTransformer
 
 from flows.config import Config
 from flows.train import _set_up_training_environment, load_wikibase_ids_from_config
+from flows.utils import SlackNotifyKnowledgeGraph
 from knowledge_graph.cloud import (
     AwsEnv,
     get_aws_ssm_param,
@@ -355,6 +356,8 @@ async def process_single_concept(
 @flow(  # pyright: ignore[reportCallIssue, reportReturnType]
     timeout_seconds=FLOW_TIMEOUT_SECONDS,
     task_runner=ThreadPoolTaskRunner(max_workers=3),  # pyright: ignore[reportArgumentType]
+    on_failure=[SlackNotifyKnowledgeGraph.message],
+    on_crashed=[SlackNotifyKnowledgeGraph.message],
 )
 async def vibe_check_inference(
     wikibase_ids: Optional[list[str]] = None,
@@ -478,5 +481,13 @@ async def vibe_check_inference(
     logger.info(
         f"Successfully processed {len(successful_results)}/{len(collected_results)} concepts"
     )
+
+    if failed_results:
+        # Raise so the run is marked as failed and the Slack hooks fire.
+        failed_ids = ", ".join(str(r["concept_id"]) for r in failed_results)
+        raise RuntimeError(
+            f"{len(failed_results)}/{len(collected_results)} concepts failed to "
+            f"process: {failed_ids}"
+        )
 
     return collected_results

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -329,8 +329,15 @@ class WikibaseSession:
         wikibase_id: WikibaseID,
         timestamp: datetime,
         entity_info: dict[str, Any],
+        incorporate_negative_concepts: bool = True,
     ) -> Concept | None:
-        """Async helper to fetch a single concept."""
+        """
+        Async helper to fetch a single concept.
+
+        :param incorporate_negative_concepts: Whether to merge the positive labels of
+            the concept's negative concepts into its negative labels. Set to False when
+            fetching the negative concepts themselves, to stop the fetch recursing.
+        """
         client = await self._get_client()
 
         # Use semaphore to limit concurrent requests
@@ -402,24 +409,29 @@ class WikibaseSession:
                 # Parse concept data
                 concept = self._parse_wikibase_entity(wikibase_id, entity, revision_id)
 
-                concept = await self._incorporate_negative_concepts(concept)
-
                 # Small delay to be gentle on the server
                 await asyncio.sleep(self.REQUEST_DELAY_SECONDS)
 
-                return concept
-
             except (KeyError, json.JSONDecodeError) as e:
                 logger.warning("❌ Failed to parse concept %s: %s", wikibase_id, e)
+                return None
             except (
                 ConceptNotFoundError,
                 RevisionNotFoundError,
                 InvalidConceptError,
             ) as e:
                 logger.warning("❌ %s", str(e))
+                return None
             except ValidationError as e:
                 logger.warning("❌ Failed to validate concept %s: %s", wikibase_id, e)
-            return None
+                return None
+
+        # Negative concepts are fetched after releasing the semaphore, otherwise
+        # one fetch consumes 2/3 semaphore permits at a given time.
+        if incorporate_negative_concepts:
+            concept = await self._incorporate_negative_concepts(concept)
+
+        return concept
 
     def _parse_wikibase_entity(
         self,
@@ -515,9 +527,14 @@ class WikibaseSession:
             return concept
 
         try:
-            # Fetch all negative concepts
+            # Fetch all negative concepts. Their own negative concepts are deliberately
+            # not incorporated: a concept's negative labels are only its negative
+            # concepts' positive labels, and concepts are routinely each other's
+            # negative concepts (eg "tax" and "tax advantage"), so recursing would
+            # never terminate.
             negative_concepts = await self.get_concepts_async(
-                wikibase_ids=concept.negative_concepts
+                wikibase_ids=concept.negative_concepts,
+                incorporate_negative_concepts=False,
             )
 
             # Combine existing negative labels with new negative labels
@@ -559,6 +576,7 @@ class WikibaseSession:
         limit: int | None = None,
         wikibase_ids: list[WikibaseID] | None = None,
         timestamp: datetime | None = None,
+        incorporate_negative_concepts: bool = True,
     ) -> list[Concept]:
         """
         Async method to get concepts from Wikibase with concurrent fetching.
@@ -572,6 +590,8 @@ class WikibaseSession:
             timestamp: If specified, the retrieved concepts will contain the data as it
                 existed at the specified timestamp. Defaults to None, and retrieves the
                 latest version of the concept.
+            incorporate_negative_concepts: Whether to merge each concept's negative
+                concepts' positive labels into its negative labels.
 
         Returns:
             List of Concept objects
@@ -648,7 +668,10 @@ class WikibaseSession:
                     str(wikibase_id), {}
                 ):
                     task = self._fetch_concept_async(
-                        wikibase_id, timestamp, entity_info
+                        wikibase_id,
+                        timestamp,
+                        entity_info,
+                        incorporate_negative_concepts=incorporate_negative_concepts,
                     )
                     tasks.append(task)
                     valid_concepts_in_batch += 1

--- a/tests/flows/test_vibe_check.py
+++ b/tests/flows/test_vibe_check.py
@@ -133,33 +133,28 @@ async def test_vibe_check_inference(vibe_check_externals):
 
 
 @pytest.mark.asyncio
-async def test_vibe_check_returns_failed_status_when_concept_not_found(
+async def test_vibe_check_fails_the_run_when_concept_not_found(
     vibe_check_externals,
 ):
     vibe_check_externals.wikibase_session.get_concept_async = AsyncMock(
         side_effect=ValueError("concept not found")
     )
 
-    results = await vibe_check_inference(wikibase_ids=["Q1"])
+    with pytest.raises(RuntimeError, match="1/1 concepts failed to process: Q1"):
+        await vibe_check_inference(wikibase_ids=["Q1"])
 
-    assert len(results) == 1
-    assert results[0]["status"] == "failed"
-    assert "concept not found" in results[0]["error"]
     # Nothing should be uploaded when the concept can't be loaded.
     assert vibe_check_externals.push_to_s3.call_count == 0
 
 
 @pytest.mark.asyncio
-async def test_vibe_check_returns_failed_status_when_s3_upload_fails(
+async def test_vibe_check_fails_the_run_when_s3_upload_fails(
     vibe_check_externals,
 ):
     vibe_check_externals.push_to_s3.side_effect = RuntimeError("s3 upload failed")
 
-    results = await vibe_check_inference(wikibase_ids=["Q1"])
-
-    assert len(results) == 1
-    assert results[0]["status"] == "failed"
-    assert "s3 upload failed" in results[0]["error"]
+    with pytest.raises(RuntimeError, match="1/1 concepts failed to process: Q1"):
+        await vibe_check_inference(wikibase_ids=["Q1"])
 
 
 @pytest.mark.asyncio
@@ -175,9 +170,8 @@ async def test_vibe_check_isolates_failures_across_multiple_concepts(
         side_effect=_get_concept
     )
 
-    results = await vibe_check_inference(wikibase_ids=["Q1", "Q2"])
+    # The run fails because Q2 failed, but Q1 is still processed and uploaded
+    with pytest.raises(RuntimeError, match="1/2 concepts failed to process: Q2"):
+        await vibe_check_inference(wikibase_ids=["Q1", "Q2"])
 
-    by_id = {r["concept_id"]: r for r in results}
-    assert by_id[WikibaseID("Q1")]["status"] == "success"
-    assert by_id[WikibaseID("Q2")]["status"] == "failed"
-    assert "Q2 not found" in by_id[WikibaseID("Q2")]["error"]
+    assert vibe_check_externals.push_to_s3.call_count == 3

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from unittest.mock import AsyncMock, patch
 
@@ -144,6 +145,48 @@ async def test_get_concepts_async__logs_warning_on_retry(MockedWikibaseSession, 
             await wikibase.get_concepts_async()
 
     assert any("Retrying" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_get_concepts_async__terminates_when_negative_concepts_form_a_cycle(
+    MockedWikibaseSession,
+):
+    """
+    Concepts which list each other as negative concepts must not recurse forever.
+
+    Real example: "tax" (Q715) has "tax advantage" (Q1269) as a negative concept, and
+    "tax advantage" has "tax" as a negative concept.
+    """
+    wikibase = MockedWikibaseSession()
+
+    cyclic_concepts = {
+        WikibaseID("Q10"): Concept(
+            wikibase_id=WikibaseID("Q10"),
+            preferred_label="tax",
+            negative_concepts=[WikibaseID("Q20")],
+        ),
+        WikibaseID("Q20"): Concept(
+            wikibase_id=WikibaseID("Q20"),
+            preferred_label="tax advantage",
+            negative_concepts=[WikibaseID("Q10")],
+        ),
+    }
+
+    with patch.object(
+        type(wikibase),
+        "_parse_wikibase_entity",
+        lambda self, wikibase_id, entity, revision_id: cyclic_concepts[
+            wikibase_id
+        ].model_copy(deep=True),
+    ):
+        concepts = await asyncio.wait_for(
+            wikibase.get_concepts_async(wikibase_ids=[WikibaseID("Q10")]),
+            timeout=30,
+        )
+
+    assert [concept.wikibase_id for concept in concepts] == [WikibaseID("Q10")]
+    # The negative concept's positive labels are still merged in, one level deep
+    assert concepts[0].negative_labels == ["tax advantage"]
 
 
 def test_get_concept_ids_with_property__invalid_property_raises(MockedWikibaseSession):


### PR DESCRIPTION
Vibe checker inference was stuck in an infinite loop ([see example flow](https://app.prefect.cloud/account/4b1558a0-3c61-4849-8b18-3e97e0516d78/workspace/1753b4f0-6221-4f6a-9233-b146518b4545/runs/flow-run/06a744df-474c-7860-8000-b3eeb2caca3f?preview=true&tab=logs&selected_id=019fea7b-7173-78ad-8915-c97f85a4ed85&selected_kind=task-run)), because recursive negative labels had been added (6th August). 

This PR fixes that by **not fetching the negative labels of a negative label** – otherwise we the process continues forever!

Also:

- adds a timeout and slack alert on failure of any concept's inference to the Prefect flow (to help us catch issues like this before the programmes team in future)
- gives the subtasks of the flow names that incorporate their `wikibase_id` for easier debugging