### PR TITLE
reads all alias language buckets from wikibase

### DIFF
--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -39,10 +39,7 @@ MAX_RETRIES = 5
 RETRY_INITIAL_WAIT = 1.0
 RETRY_MAX_WAIT = 60.0
 
-# Wikibase stores labels and aliases in buckets keyed by language tag. Concepts carry
-# their English variants across several of these, eg British spellings like "licence"
-# are tagged "en-gb", so we read all of them into the concept's alternative labels.
-# "mul" is Wikibase's tag for values which apply across languages.
+# Aliases are bucketed by language tag, eg "licence" sits under "en-gb" not "en".
 ALIAS_LANGUAGES: Final[tuple[str, ...]] = ("en", "en-gb", "en-us", "mul")
 
 

--- a/knowledge_graph/wikibase.py
+++ b/knowledge_graph/wikibase.py
@@ -39,6 +39,12 @@ MAX_RETRIES = 5
 RETRY_INITIAL_WAIT = 1.0
 RETRY_MAX_WAIT = 60.0
 
+# Wikibase stores labels and aliases in buckets keyed by language tag. Concepts carry
+# their English variants across several of these, eg British spellings like "licence"
+# are tagged "en-gb", so we read all of them into the concept's alternative labels.
+# "mul" is Wikibase's tag for values which apply across languages.
+ALIAS_LANGUAGES: Final[tuple[str, ...]] = ("en", "en-gb", "en-us", "mul")
+
 
 class WikibaseAuth(BaseModel):
     """For creating a WikibaseSession."""
@@ -449,11 +455,13 @@ class WikibaseSession:
             )
 
         alternative_labels = []
-        if isinstance(entity.get("aliases"), dict):
+        aliases = entity.get("aliases")
+        if isinstance(aliases, dict):
             alternative_labels = [
-                alias.get("value")
-                for alias in entity.get("aliases", {}).get("en", [])
-                if alias.get("language") == "en"
+                alias["value"]
+                for language in ALIAS_LANGUAGES
+                for alias in aliases.get(language) or []
+                if alias.get("value")
             ]
 
         description = (

--- a/tests/test_wikibase.py
+++ b/tests/test_wikibase.py
@@ -260,6 +260,70 @@ def test_wikibase__create_concept__minimal(MockedWikibaseSession):
     assert isinstance(new_id, WikibaseID)
 
 
+def _entity_with_aliases(aliases: dict[str, list[str]]) -> dict:
+    """Build a minimal Wikibase entity whose aliases span the given language tags."""
+    return {
+        "labels": {"en": {"language": "en", "value": "license"}},
+        "aliases": {
+            language: [{"language": language, "value": value} for value in values]
+            for language, values in aliases.items()
+        },
+    }
+
+
+def test_wikibase__parse_entity_reads_all_english_alias_languages(
+    MockedWikibaseSession,
+):
+    """British spellings are tagged en-gb in Wikibase, so they must be read too."""
+    wikibase = MockedWikibaseSession()
+
+    concept = wikibase._parse_wikibase_entity(
+        WikibaseID("Q1432"),
+        _entity_with_aliases(
+            {
+                "en": ["licenses", "licensing"],
+                "en-gb": ["licence", "licencing"],
+                "en-us": ["license fee"],
+                "mul": ["CO2"],
+            }
+        ),
+    )
+
+    assert concept.preferred_label == "license"
+    assert set(concept.alternative_labels) == {
+        "licenses",
+        "licensing",
+        "licence",
+        "licencing",
+        "license fee",
+        "CO2",
+    }
+
+
+def test_wikibase__parse_entity_ignores_non_english_alias_languages(
+    MockedWikibaseSession,
+):
+    wikibase = MockedWikibaseSession()
+
+    concept = wikibase._parse_wikibase_entity(
+        WikibaseID("Q1432"),
+        _entity_with_aliases({"en": ["licenses"], "fr": ["licence d'exploitation"]}),
+    )
+
+    assert concept.alternative_labels == ["licenses"]
+
+
+def test_wikibase__parse_entity_without_aliases(MockedWikibaseSession):
+    wikibase = MockedWikibaseSession()
+
+    concept = wikibase._parse_wikibase_entity(
+        WikibaseID("Q1432"),
+        {"labels": {"en": {"language": "en", "value": "license"}}},
+    )
+
+    assert concept.alternative_labels == []
+
+
 def test_wikibase__add_claim(MockedWikibaseSession):
     wikibase = MockedWikibaseSession()
     # Should not raise


### PR DESCRIPTION
## Description

`_parse_wikibase_entity` hardcoded the `en` alias bucket, so any alias tagged with another language tag was silently dropped before reaching the `Concept`.

Wikibase keeps aliases in buckets keyed by language tag. British spellings have been added under `en-gb` - [Q1432 `license`](https://climatepolicyradar.wikibase.cloud/wiki/Item:Q1432) has `licence` and `licencing` there - so none of them were matchable.

Fixes [FUS-252](https://linear.app/climate-policy-radar/issue/FUS-252).

```python
# before
for alias in entity.get("aliases", {}).get("en", [])
if alias.get("language") == "en"

# after
for language in ALIAS_LANGUAGES          # ("en", "en-gb", "en-us", "mul")
for alias in aliases.get(language) or []
```

Preferred label and description deliberately stay `en`-only, so a regional variant can't override the canonical preferred label.

## Impact

28 concepts gain 92 labels in total — `labour`/`labourer`, `neighbourhood`, `marginalised`, `programme`, `centre`, `fertiliser`, plus `licence`/`licencing` on Q1432.

**None of the 28 are currently in `v2/production.yaml`**, so no deployed classifier changes and there's no re-inference cost from merging. They'll pick the new labels up whenever they're next trained. Classifier IDs do change (they're derived from labels), so the affected concepts will need retraining and a spec refresh at that point.

## Testing

- three new tests in `tests/test_wikibase.py`: all English buckets read, non-English (`fr`) still ignored, entity with no aliases
- `pytest tests/test_wikibase.py tests/test_concept.py tests/test_classifier.py tests/operations`  → 170 passed, 1 skipped
- verified against live Q1432: `"an environmental licence was granted"` returns a span where it previously returned `[]`
