### PR TITLE
turns keyword matching relaxations on by default and exposes them in …

### DIFF
--- a/knowledge_graph/classifier/keyword.py
+++ b/knowledge_graph/classifier/keyword.py
@@ -120,8 +120,8 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
     but not
         "The greenhouse gas emissions are a major contributor to climate change."
 
-    Two optional relaxations of the matching are available, both off by default, and
-    they can be combined:
+    Two relaxations of the matching are available, both on by default, and they can be
+    disabled independently:
 
     - fold_subscripts: matches subscript and superscript digits against their ASCII
       equivalents, in both directions, so a "CO2" label matches "CO₂" in the text and
@@ -131,14 +131,18 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
       Uses regex rules which are imprecise but quick.
 
     Both are applied to negative labels as well as positive ones, so that a loosened
-    positive match cannot slip past a still-strict veto. Enabling either changes the
-    classifier's id, so a relaxed variant never collides with the default
-    configuration. Spans are always reported as offsets into the original text.
+    positive match cannot slip past a still-strict veto. Only the strict configuration
+    (both off) keeps the ids that keyword classifiers had before these options existed,
+    so a relaxed classifier never collides with a strict one. Spans are always reported
+    as offsets into the original text.
 
     KeywordClassifier does not output prediction probabilities, so spans identified by
     this classifier will not have prediction_probability values set.
     """
 
+    # Deliberately the opposite of the constructor's defaults: these are only read
+    # for classifiers pickled before the options existed. Flipping them would relax -
+    # and change the id of - every keyword classifier already in W&B and S3.
     fold_subscripts: bool = False
     match_word_forms: bool = False
 
@@ -152,8 +156,8 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
     def __init__(
         self,
         concept: Concept,
-        fold_subscripts: bool = False,
-        match_word_forms: bool = False,
+        fold_subscripts: bool = True,
+        match_word_forms: bool = True,
     ):
         r"""
         Create a new KeywordClassifier instance.
@@ -172,9 +176,9 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
 
         :param Concept concept: The concept which the classifier will identify in text
         :param bool fold_subscripts: Match subscript and superscript digits against
-            their ASCII equivalents, in both directions
+            their ASCII equivalents, in both directions. On by default.
         :param bool match_word_forms: Also match the English plural of each label's
-            final word
+            final word. On by default.
         """
         super().__init__(concept)
 
@@ -319,8 +323,8 @@ class KeywordClassifier(Classifier, ZeroShotClassifier):
         """
         Return a deterministic, human-readable identifier for the classifier.
 
-        The match options are only hashed in when they are enabled, so that default
-        classifiers keep the ids they had before the introduction of these.
+        The match options are only hashed in when they are enabled, so that strictly
+        matching classifiers keep the ids they had before the introduction of these.
         """
         if not (self.fold_subscripts or self.match_word_forms):
             return ClassifierID.generate(self.name, self.concept.id)

--- a/knowledge_graph/classifier/keyword_expansion.py
+++ b/knowledge_graph/classifier/keyword_expansion.py
@@ -21,8 +21,8 @@ class KeywordExpansionClassifier(KeywordClassifier):
         self,
         concept: Concept,
         model: str = "claude-3-5-haiku-20241022",
-        fold_subscripts: bool = False,
-        match_word_forms: bool = False,
+        fold_subscripts: bool = True,
+        match_word_forms: bool = True,
     ):
         self.original_concept = concept
         self.concept = concept

--- a/knowledge_graph/custom_classifier_config.py
+++ b/knowledge_graph/custom_classifier_config.py
@@ -148,6 +148,25 @@ class BERTClassifierConfig(BaseModel):
         }
 
 
+class KeywordClassifierConfig(BaseModel):
+    """
+    Maps to KeywordClassifier kwargs (keyword.py), unset unless the YAML sets them.
+
+    Restating the classifier's own defaults here would give them a second home to
+    drift from. Since the options are hashed into the classifier's id, the two homes
+    disagreeing would send one concept to two different ids.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    fold_subscripts: bool | None = None
+    match_word_forms: bool | None = None
+
+    def to_classifier_kwargs(self) -> dict[str, Any]:
+        """Only the explicitly set options (drops None so the classifier defaults win)."""
+        return self.model_dump(exclude_none=True)
+
+
 class CustomClassifierConfig(BaseModel):
     """Config for custom concept classifier (one YAML file per concept)."""
 
@@ -156,8 +175,10 @@ class CustomClassifierConfig(BaseModel):
     wikibase_id: WikibaseID
     concept_overrides: ConceptOverrides = Field(default_factory=ConceptOverrides)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
-    llm: LLMClassifierConfig
+    # Optional because a keyword classifier is trained without any LLM labelling step
+    llm: LLMClassifierConfig | None = None
     bert: BERTClassifierConfig = Field(default_factory=BERTClassifierConfig)
+    keyword: KeywordClassifierConfig = Field(default_factory=KeywordClassifierConfig)
 
     @classmethod
     def from_yaml(cls, path: Path | str) -> "CustomClassifierConfig":

--- a/scripts/benchmarks/keywordclassifier_option_sweep.py
+++ b/scripts/benchmarks/keywordclassifier_option_sweep.py
@@ -1,9 +1,10 @@
 r"""
 Sweep the optional KeywordClassifier matching relaxations across many concepts.
 
-KeywordClassifier gained two optional relaxations - subscript folding and plural word
-forms - both off by default. This script measures what each one actually buys, per
-concept, against the human-labelled passages in Argilla.
+KeywordClassifier has two matching relaxations - subscript folding and plural word
+forms - both on by default. This script measures what each one actually buys, per
+concept, against the human-labelled passages in Argilla, with the strict configuration
+as the control.
 
 For every concept listed in ``vibe-checker/config.yml`` it builds one classifier per
 option combination, evaluates it against that concept's gold passages, and appends the
@@ -51,9 +52,10 @@ DEFAULT_OUTPUT_DIR = Path("scripts/benchmarks/keywordclassifier_option_sweep_res
 AGREEMENT_LEVELS = ["Passage level", "Span level (0.5)"]
 
 # The option combinations under test. "default" is the control, and must stay first so
-# that every other variant can be compared against it.
+# that every other variant can be compared against it. Its kwargs are spelled out
+# because the classifier's own defaults now have both options on.
 VARIANTS: dict[str, dict[str, Any]] = {
-    "default": {},
+    "default": {"fold_subscripts": False, "match_word_forms": False},
     "fold_subscripts": {"fold_subscripts": True},
     "match_word_forms": {"match_word_forms": True},
     "all_on": {"fold_subscripts": True, "match_word_forms": True},

--- a/scripts/custom_concept_training/configs_cli.py
+++ b/scripts/custom_concept_training/configs_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Any
+from types import UnionType
+from typing import Any, Union, get_args, get_origin
 
 import typer
 import yaml
@@ -83,6 +84,12 @@ def to_example_dict(model_class: type[BaseModel]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for field_name, field_info in model_class.model_fields.items():
         annotation = field_info.annotation
+        # Unwrap `X | None` so optional sections are templated out in full rather
+        # than left as a bare null
+        if get_origin(annotation) in (UnionType, Union):
+            annotation = next(
+                (arg for arg in get_args(annotation) if arg is not type(None)), None
+            )
         if isinstance(annotation, type) and issubclass(annotation, BaseModel):
             result[field_name] = to_example_dict(annotation)
         elif field_info.is_required():

--- a/scripts/custom_concept_training/validate.py
+++ b/scripts/custom_concept_training/validate.py
@@ -31,7 +31,8 @@ def validate_dir(config_dir: Path = CONFIG_DIR) -> None:
 
 def check_wikibase_ids(cfg: CustomClassifierConfig, session: "WikibaseSession") -> None:
     """Live: confirm wikibase_id + related_definitions resolve in the concept store."""
-    for wid in [cfg.wikibase_id, *cfg.llm.related_definitions]:
+    related = cfg.llm.related_definitions if cfg.llm else []
+    for wid in [cfg.wikibase_id, *related]:
         try:
             session.get_concept(wid)
         except ConceptNotFoundError as e:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -158,6 +158,11 @@ def main(
     if cfg is not None:
         concept_overrides = cfg.concept_overrides.as_overrides()
         if classifier_type == "LLMClassifier":
+            if cfg.llm is None:
+                raise typer.BadParameter(
+                    f"{from_yaml_config} has no 'llm' section, which "
+                    "--classifier-type LLMClassifier requires."
+                )
             related = cfg.llm.related_definitions
             session = WikibaseSession() if related else None
             defs = (
@@ -173,9 +178,12 @@ def main(
             classifier_kwargs = cfg.bert.to_classifier_kwargs()
             training_data_wandb_path = cfg.bert.training_data_wandb_path
             limit_training_samples = cfg.bert.limit_training_samples
+        elif classifier_type == "KeywordClassifier":
+            classifier_kwargs = cfg.keyword.to_classifier_kwargs()
         else:
             raise typer.BadParameter(
-                "--classifier-type must be LLMClassifier or BertBasedClassifier"
+                "--classifier-type must be LLMClassifier, BertBasedClassifier or "
+                "KeywordClassifier"
             )
 
     if compute is not ComputeTarget.local:

--- a/tests/scripts/test_train_cli.py
+++ b/tests/scripts/test_train_cli.py
@@ -1,0 +1,99 @@
+"""Tests for the classifier kwarg overrides exposed by the train CLI."""
+
+from typer.testing import CliRunner
+
+import scripts.train as train_mod
+from knowledge_graph.identifiers import WikibaseID
+
+
+def _capturing_run_training(monkeypatch) -> dict:
+    """Replace run_training with a stub that records the kwargs it was called with."""
+    captured: dict = {}
+
+    async def _fake_run_training(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(train_mod, "run_training", _fake_run_training)
+    return captured
+
+
+def test_classifier_override_reaches_local_training(monkeypatch):
+    """--classifier-override turns the keyword match options off for one run."""
+    captured = _capturing_run_training(monkeypatch)
+
+    result = CliRunner().invoke(
+        train_mod.app,
+        [
+            "--wikibase-id",
+            "Q123",
+            "--classifier-type",
+            "KeywordClassifier",
+            "--classifier-override",
+            "fold_subscripts=false",
+            "--classifier-override",
+            "match_word_forms=false",
+            "--no-track-and-upload",
+            "--no-evaluate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["wikibase_id"] == WikibaseID("Q123")
+    assert captured["classifier_type"] == "KeywordClassifier"
+    assert captured["classifier_kwargs"] == {
+        "fold_subscripts": False,
+        "match_word_forms": False,
+    }
+
+
+def test_classifier_override_reaches_the_remote_deployment(monkeypatch):
+    """The overrides must survive the hop through the Prefect deployment parameters."""
+    captured: dict = {}
+
+    def _fake_run_deployment(*, name, parameters, timeout):
+        captured["name"] = name
+        captured["parameters"] = parameters
+        return None
+
+    monkeypatch.setattr(train_mod, "run_deployment", _fake_run_deployment)
+    monkeypatch.setattr(train_mod, "get_flow_run_ui_url", lambda flow_run: "http://x")
+
+    result = CliRunner().invoke(
+        train_mod.app,
+        [
+            "--wikibase-id",
+            "Q123",
+            "--classifier-type",
+            "KeywordClassifier",
+            "--classifier-override",
+            "fold_subscripts=false",
+            "--compute",
+            "remote-cpu",
+            "--no-track-and-upload",
+            "--no-evaluate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["parameters"]["classifier_type"] == "KeywordClassifier"
+    assert captured["parameters"]["classifier_kwargs"] == {"fold_subscripts": False}
+
+
+def test_no_override_leaves_the_classifier_defaults_in_place(monkeypatch):
+    """With no override the flow gets empty kwargs, so the classifier's own defaults win."""
+    captured = _capturing_run_training(monkeypatch)
+
+    result = CliRunner().invoke(
+        train_mod.app,
+        [
+            "--wikibase-id",
+            "Q123",
+            "--classifier-type",
+            "KeywordClassifier",
+            "--no-track-and-upload",
+            "--no-evaluate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["classifier_kwargs"] == {}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -220,7 +220,6 @@ def test_whether_classifier_hashes_are_generated_correctly(
     classifier_class: Type[Classifier], concept: Concept
 ):
     classifier = classifier_class(concept)
-    assert classifier.id == ClassifierID.generate(classifier.name, concept.id)
     assert classifier == classifier_class(concept)
 
 
@@ -734,16 +733,31 @@ def test_whether_suffix_flexible_escapes_regex_metacharacters():
 
 
 @pytest.mark.xdist_group(name="classifier")
-def test_whether_keyword_matching_relaxations_are_off_by_default():
+def test_whether_keyword_matching_relaxations_are_on_by_default():
     concept = Concept(wikibase_id=WikibaseID("Q123"), preferred_label="greenhouse gas")
     classifier = KeywordClassifier(concept)
 
-    assert classifier.fold_subscripts is False
-    assert classifier.match_word_forms is False
+    assert classifier.fold_subscripts is True
+    assert classifier.match_word_forms is True
 
-    # The default configuration must keep the id it has always had, so that existing
-    # artifacts, model paths and classifier spec entries stay valid.
+    assert classifier.predict("greenhouse gases were measured")
+
+
+@pytest.mark.xdist_group(name="classifier")
+def test_whether_the_strict_configuration_keeps_its_original_id():
+    """
+    Turning the relaxations off must reproduce the pre-relaxation id exactly.
+
+    This is what lets an already-trained classifier be rebuilt at the id its artifact,
+    model path and classifier spec entry were recorded under.
+    """
+    concept = Concept(wikibase_id=WikibaseID("Q123"), preferred_label="greenhouse gas")
+    classifier = KeywordClassifier(
+        concept, fold_subscripts=False, match_word_forms=False
+    )
+
     assert classifier.id == ClassifierID.generate(classifier.name, concept.id)
+    assert classifier.id != KeywordClassifier(concept).id
 
 
 @given(concept=concept_strategy(), text_data=st.data())
@@ -800,10 +814,12 @@ def test_whether_folding_subscripts_matches_across_scripts(
 
 
 @pytest.mark.xdist_group(name="classifier")
-def test_whether_folding_subscripts_is_required_to_match_across_scripts():
+def test_whether_folding_subscripts_can_be_disabled():
     concept = Concept(wikibase_id=WikibaseID("Q123"), preferred_label="CO2")
 
-    assert not KeywordClassifier(concept).predict("CO₂ emissions rose")
+    assert not KeywordClassifier(concept, fold_subscripts=False).predict(
+        "CO₂ emissions rose"
+    )
 
 
 @pytest.mark.xdist_group(name="classifier")
@@ -830,10 +846,12 @@ def test_whether_matching_word_forms_matches_plurals(
 
 
 @pytest.mark.xdist_group(name="classifier")
-def test_whether_matching_word_forms_is_required_to_match_plurals():
+def test_whether_matching_word_forms_can_be_disabled():
     concept = Concept(wikibase_id=WikibaseID("Q123"), preferred_label="greenhouse gas")
 
-    assert not KeywordClassifier(concept).predict("greenhouse gases were measured")
+    assert not KeywordClassifier(concept, match_word_forms=False).predict(
+        "greenhouse gases were measured"
+    )
 
 
 @pytest.mark.xdist_group(name="classifier")
@@ -855,9 +873,9 @@ def test_whether_match_options_change_the_classifier_id():
     concept = Concept(wikibase_id=WikibaseID("Q123"), preferred_label="greenhouse gas")
 
     variants = [
-        KeywordClassifier(concept),
-        KeywordClassifier(concept, fold_subscripts=True),
-        KeywordClassifier(concept, match_word_forms=True),
+        KeywordClassifier(concept, fold_subscripts=False, match_word_forms=False),
+        KeywordClassifier(concept, fold_subscripts=True, match_word_forms=False),
+        KeywordClassifier(concept, fold_subscripts=False, match_word_forms=True),
         KeywordClassifier(concept, fold_subscripts=True, match_word_forms=True),
     ]
 
@@ -865,10 +883,7 @@ def test_whether_match_options_change_the_classifier_id():
     assert len(set(ids)) == len(ids), f"ids collided: {ids}"
 
     # Passing the defaults explicitly is still the default configuration
-    explicit_default = KeywordClassifier(
-        concept, fold_subscripts=False, match_word_forms=False
-    )
-    assert explicit_default.id == variants[0].id
+    assert KeywordClassifier(concept).id == variants[-1].id
 
 
 @pytest.mark.xdist_group(name="classifier")
@@ -916,7 +931,7 @@ def test_whether_keyword_classifiers_pickled_before_match_options_still_work(tmp
         preferred_label="greenhouse gas",
         negative_labels=["natural gas"],
     )
-    original = KeywordClassifier(concept)
+    original = KeywordClassifier(concept, fold_subscripts=False, match_word_forms=False)
     expected_id = original.id
 
     # Simulate a classifier pickled before the match options existed

--- a/tests/test_from_yaml.py
+++ b/tests/test_from_yaml.py
@@ -8,7 +8,9 @@ from typer.testing import CliRunner
 
 import scripts.sample as sample_mod
 import scripts.train as train_mod
+from knowledge_graph.classifier.keyword import KeywordClassifier
 from knowledge_graph.classifier.large_language_model import LLMClassifierPrompt
+from knowledge_graph.concept import Concept
 from knowledge_graph.custom_classifier_config import (
     CustomClassifierConfig,
     LLMClassifierConfig,
@@ -30,6 +32,7 @@ def test_config_loads_and_builds_llm_prompt(path: Path):
     """Every committed config loads, yields a valid LLM prompt, and interpolates its related definitions."""
     cfg = CustomClassifierConfig.from_yaml(path)
     assert cfg.wikibase_id == WikibaseID(path.stem.upper())
+    assert cfg.llm is not None
     stub = {wid: f"DEF::{wid}" for wid in cfg.llm.related_definitions}
     prompt = cfg.llm.to_classifier_kwargs(definitions=stub)["system_prompt_template"]
     assert isinstance(prompt, LLMClassifierPrompt)
@@ -123,6 +126,93 @@ def test_train_main_from_yaml_passes_llm_kwargs_to_run_training(monkeypatch):
     assert isinstance(
         captured["classifier_kwargs"]["system_prompt_template"], LLMClassifierPrompt
     )
+
+
+def test_train_main_from_yaml_passes_keyword_kwargs_to_run_training(
+    monkeypatch, tmp_path: Path
+):
+    """--from-yaml-config (keyword) forwards the YAML's match options as classifier kwargs."""
+    captured = {}
+
+    async def _fake_run_training(**kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(train_mod, "run_training", _fake_run_training)
+    path = tmp_path / "q7.yaml"
+    path.write_text(
+        "wikibase_id: Q7\nkeyword:\n  fold_subscripts: false\n  match_word_forms: true\n"
+    )
+    result = CliRunner().invoke(
+        train_mod.app,
+        [
+            "--from-yaml-config",
+            str(path),
+            "--classifier-type",
+            "KeywordClassifier",
+            "--no-track-and-upload",
+            "--no-evaluate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["wikibase_id"] == WikibaseID("Q7")
+    assert captured["classifier_kwargs"] == {
+        "fold_subscripts": False,
+        "match_word_forms": True,
+    }
+
+
+def test_keyword_config_without_a_keyword_section_overrides_nothing(tmp_path: Path):
+    """Empty kwargs are what make a YAML-driven run identical to a bare one."""
+    path = tmp_path / "q8.yaml"
+    path.write_text("wikibase_id: Q8\n")
+    cfg = CustomClassifierConfig.from_yaml(path)
+
+    assert cfg.llm is None
+    assert cfg.keyword.to_classifier_kwargs() == {}
+
+    concept = Concept(wikibase_id=WikibaseID("Q8"), preferred_label="greenhouse gas")
+    assert (
+        KeywordClassifier(concept, **cfg.keyword.to_classifier_kwargs()).id
+        == KeywordClassifier(concept).id
+    )
+
+
+def test_keyword_config_passes_through_a_single_option(tmp_path: Path):
+    """Setting one option must not imply anything about the other."""
+    path = tmp_path / "q10.yaml"
+    path.write_text("wikibase_id: Q10\nkeyword:\n  match_word_forms: false\n")
+    cfg = CustomClassifierConfig.from_yaml(path)
+
+    assert cfg.keyword.to_classifier_kwargs() == {"match_word_forms": False}
+
+
+def test_train_main_from_yaml_rejects_llm_type_without_an_llm_section(
+    monkeypatch, tmp_path: Path
+):
+    """Asking for an LLM classifier from a keyword-only config fails loudly."""
+
+    async def _fail(**kw):
+        raise AssertionError("run_training should not be reached")
+
+    monkeypatch.setattr(train_mod, "run_training", _fail)
+    path = tmp_path / "q9.yaml"
+    path.write_text("wikibase_id: Q9\n")
+    result = CliRunner().invoke(
+        train_mod.app,
+        [
+            "--from-yaml-config",
+            str(path),
+            "--classifier-type",
+            "LLMClassifier",
+            "--no-track-and-upload",
+            "--no-evaluate",
+        ],
+        # Typer wraps the error to the terminal width, which varies with how pytest
+        # is invoked; a wide terminal keeps the message on one line
+        env={"COLUMNS": "200"},
+    )
+    assert result.exit_code != 0
+    assert "has no 'llm' section" in result.output
 
 
 def test_resolve_config_inputs_rejects_both():


### PR DESCRIPTION
…yaml config

Closes the remaining two boxes on [FUS-262](https://linear.app/climate-policy-radar/issue/FUS-262).
Follows #1252, which added the two match options but left them switched off.

^ I think this is what was needed from the ticket description, but Kalyan/dsci feel free to merge when I'm gone :)

## What this does

- **Both options default to on**, so newly trained keyword classifiers match plurals
  and sub/superscript digits without being asked.
- **The options can be switched off per concept from yaml**, which previously rejected
  any classifier type but `LLMClassifier` and `BertBasedClassifier`:

  ```yaml
  wikibase_id: Q650
  keyword:
    match_word_forms: false
  ```

  Unset means "use the classifier's default", so a config saying nothing about keyword options trains identically to a bare run. `llm:` is now optional, since a keyword  classifier has no LLM labelling step.
- `--classifier-override match_word_forms=false` already worked; it now has tests covering the local path and the hop into the Prefect deployment parameters, where a dropped kwarg would fail silently.

## Also in here

Two knock-on fixes. The sweep script's control variant said "use the defaults", which after this change would have compared relaxed against relaxed. And classifier-configs create would have started generating llm: null instead of a fillable section, now that llm is optional.

## Testing

Added tests for: relaxations on by default, the strict configuration still producing its pre-relaxation id, options reaching training from yaml and from `--classifier-override`, and an unset keyword section overriding nothing.

