### PR TITLE
chore: set CODEOWNERS to @climatepolicyradar/enrichment with Fusion co-review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,21 @@
-tests/flows/    @climatepolicyradar/deng
-flows/          @climatepolicyradar/deng
-automations.py  @climatepolicyradar/deng
-deployments.py  @climatepolicyradar/deng
-*               @climatepolicyradar/deng @climatepolicyradar/fusion
+# Ownership per [RFC] Ownership of code and services
+# https://www.notion.so/3a49109609a480c4ae38f1f5b2672675
+#
+# Razor: orchestration, deployment and build plumbing is Enrichment-only;
+# modelling and concept code also gets data science review (Fusion).
 
-# Dependency updates - only require deng team
-pyproject.toml             @climatepolicyradar/deng
-uv.lock                    @climatepolicyradar/deng
-.github/workflows/*.yml    @climatepolicyradar/deng
-Dockerfile                 @climatepolicyradar/deng
-mcp/Dockerfile             @climatepolicyradar/deng
-docker-compose.yml         @climatepolicyradar/deng
+*               @climatepolicyradar/enrichment @climatepolicyradar/fusion
+
+# Orchestration and deployment — Enrichment only
+flows/          @climatepolicyradar/enrichment
+tests/flows/    @climatepolicyradar/enrichment
+automations.py  @climatepolicyradar/enrichment
+deployments.py  @climatepolicyradar/enrichment
+
+# Dependency updates and build plumbing — Enrichment only
+pyproject.toml             @climatepolicyradar/enrichment
+uv.lock                    @climatepolicyradar/enrichment
+.github/workflows/*.yml    @climatepolicyradar/enrichment
+Dockerfile                 @climatepolicyradar/enrichment
+mcp/Dockerfile             @climatepolicyradar/enrichment
+docker-compose.yml         @climatepolicyradar/enrichment


### PR DESCRIPTION
## What

Points CODEOWNERS at `@climatepolicyradar/enrichment`, replacing `@climatepolicyradar/deng`, keeping `@climatepolicyradar/fusion` co-review on the default rule.

## Why

Implements Phase 1 of [\[RFC\] Ownership of code and services](https://www.notion.so/3a49109609a480c4ae38f1f5b2672675),
which assigns this repository to Enrichment with split CODEOWNERS keeping data science review on
modelling code. Ownership here means stewardship and accountability — the owning
team sets the quality bar and is accountable for the health of the repo. It is not
gatekeeping: anyone may contribute to any CPR codebase, subject to following the owning
team's documented process and PRing changes for review.

The razor for the split, now stated in the file: orchestration, deployment and build
plumbing is Enrichment-only; modelling and concept code also gets data science review (Fusion).

`deng` is being sunset as a GitHub team once no codebase references it.

## Change

| | Before | After |
|---|---|---|
| Default owner (`*`) | `@climatepolicyradar/deng` `@climatepolicyradar/fusion` | `@climatepolicyradar/enrichment` `@climatepolicyradar/fusion` |
| `flows/`, `tests/flows/`, `automations.py`, `deployments.py` | `@climatepolicyradar/deng` | `@climatepolicyradar/enrichment` |
| Dependency/build files (`pyproject.toml`, `uv.lock`, workflows, Dockerfiles, `docker-compose.yml`) | `@climatepolicyradar/deng` | `@climatepolicyradar/enrichment` |

One behavioural fix: CODEOWNERS is last-match-wins, and the `*` line previously sat after the
`flows/`, `tests/flows/`, `automations.py` and `deployments.py` rules, so those four carve-outs
never took effect — flow changes were requesting Fusion review despite the file's evident intent.
The `*` rule now comes first, so all carve-outs behave as written.

Also in this PR:

- Swept the repo for `@climatepolicyradar/deng` — `.github/CODEOWNERS` was the only reference
