### PR TITLE
chore: add lifecycle policy for ECR

### DIFF
--- a/infra/Pulumi.labs.yaml
+++ b/infra/Pulumi.labs.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: eu-west-1

--- a/infra/Pulumi.sandbox.yaml
+++ b/infra/Pulumi.sandbox.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: eu-west-1

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: eu-west-1

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,17 @@
-# AWS S3 bucket infra-as-code
+# Infrastructure-as-code
 
-The code in this repo manages the bucket `s3://cpr-kg-feather-files` which exists in production and has cross-account access to labs. Labs cross-account access is needed as the feather files stored in this bucket are used by processes related to model training (AWS production) and the vibe checker (AWS labs).
+Pulumi manages a small amount of AWS infrastructure for this repo. There is one
+stack per AWS environment, named after that environment.
+
+## What's managed
+
+- **ECR repository `knowledge-graph`** — exists in all four environments, and
+  holds the images that the Prefect flow deployments run from. The repository
+  name has to match the name of this GitHub repo, because that is where
+  `.github/workflows/prefect_deploy.yml` gets it from.
+- **S3 bucket `s3://cpr-kg-feather-files`** — production only, with cross-account
+  read access for labs. Labs needs it because the feather files in this bucket
+  are used both by model training (AWS production) and by the vibe checker (AWS
+  labs).
 
 Vibe checker infra on AWS labs is managed separately in `vibe-checker/infra`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,6 +9,8 @@ stack per AWS environment, named after that environment.
   holds the images that the Prefect flow deployments run from. The repository
   name has to match the name of this GitHub repo, because that is where
   `.github/workflows/prefect_deploy.yml` gets it from.
+  Each repository has a lifecycle policy that expires untagged images after 7
+  days and keeps only the 50 most recently pushed tagged images.
 - **S3 bucket `s3://cpr-kg-feather-files`** — production only, with cross-account
   read access for labs. Labs needs it because the feather files in this bucket
   are used both by model training (AWS production) and by the vibe checker (AWS

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,15 +3,9 @@ import json
 import pulumi
 import pulumi_aws as aws
 
-# One stack per AWS environment, named after that environment. Each stack must be
-# run against the matching account's credentials, eg `AWS_PROFILE=labs pulumi up
-# -s labs`.
 stack = pulumi.get_stack()
 
 # ECR repository holding the images that the Prefect flow deployments run from.
-# It exists in every environment, and is named after this GitHub repo because
-# that is where the deployment tooling gets the repository name from (see
-# .github/workflows/prefect_deploy.yml).
 knowledge_graph_ecr_repository = aws.ecr.Repository(
     f"{stack}-knowledge-graph-ecr-repository",
     name="knowledge-graph",
@@ -29,17 +23,6 @@ knowledge_graph_ecr_repository = aws.ecr.Repository(
 
 pulumi.export("ecr_repository_url", knowledge_graph_ecr_repository.repository_url)
 
-# Every build pushes the same manifest under three tags (the package version, the
-# commit sha and `latest`), and re-pushing those mutable tags orphans the previous
-# manifest. That is why the vast majority of images in these repositories are
-# untagged, so expiring them is where nearly all of the reclaimed storage comes
-# from.
-#
-# Deliberately no rule matches tags by pattern: because the version tag shares a
-# manifest with the commit sha, a rule aimed at sha tags would take the version
-# tag with it, and the Prefect deployments run from the version tag (see
-# deployments.py). Retaining by count is safe instead, as the version tag in use
-# is always on the most recently pushed manifest.
 aws.ecr.LifecyclePolicy(
     f"{stack}-knowledge-graph-ecr-lifecycle-policy",
     repository=knowledge_graph_ecr_repository.name,
@@ -62,11 +45,6 @@ aws.ecr.LifecyclePolicy(
                     "description": "Keep only the 50 most recently pushed tagged images",
                     "selection": {
                         "tagStatus": "tagged",
-                        # A lone wildcard matches every tag, so this covers the
-                        # version, sha, `latest` and `buildcache` tags alike. The
-                        # first three share the newest manifest and `buildcache` is
-                        # rewritten on every build, so all of them stay well inside
-                        # the retained 50.
                         "tagPatternList": ["*"],
                         "countType": "imageCountMoreThan",
                         "countNumber": 50,

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,3 +1,5 @@
+import json
+
 import pulumi
 import pulumi_aws as aws
 
@@ -26,6 +28,55 @@ knowledge_graph_ecr_repository = aws.ecr.Repository(
 )
 
 pulumi.export("ecr_repository_url", knowledge_graph_ecr_repository.repository_url)
+
+# Every build pushes the same manifest under three tags (the package version, the
+# commit sha and `latest`), and re-pushing those mutable tags orphans the previous
+# manifest. That is why the vast majority of images in these repositories are
+# untagged, so expiring them is where nearly all of the reclaimed storage comes
+# from.
+#
+# Deliberately no rule matches tags by pattern: because the version tag shares a
+# manifest with the commit sha, a rule aimed at sha tags would take the version
+# tag with it, and the Prefect deployments run from the version tag (see
+# deployments.py). Retaining by count is safe instead, as the version tag in use
+# is always on the most recently pushed manifest.
+aws.ecr.LifecyclePolicy(
+    f"{stack}-knowledge-graph-ecr-lifecycle-policy",
+    repository=knowledge_graph_ecr_repository.name,
+    policy=json.dumps(
+        {
+            "rules": [
+                {
+                    "rulePriority": 1,
+                    "description": "Expire untagged images after 7 days",
+                    "selection": {
+                        "tagStatus": "untagged",
+                        "countType": "sinceImagePushed",
+                        "countUnit": "days",
+                        "countNumber": 7,
+                    },
+                    "action": {"type": "expire"},
+                },
+                {
+                    "rulePriority": 2,
+                    "description": "Keep only the 50 most recently pushed tagged images",
+                    "selection": {
+                        "tagStatus": "tagged",
+                        # A lone wildcard matches every tag, so this covers the
+                        # version, sha, `latest` and `buildcache` tags alike. The
+                        # first three share the newest manifest and `buildcache` is
+                        # rewritten on every build, so all of them stay well inside
+                        # the retained 50.
+                        "tagPatternList": ["*"],
+                        "countType": "imageCountMoreThan",
+                        "countNumber": 50,
+                    },
+                    "action": {"type": "expire"},
+                },
+            ]
+        }
+    ),
+)
 
 # The feather files bucket only exists in production, where it is read by model
 # training and (cross-account) by the vibe checker in labs.

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,58 +1,93 @@
 import pulumi
 import pulumi_aws as aws
 
-config = pulumi.Config()
-labs_aws_account_id = config.require_secret("labs_aws_account_id")
+# One stack per AWS environment, named after that environment. Each stack must be
+# run against the matching account's credentials, eg `AWS_PROFILE=labs pulumi up
+# -s labs`.
+stack = pulumi.get_stack()
 
-production_knowledge_graph_feather_files_bucket = aws.s3.Bucket(
-    "production-knowledge-graph-feather-files-bucket",
-    bucket="cpr-kg-feather-files",
-    grants=[
-        aws.s3.BucketGrantArgs(
-            id="0fedc730a2af259d90402b1197e87cf40c4014a20851f540cac4269c0156abb9",
-            permissions=["FULL_CONTROL"],
-            type="CanonicalUser",
+# ECR repository holding the images that the Prefect flow deployments run from.
+# It exists in every environment, and is named after this GitHub repo because
+# that is where the deployment tooling gets the repository name from (see
+# .github/workflows/prefect_deploy.yml).
+knowledge_graph_ecr_repository = aws.ecr.Repository(
+    f"{stack}-knowledge-graph-ecr-repository",
+    name="knowledge-graph",
+    image_tag_mutability="MUTABLE",
+    image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
+        scan_on_push=False,
+    ),
+    encryption_configurations=[
+        aws.ecr.RepositoryEncryptionConfigurationArgs(
+            encryption_type="AES256",
         )
     ],
-    region="eu-west-1",
-    request_payer="BucketOwner",
-    server_side_encryption_configuration=aws.s3.BucketServerSideEncryptionConfigurationArgs(
-        rule=aws.s3.BucketServerSideEncryptionConfigurationRuleArgs(
-            apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(
-                sse_algorithm="AES256",
-            ),
-            bucket_key_enabled=True,
-        ),
-    ),
     opts=pulumi.ResourceOptions(protect=True),
 )
 
-# Grant the labs AWS account read-only access to the feather files bucket
-labs_cross_account_policy = aws.iam.get_policy_document(
-    statements=[
-        aws.iam.GetPolicyDocumentStatementArgs(
-            sid="LabsCrossAccountReadOnly",
-            effect="Allow",
-            principals=[
-                aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                    type="AWS",
-                    identifiers=[f"arn:aws:iam::{labs_aws_account_id}:root"],
-                )
-            ],
-            actions=[
-                "s3:GetObject",
-                "s3:ListBucket",
-            ],
-            resources=[
-                "arn:aws:s3:::cpr-kg-feather-files",
-                "arn:aws:s3:::cpr-kg-feather-files/*",
-            ],
-        ),
-    ],
-)
+pulumi.export("ecr_repository_url", knowledge_graph_ecr_repository.repository_url)
 
-production_knowledge_graph_feather_files_bucket_policy = aws.s3.BucketPolicy(
-    "production-knowledge-graph-feather-files-bucket-policy",
-    bucket=production_knowledge_graph_feather_files_bucket.id,
-    policy=labs_cross_account_policy.json,
-)
+# The feather files bucket only exists in production, where it is read by model
+# training and (cross-account) by the vibe checker in labs.
+if stack == "production":
+    config = pulumi.Config()
+    labs_aws_account_id = config.require_secret("labs_aws_account_id")
+
+    production_knowledge_graph_feather_files_bucket = aws.s3.Bucket(
+        "production-knowledge-graph-feather-files-bucket",
+        bucket="cpr-kg-feather-files",
+        grants=[
+            aws.s3.BucketGrantArgs(
+                id="0fedc730a2af259d90402b1197e87cf40c4014a20851f540cac4269c0156abb9",
+                permissions=["FULL_CONTROL"],
+                type="CanonicalUser",
+            )
+        ],
+        region="eu-west-1",
+        request_payer="BucketOwner",
+        server_side_encryption_configuration=aws.s3.BucketServerSideEncryptionConfigurationArgs(
+            rule=aws.s3.BucketServerSideEncryptionConfigurationRuleArgs(
+                apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(
+                    sse_algorithm="AES256",
+                ),
+                bucket_key_enabled=True,
+            ),
+        ),
+        opts=pulumi.ResourceOptions(protect=True),
+    )
+
+    # Grant the labs AWS account read-only access to the feather files bucket.
+    # This uses the _output form of the invoke so that the labs account id, which
+    # is a secret Output, is resolved rather than stringified into the ARN.
+    labs_cross_account_policy = aws.iam.get_policy_document_output(
+        statements=[
+            aws.iam.GetPolicyDocumentStatementArgs(
+                sid="LabsCrossAccountReadOnly",
+                effect="Allow",
+                principals=[
+                    aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="AWS",
+                        identifiers=[
+                            labs_aws_account_id.apply(
+                                lambda account_id: f"arn:aws:iam::{account_id}:root"
+                            )
+                        ],
+                    )
+                ],
+                actions=[
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                ],
+                resources=[
+                    "arn:aws:s3:::cpr-kg-feather-files",
+                    "arn:aws:s3:::cpr-kg-feather-files/*",
+                ],
+            ),
+        ],
+    )
+
+    production_knowledge_graph_feather_files_bucket_policy = aws.s3.BucketPolicy(
+        "production-knowledge-graph-feather-files-bucket-policy",
+        bucket=production_knowledge_graph_feather_files_bucket.id,
+        policy=labs_cross_account_policy.json,
+    )


### PR DESCRIPTION
This involves importing the resources and applying a tag based & untagged based policy. I've already applied all of them as the infra isnt run in ci.