### PR TITLE
Feature/enri 1639 migrate topics pipeline off parseroutput to the simplified

### DIFF
--- a/flows/inference.py
+++ b/flows/inference.py
@@ -11,7 +11,6 @@ from typing import Any, Final, Literal, NamedTuple, Optional, TypeAlias, cast, o
 import wandb
 from aiobotocore.config import AioConfig
 from botocore.exceptions import ClientError
-from cpr_sdk.parser_models import BaseParserOutput, BaseParserOutputV2, BlockType
 from mypy_boto3_s3.type_defs import (
     PutObjectOutputTypeDef,
 )
@@ -40,6 +39,7 @@ from flows.classifier_specs.spec_interface import (
     should_skip_doc,
 )
 from flows.config import Config, validate_s3_prefix
+from flows.models import BaseParserOutput, BaseParserOutputV2, BlockType
 from flows.utils import (
     DocumentImportId,
     DocumentStem,

--- a/flows/models.py
+++ b/flows/models.py
@@ -1,0 +1,314 @@
+from datetime import date
+from enum import Enum
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+from pydantic import BaseModel, Field
+
+
+class VerticalFlipError(Exception):
+    """Exception for when a vertical flip fails."""
+
+    pass
+
+
+class BlockType(str, Enum):
+    """
+    List of possible block types from the PubLayNet model.
+
+    https://layout-parser.readthedocs.io/en/latest/notes/modelzoo.html#model-label-map
+    """
+
+    TEXT = "Text"
+    TITLE = "Title"
+    LIST = "List"
+    TABLE = "Table"
+    TABLE_CELL = "TableCell"
+    FIGURE = "Figure"
+    INFERRED = "Inferred from gaps"
+    AMBIGUOUS = "Ambiguous"
+    GOOGLE_BLOCK = "Google Text Block"
+    PAGE_HEADER = "pageHeader"
+    PAGE_FOOTER = "pageFooter"
+    TITLE_LOWER_CASE = "title"
+    SECTION_HEADING = "sectionHeading"
+    PAGE_NUMBER = "pageNumber"
+    DOCUMENT_HEADER = "Document Header"
+    FOOT_NOTE = "footnote"
+
+
+class _TextBlockProto(Protocol):
+    """
+    Protocol capturing the shared interface of text block types.
+
+    All text blocks (TextBlock, TextBlockV2, HTMLTextBlock) share these
+    attributes/methods from _TextBlockMixin.
+    """
+
+    language: Optional[str]
+
+    def to_string(self) -> str: ...
+
+    def model_dump_json(
+        self, *, exclude: Union[set[str], dict[str, Any], None] = None
+    ) -> str: ...
+
+
+class _TextBlockMixin:
+    """
+    Shared fields for TextBlock* classes.
+
+    Must be used with a class that inherits from Pydantic's BaseModel.
+    """
+
+    language: Optional[str] = (
+        None  # TODO: validate this against a list of language ISO codes
+    )
+    type: BlockType
+    type_confidence: float = Field(ge=0, le=1)
+
+
+class TextBlock(_TextBlockMixin, BaseModel):
+    """
+    text block with text as a list (v1).
+
+    :attribute text: list of text lines contained in the text block
+    """
+
+    text_block_id: str
+    text: List[str]
+
+    def to_string(self) -> str:
+        """Returns lines in a text block separated by spaces as a string."""
+
+        return " ".join([line.strip() for line in self.text])
+
+
+class TextBlockV2(_TextBlockMixin, BaseModel):
+    """
+    text block with text as singular (v2).
+
+    :attribute text: text lines in the text block
+    """
+
+    text: str
+
+    def to_string(self) -> str:
+        """
+        Returns lines in a text block separated by spaces as a string.
+
+        For backwards compatibility with v1.
+        """
+
+        return self.text
+
+
+class HTMLTextBlock(TextBlock):
+    """
+    Text block parsed from an HTML document.
+
+    Type is set to "Text" with a confidence of 1.0 by default, as we do not predict
+    types for text blocks parsed from HTML.
+    """
+
+
+class PDFTextBlock(TextBlock):
+    """
+    Text block parsed from a PDF document.
+
+    Stores the text and positional information for a single text block extracted from
+    a document.
+
+    :attribute coords: list of coordinates of the vertices defining the boundary of
+    the text block. Each coordinate is a tuple in the format (x, y). (0, 0) is at the
+    top left corner of the page, and the positive x- and y- directions are right and
+    down. :attribute page_number: page number of the page containing the text block.
+    """
+
+    coords: List[Tuple[float, float]]
+    page_number: int = Field(ge=0)
+
+    def to_string(self) -> str:
+        """Returns lines in a text block separated by spaces as a string."""
+
+        return " ".join([line.strip() for line in self.text])
+
+
+class Page(BaseModel):
+    """Bounding boxes for a specific page."""
+
+    class BoundingBox(BaseModel):
+        """A bounding box defined by a specific number coordinate points."""
+
+        class Coordinate(BaseModel):
+            """A single (x, y) coordinate point."""
+
+            x: Annotated[float, Field(ge=0, description="X dimension of point.")]
+            y: Annotated[float, Field(ge=0, description="Y dimension of point.")]
+
+        coordinates: Annotated[
+            list[Coordinate],
+            Field(
+                min_length=4,
+                max_length=4,
+                description="A restricted number of coordinates to represent the bounding box.",
+            ),
+        ]
+
+    number: Annotated[
+        int,
+        Field(ge=0, description="Page number this entry corresponds to."),
+    ]
+
+    bounding_boxes: Annotated[
+        list[BoundingBox],
+        Field(
+            min_length=1,
+            description="List of bounding boxes on this page.",
+        ),
+    ]
+
+
+class PDFTextBlockV2(TextBlockV2):
+    """V2 text block parsed from a PDF document with str text."""
+
+    id: Annotated[
+        str,
+        Field(description="Global ID. Replaces `text_block_id`."),
+    ]
+
+    idx: Annotated[
+        int,
+        Field(
+            strict=True,
+            ge=0,
+            description="Index of this text block within the range of all text blocks on the parent document",
+        ),
+    ]
+
+    pages: Annotated[
+        list[Page],
+        Field(
+            min_length=1,
+            description="Page(s) within the document that this text block is found on.",
+        ),
+    ]
+
+    heading_id: Optional[str] = None
+    tokens: Optional[list[str]] = None
+    serialised_text: Optional[str] = None
+
+    def to_string(self) -> str:
+        """
+        Returns the text content as a string.
+
+        For backwards compatibility with v1.
+        """
+        return self.text
+
+
+class HTMLData(BaseModel):
+    """Set of metadata specific to HTML documents."""
+
+    detected_title: Optional[str] = None
+    detected_date: Optional[date] = None
+    has_valid_text: bool
+    text_blocks: Sequence[HTMLTextBlock]
+
+
+class PDFPageMetadata(BaseModel):
+    """
+    Set of metadata for a single page of a PDF document.
+
+    :attribute dimensions: (width, height) of the page in pixels
+    """
+
+    page_number: int = Field(ge=0)
+    dimensions: Tuple[float, float]
+
+
+class PDFData(BaseModel):
+    """
+    Set of metadata unique to PDF documents.
+
+    :attribute pages: List of pages contained in the document :attribute filename:
+    Name of the PDF file, without extension :attribute md5sum: md5sum of PDF content
+    :attribute language: list of 2-letter ISO language codes, optional. If null,
+    the OCR processor didn't support language detection
+    """
+
+    page_metadata: Sequence[PDFPageMetadata]
+    md5sum: str
+    text_blocks: Sequence[PDFTextBlock]
+
+
+class PDFDataV2(BaseModel):
+    """
+    Set of metadata unique to PDF documents.
+
+    :attribute pages: List of pages contained in the document :attribute filename:
+    Name of the PDF file, without extension :attribute md5sum: md5sum of PDF content
+    :attribute language: list of 2-letter ISO language codes, optional. If null,
+    the OCR processor didn't support language detection
+    """
+
+    page_metadata: Sequence[PDFPageMetadata]
+    md5sum: str
+    text_blocks: Sequence[PDFTextBlockV2]
+
+
+PDFDataT = TypeVar("PDFDataT", PDFData, PDFDataV2)
+PDFTextBlockT = TypeVar("PDFTextBlockT", PDFTextBlock, PDFTextBlockV2)
+
+
+class _BaseParserOutputFieldsMixin(BaseModel, Generic[PDFDataT, PDFTextBlockT]):
+    """Shared fields and methods for BaseParserOutput* classes."""
+
+    document_id: str
+    document_content_type: Optional[str] = None
+    languages: Optional[Sequence[str]] = None
+    html_data: Optional[HTMLData] = None
+    pdf_data: Optional[PDFDataT] = None
+
+    @property
+    def text_blocks(self) -> Sequence[_TextBlockProto]:
+        """
+        Return the text blocks in the document.
+
+        These could differ in format depending on the content type.
+        """
+
+        if self.html_data is not None:
+            return self.html_data.text_blocks
+        elif self.pdf_data is not None:
+            return self.pdf_data.text_blocks
+        return []
+
+    def get_text_blocks(self) -> Sequence[_TextBlockProto]:
+        """A method for getting text blocks."""
+        return self.text_blocks
+
+    def to_string(self) -> str:
+        """Return the text blocks in the parser output as a string"""
+
+        return " ".join(
+            [text_block.to_string().strip() for text_block in self.text_blocks]
+        )
+
+
+class BaseParserOutput(_BaseParserOutputFieldsMixin[PDFData, PDFTextBlock]):
+    """Base class for an output to a parser (v1)."""
+
+
+class BaseParserOutputV2(_BaseParserOutputFieldsMixin[PDFDataV2, PDFTextBlockV2]):
+    """Base class for an output from a parser (v2)."""

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -12,14 +12,6 @@ import boto3
 import pytest
 import pytest_asyncio
 from botocore.config import Config as BotoCoreConfig
-from cpr_sdk.parser_models import (
-    BaseParserOutput,
-    BlockType,
-    HTMLData,
-    HTMLTextBlock,
-    PDFData,
-    PDFTextBlock,
-)
 from moto import mock_aws
 from prefect import Flow, State
 from prefect.client.schemas import StateType
@@ -31,6 +23,14 @@ from types_aiobotocore_s3.client import S3Client
 
 from flows.config import Config
 from flows.inference import S3_BLOCK_RESULTS_CACHE
+from flows.models import (
+    BaseParserOutput,
+    BlockType,
+    HTMLData,
+    HTMLTextBlock,
+    PDFData,
+    PDFTextBlock,
+)
 from flows.utils import DocumentStem
 from flows.wikibase_to_s3 import Config as WikibaseToS3Config
 from knowledge_graph.cloud import AwsEnv
@@ -297,10 +297,6 @@ def local_classifier_id(mock_classifiers_dir):
 def parser_output() -> Generator[BaseParserOutput, None, None]:
     yield BaseParserOutput(
         document_id="test id",
-        document_metadata={},
-        document_name="test name",
-        document_slug="test slug",
-        document_description="test description",
     )
 
 

--- a/tests/flows/fixtures/CPR.document.0.1.json
+++ b/tests/flows/fixtures/CPR.document.0.1.json
@@ -1,12 +1,6 @@
 {
     "document_id": "CPR.document.0.1",
-    "document_name": "",
-    "document_description": "",
-    "document_slug": "",
     "document_content_type": "text/html",
-    "document_metadata": {
-        "import_id": "CPR.document.0.1"
-    },
     "pdf_data": null,
     "html_data": {
         "has_valid_text": true,
@@ -16,7 +10,7 @@
                     "Ministry of Environment and Natural Resources"
                 ],
                 "text_block_id": "p_0_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -24,7 +18,7 @@
                     "Kenya National Adaptation Plan\n2015-2030"
                 ],
                 "text_block_id": "p_0_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -32,7 +26,7 @@
                     "Prof Judi Wakhungu, Cabinet Secretary, Ministry of Environment and\nNatural Resources"
                 ],
                 "text_block_id": "p_4_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -40,7 +34,7 @@
                     "Climate change has adverse impacts on our country's economic\ndevelopment and threatens the realisation of our Vision 2030\ngoals of creating a competitive and prosperous nation with a\nhigh quality of life. Kenya's economy is highly dependent on\nnatural resources, meaning that recurring droughts, erratic\nrainfall patterns and floods will continue to negatively impact\nlivelihoods and community assets."
                 ],
                 "text_block_id": "p_4_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -48,7 +42,7 @@
                     "The Government of Kenya recognizes the threats posed by climate\nchange and has taken action to address them. In this regard, my\nministry coordinated the development of the National Climate\nChange Response Strategy in 2010, and the National Climate\nChange Action Plan (NCCAP 2013-2017) in 2012. This National Adaptation Plan (NAP) marks yet\nanother landmark in efforts to address the country's vulnerability and resilience to climate change."
                 ],
                 "text_block_id": "p_4_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -56,7 +50,7 @@
                     "The NAP was developed through a cooperative and consultative process that included stakeholders\nfrom the Government, the private sector, and the civil society; with the support of international\ndevelopment agencies. All of these partners continue to support the implementation of the NAP\nthrough the design, financing and implementation of priority actions. Effective implementation of\nthe NAP will be supported through the establishment of enabling governance structures, including\nthose set out in the Climate Change Act, that was enacted into law by His Excellency, the President\nin May 2016. Additional support and increased partnerships will be required for Kenya to achieve\nits adaptation goals."
                 ],
                 "text_block_id": "p_4_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -64,7 +58,7 @@
                     "The Government of Kenya is fully committed to addressing climate change domestically, as well as\ndemonstrating leadership in the global fight against climate change. Kenya submitted an ambitious\nIntended Nationally Determined Contribution (INDC) to the United Nations Framework Convention\non Climate Change (UNFCCC). INDCs are anchored in the Paris Agreement as five-year Nationally\nDetermined Contribution (NDC) iterative cycles. It is informative that the Paris Agreement, indeed,\nrecognises the role of NDCS and NAPs as the vehicles for delivering on mitigation and adaptation\nobligations, respectively, under the Agreement. Our INDC reiterates that adaptation is Kenya's priority\nresponse to climate change, and this NAP is the foundation of Kenya's contribution on adaptation."
                 ],
                 "text_block_id": "p_4_b_4",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -72,7 +66,7 @@
                     "This NAP demonstrates Kenya's commitment to the Paris Agreement, and will help bring to life our\ncritical responses to the impacts of climate change. Building climate resilience in as low carbon a\nmanner as possible will ensure that Kenya contributes to the goals of the Paris Agreement and the\nSustainable Development Goals."
                 ],
                 "text_block_id": "p_5_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -80,7 +74,7 @@
                     "Ministry of Environment and Natural Resources"
                 ],
                 "text_block_id": "p_5_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -88,7 +82,7 @@
                     "Charles Sunkuli, Principal Secretary - State Department of Environment"
                 ],
                 "text_block_id": "p_6_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -96,7 +90,7 @@
                     "This National Adaptation Plan (NAP 2015-2030) is a critical response\nto the climate change challenge facing our country. The NAP is\nKenya's first plan on adaptation, and demonstrates our commitment\nto operationalise the National Climate Change Action Plan by\nmainstreaming adaptation across all sectors in the national planning,\nbudgeting and implementation processes. Our mainstreaming\napproach recognizes that climate change is a cross-cutting sustainable\ndevelopment issue with economic, social and environmental impacts.\nThe NAP was validated at a national workshop held in Nairobi on 18\nNovember 2015."
                 ],
                 "text_block_id": "p_6_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -104,7 +98,7 @@
                     "The NAP sets out Kenya's national circumstances, focusing on current and future climate trends,\nand describes the country's vulnerability to climate change. The NAP also elaborates institutional\narrangements, including monitoring and evaluation processes. Priority actions are identified in 20\nplanning sectors for the short, medium and long term. This builds on the premise that all our socio-\neconomic sectors are vulnerable to climate change impacts, although the manifestation of these\nimpacts may vary from one sector to the other."
                 ],
                 "text_block_id": "p_6_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -112,7 +106,7 @@
                     "The NAP was prepared through an extensive consultation process. The consultations cut across\nstakeholders from within the Government, and non-state-actors like civil society, academia and the\nprivate sector, at both national and county levels. The process was coordinated by personnel from the\nNational Climate Change Secretariat, whom I would like to recognise for their professionalism and\ndiligence throughout the process. The technical inputs of the Adaptation Thematic Working Group\n(TWG), whose membership was inclusive and drawn from Government, civil society, academia and\nthe private sector institutions, enriched the process. The contribution of the TWG members, both\nindividually and corporately, is greatly appreciated. The Ministry is also grateful to the national and\ninternational adaptation experts who provided valuable technical guidance to the process."
                 ],
                 "text_block_id": "p_6_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -120,7 +114,7 @@
                     "The NAP was finalised with the support of the Technical Assistance component of the Strengthening\nAdaptation and Resilience to Climate Change Plus (STARCK+) programme, which is funded by the\nUnited Kingdom's Department for International Development (DFID). I would, consequently, like\nto thank DFID for this support."
                 ],
                 "text_block_id": "p_6_b_4",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -128,7 +122,7 @@
                     "The NAP will be distributed widely to national and county government institutions, and amongst\nnon-state actors, to guide their expected implementation roles. It is expected that development\npartners will find the information helpful in aligning their funding preferences with Kenya's aspirations\nto attain a low carbon climate resilient economy by addressing climate change adaptation and\nmitigation on equal footing."
                 ],
                 "text_block_id": "p_7_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -136,7 +130,7 @@
                     "The Government is committed to the implementation and continuous revision of the National\nAdaptation Plan and its integration in the national development agenda, not only for the attainment\nof Vision 2030, but also for the realisation of the goals of the Paris Agreement and the UN Sustainable\nDevelopment Goals."
                 ],
                 "text_block_id": "p_7_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -144,7 +138,7 @@
                     "Principal Secretary - State Department of Environment, Ministry of Environment\nand Natural Resources"
                 ],
                 "text_block_id": "p_7_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -152,7 +146,7 @@
                     "National Adaptation Plan Thematic\nWorking Group"
                 ],
                 "text_block_id": "p_8_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -160,7 +154,7 @@
                     "Victor Orindi (Chair)"
                 ],
                 "text_block_id": "p_8_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -168,7 +162,7 @@
                     "Ministry of Agriculture Livestock and Fisheries"
                 ],
                 "text_block_id": "p_8_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             }
         ]

--- a/tests/flows/fixtures/GEF.document.0.1.json
+++ b/tests/flows/fixtures/GEF.document.0.1.json
@@ -1,13 +1,9 @@
 {
     "document_id": "GEF.document.0.1",
-    "document_name": "",
-    "document_description": "",
-    "document_slug": "",
     "document_content_type": "application/pdf",
-    "document_metadata": {
-        "import_id": "GEF.document.0.1"
-    },
-    "languages": ["en"],
+    "languages": [
+        "en"
+    ],
     "html_data": null,
     "pdf_data": {
         "page_metadata": [],

--- a/tests/flows/fixtures/Sabin.document.16944.17490.json
+++ b/tests/flows/fixtures/Sabin.document.16944.17490.json
@@ -1,12 +1,6 @@
 {
     "document_id": "HTML.document.0.1",
-    "document_name": "",
-    "document_description": "",
-    "document_slug": "",
     "document_content_type": "text/html",
-    "document_metadata": {
-        "import_id": "HTML.document.0.1"
-    },
     "pdf_data": null,
     "html_data": {
         "has_valid_text": true,
@@ -16,7 +10,7 @@
                     "Ministry of Environment and Natural Resources"
                 ],
                 "text_block_id": "p_0_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -24,7 +18,7 @@
                     "Kenya National Adaptation Plan\n2015-2030"
                 ],
                 "text_block_id": "p_0_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -32,7 +26,7 @@
                     "Prof Judi Wakhungu, Cabinet Secretary, Ministry of Environment and\nNatural Resources"
                 ],
                 "text_block_id": "p_4_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -40,7 +34,7 @@
                     "Climate change has adverse impacts on our country's economic\ndevelopment and threatens the realisation of our Vision 2030\ngoals of creating a competitive and prosperous nation with a\nhigh quality of life. Kenya's economy is highly dependent on\nnatural resources, meaning that recurring droughts, erratic\nrainfall patterns and floods will continue to negatively impact\nlivelihoods and community assets."
                 ],
                 "text_block_id": "p_4_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -48,7 +42,7 @@
                     "The Government of Kenya recognizes the threats posed by climate\nchange and has taken action to address them. In this regard, my\nministry coordinated the development of the National Climate\nChange Response Strategy in 2010, and the National Climate\nChange Action Plan (NCCAP 2013-2017) in 2012. This National Adaptation Plan (NAP) marks yet\nanother landmark in efforts to address the country's vulnerability and resilience to climate change."
                 ],
                 "text_block_id": "p_4_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -56,7 +50,7 @@
                     "The NAP was developed through a cooperative and consultative process that included stakeholders\nfrom the Government, the private sector, and the civil society; with the support of international\ndevelopment agencies. All of these partners continue to support the implementation of the NAP\nthrough the design, financing and implementation of priority actions. Effective implementation of\nthe NAP will be supported through the establishment of enabling governance structures, including\nthose set out in the Climate Change Act, that was enacted into law by His Excellency, the President\nin May 2016. Additional support and increased partnerships will be required for Kenya to achieve\nits adaptation goals."
                 ],
                 "text_block_id": "p_4_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -64,7 +58,7 @@
                     "The Government of Kenya is fully committed to addressing climate change domestically, as well as\ndemonstrating leadership in the global fight against climate change. Kenya submitted an ambitious\nIntended Nationally Determined Contribution (INDC) to the United Nations Framework Convention\non Climate Change (UNFCCC). INDCs are anchored in the Paris Agreement as five-year Nationally\nDetermined Contribution (NDC) iterative cycles. It is informative that the Paris Agreement, indeed,\nrecognises the role of NDCS and NAPs as the vehicles for delivering on mitigation and adaptation\nobligations, respectively, under the Agreement. Our INDC reiterates that adaptation is Kenya's priority\nresponse to climate change, and this NAP is the foundation of Kenya's contribution on adaptation."
                 ],
                 "text_block_id": "p_4_b_4",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -72,7 +66,7 @@
                     "This NAP demonstrates Kenya's commitment to the Paris Agreement, and will help bring to life our\ncritical responses to the impacts of climate change. Building climate resilience in as low carbon a\nmanner as possible will ensure that Kenya contributes to the goals of the Paris Agreement and the\nSustainable Development Goals."
                 ],
                 "text_block_id": "p_5_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -80,7 +74,7 @@
                     "Ministry of Environment and Natural Resources"
                 ],
                 "text_block_id": "p_5_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -88,7 +82,7 @@
                     "Charles Sunkuli, Principal Secretary - State Department of Environment"
                 ],
                 "text_block_id": "p_6_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -96,7 +90,7 @@
                     "This National Adaptation Plan (NAP 2015-2030) is a critical response\nto the climate change challenge facing our country. The NAP is\nKenya's first plan on adaptation, and demonstrates our commitment\nto operationalise the National Climate Change Action Plan by\nmainstreaming adaptation across all sectors in the national planning,\nbudgeting and implementation processes. Our mainstreaming\napproach recognizes that climate change is a cross-cutting sustainable\ndevelopment issue with economic, social and environmental impacts.\nThe NAP was validated at a national workshop held in Nairobi on 18\nNovember 2015."
                 ],
                 "text_block_id": "p_6_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -104,7 +98,7 @@
                     "The NAP sets out Kenya's national circumstances, focusing on current and future climate trends,\nand describes the country's vulnerability to climate change. The NAP also elaborates institutional\narrangements, including monitoring and evaluation processes. Priority actions are identified in 20\nplanning sectors for the short, medium and long term. This builds on the premise that all our socio-\neconomic sectors are vulnerable to climate change impacts, although the manifestation of these\nimpacts may vary from one sector to the other."
                 ],
                 "text_block_id": "p_6_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -112,7 +106,7 @@
                     "The NAP was prepared through an extensive consultation process. The consultations cut across\nstakeholders from within the Government, and non-state-actors like civil society, academia and the\nprivate sector, at both national and county levels. The process was coordinated by personnel from the\nNational Climate Change Secretariat, whom I would like to recognise for their professionalism and\ndiligence throughout the process. The technical inputs of the Adaptation Thematic Working Group\n(TWG), whose membership was inclusive and drawn from Government, civil society, academia and\nthe private sector institutions, enriched the process. The contribution of the TWG members, both\nindividually and corporately, is greatly appreciated. The Ministry is also grateful to the national and\ninternational adaptation experts who provided valuable technical guidance to the process."
                 ],
                 "text_block_id": "p_6_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -120,7 +114,7 @@
                     "The NAP was finalised with the support of the Technical Assistance component of the Strengthening\nAdaptation and Resilience to Climate Change Plus (STARCK+) programme, which is funded by the\nUnited Kingdom's Department for International Development (DFID). I would, consequently, like\nto thank DFID for this support."
                 ],
                 "text_block_id": "p_6_b_4",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -128,7 +122,7 @@
                     "The NAP will be distributed widely to national and county government institutions, and amongst\nnon-state actors, to guide their expected implementation roles. It is expected that development\npartners will find the information helpful in aligning their funding preferences with Kenya's aspirations\nto attain a low carbon climate resilient economy by addressing climate change adaptation and\nmitigation on equal footing."
                 ],
                 "text_block_id": "p_7_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -136,7 +130,7 @@
                     "The Government is committed to the implementation and continuous revision of the National\nAdaptation Plan and its integration in the national development agenda, not only for the attainment\nof Vision 2030, but also for the realisation of the goals of the Paris Agreement and the UN Sustainable\nDevelopment Goals."
                 ],
                 "text_block_id": "p_7_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -144,7 +138,7 @@
                     "Principal Secretary - State Department of Environment, Ministry of Environment\nand Natural Resources"
                 ],
                 "text_block_id": "p_7_b_3",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -152,7 +146,7 @@
                     "National Adaptation Plan Thematic\nWorking Group"
                 ],
                 "text_block_id": "p_8_b_0",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -160,7 +154,7 @@
                     "Victor Orindi (Chair)"
                 ],
                 "text_block_id": "p_8_b_1",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             },
             {
@@ -168,7 +162,7 @@
                     "Ministry of Agriculture Livestock and Fisheries"
                 ],
                 "text_block_id": "p_8_b_2",
-                "type" :"Text",
+                "type": "Text",
                 "type_confidence": 0.5
             }
         ]

--- a/tests/flows/fixtures/embeddings_input_v2/AF.chunked.1.1.json
+++ b/tests/flows/fixtures/embeddings_input_v2/AF.chunked.1.1.json
@@ -1,44 +1,9 @@
 {
   "document_id": "AF.chunked.1.1",
-  "document_metadata": {
-    "name": "Building Resilience",
-    "document_title": "Project document",
-    "description": "...",
-    "import_id": "AF.chunked.1.1",
-    "slug": "project-document_1",
-    "family_import_id": "AF.family.1.1",
-    "family_slug": "chunked-document-sample_0da5",
-    "publication_ts": "2026-01-12T00:00:00Z",
-    "date": null,
-    "source_url": "https://climatepolicyradar.org/test.pdf",
-    "download_url": null,
-    "corpus_import_id": "MCF.corpus.AF.n0000",
-    "corpus_type_name": "AF",
-    "collection_title": null,
-    "collection_summary": null,
-    "type": "",
-    "source": "AF",
-    "category": "MCF",
-    "geography": "ZAF",
-    "geographies": [
-      "ZAF"
-    ],
-    "languages": [
-      "English"
-    ],
-    "metadata": {}
-  },
-  "document_name": "Building Resilience",
-  "document_description": "...",
-  "document_source_url": "https://climatepolicyradar.org/test.pdf",
-  "document_cdn_object": "SOME/1990/pdf-object",
   "document_content_type": "application/pdf",
-  "document_md5_sum": "dad18bb27a04a750bde7b9be28de069a",
-  "document_slug": "project-document_1",
   "languages": [
     "en"
   ],
-  "translated": false,
   "html_data": null,
   "pdf_data": {
     "page_metadata": [
@@ -1216,12 +1181,5 @@
         "serialised_text": "Section context: this excerpt is from the section titled 'PART I: PROJECT INFORMATION'. Project Category:\nRegular\nCountry:\nSouth Africa\nTitle of Project:\nBuilding Resilience in the Greater uMngeni Catchment\nType of Implementing Entity:\nNational\nImplementing Entity:\nSouth African National Biodiversity Institute\nExecuting Entity:\nuMgungundlovu District Municipality\nAmount of Financing Requested:\nUSD 7,495,055"
       }
     ]
-  },
-  "pipeline_metadata": {
-    "parser_metadata": {
-      "azure_api_version": "2023-07-31",
-      "azure_model_id": "prebuilt-document",
-      "parsing_date": "2025-05-22T17:35:22.344845"
-    }
   }
 }

--- a/tests/flows/test_inference.py
+++ b/tests/flows/test_inference.py
@@ -12,13 +12,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.client import ClientError
-from cpr_sdk.parser_models import (
-    BaseParserOutput,
-    BaseParserOutputV2,
-    BlockType,
-    PDFData,
-    PDFTextBlock,
-)
 from prefect.client.schemas.objects import FlowRun
 from prefect.context import FlowRunContext
 from prefect.states import Completed, Running
@@ -54,6 +47,13 @@ from flows.inference import (
     run_classifier_inference_on_document,
     store_inference_result,
     store_metadata,
+)
+from flows.models import (
+    BaseParserOutput,
+    BaseParserOutputV2,
+    BlockType,
+    PDFData,
+    PDFTextBlock,
 )
 from flows.utils import (
     DocumentImportId,
@@ -364,10 +364,6 @@ async def test_load_classifier__existing_classifier(
 
 _BASE_DOC_KWARGS = dict(
     document_id="test",
-    document_metadata={},
-    document_name="test",
-    document_slug="test",
-    document_description="test",
 )
 _STUB_PDF_DATA = PDFData(page_metadata=[], md5sum="", text_blocks=[])
 
@@ -456,7 +452,7 @@ def test_stringify():
 
 def test_document_passages__blocked_types(parser_output_pdf):
     # Add a page number block that should be filtered out
-    from cpr_sdk.parser_models import TextBlock
+    from flows.models import TextBlock
 
     parser_output_pdf.pdf_data.text_blocks.append(
         TextBlock(
@@ -686,16 +682,8 @@ async def test_run_classifier_inference_on_document(
         labelled_passages=[],
         document=BaseParserOutput(
             document_id=document_stem,
-            document_metadata={},
-            document_name="test document",
-            document_description="test description",
-            document_source_url=None,
-            document_cdn_object=None,
             document_content_type="text/html",
-            document_md5_sum=None,
-            document_slug=document_stem,
             languages=None,
-            translated=False,
             html_data=None,
             pdf_data=PDFData(
                 page_metadata=[],
@@ -713,7 +701,6 @@ async def test_run_classifier_inference_on_document(
                     )
                 ],
             ),
-            pipeline_metadata={},
         ),
         classifier_spec=classifier_spec,
     )


### PR DESCRIPTION
We're cutting down on the data that we pass around in S3. This simplification lets us save storage as well as unblocks mapper -> processing interface. Here the sdk code is vendored, the extra fields are then removed, and associated test code cleaned up.

We have chosen to reproduce the models in the knowledge graph at this stage so we can break the dependency on the sdk. We're not looking at making a new, common abstraction at this time but also haven't necessarily ruled it out in the future.