### PR TITLE
add llm reviewed status metadata to argilla

### DIFF
--- a/knowledge_graph/labelling.py
+++ b/knowledge_graph/labelling.py
@@ -16,6 +16,7 @@ from argilla import (
     SpanQuestion,
     Suggestion,
     TaskDistribution,
+    TermsMetadataProperty,
     TextField,
     User,
     Workspace,
@@ -41,6 +42,11 @@ from knowledge_graph.span import Span
 logger = getLogger(__name__)
 
 load_dotenv(find_dotenv())
+
+# Key for Argilla records metadata that says whether a record has been LLM-prelabelled.
+# This is needed to be able to tell a prelabelled passage with 0 spans from one that
+# hasn't been prelabelled.
+LLM_PRELABELLED_METADATA_KEY = "llm_prelabelled"
 
 
 def create_llm_ensemble_for_prelabelling_validation_dataset(
@@ -243,6 +249,16 @@ class ArgillaSession:
         )
         return datasets
 
+    def _llm_prelabelled_metadata_property(self) -> TermsMetadataProperty:
+        """Build the metadata property recording whether a record was pre-labelled."""
+        return TermsMetadataProperty(
+            name=LLM_PRELABELLED_METADATA_KEY,
+            options=["true", "false"],
+            title="Pre-labelled by LLM ensemble",
+            visible_for_annotators=True,
+            client=self.client,
+        )
+
     def create_dataset(
         self,
         concept: Concept,
@@ -284,6 +300,7 @@ class ArgillaSession:
                     allow_overlapping=False,
                 )
             ],
+            metadata=[self._llm_prelabelled_metadata_property()],
             distribution=TaskDistribution(min_submitted=2),
             allow_extra_metadata=True,
         )
@@ -711,6 +728,21 @@ class ArgillaSession:
             for spans in suggestion_model.predict(texts, batch_size=batch_size)
         ]
 
+    def _ensure_llm_prelabelled_metadata_property(self, dataset: Dataset) -> None:
+        """Declare the pre-labelling metadata property on a dataset which lacks it."""
+        if LLM_PRELABELLED_METADATA_KEY in {
+            metadata_property.name for metadata_property in dataset.settings.metadata
+        }:
+            return
+
+        logger.info(
+            "Adding the '%s' metadata property to dataset: %s",
+            LLM_PRELABELLED_METADATA_KEY,
+            dataset.name,
+        )
+        dataset.settings.metadata.add(self._llm_prelabelled_metadata_property())
+        dataset.update()
+
     def add_labelled_passages(
         self,
         labelled_passages: list[LabelledPassage],
@@ -735,6 +767,10 @@ class ArgillaSession:
         Suggestions are kept separate from the passages' own spans, so model predictions
         are never mistaken for submitted human responses.
 
+        Every record also records whether it was pre-labelled under the
+        `llm_prelabelled` metadata key, which Argilla exposes in its metadata filter
+        and sort controls.
+
         :param labelled_passages: List of LabelledPassage objects to add.
         :param wikibase_id: Wikibase ID of the dataset to add passages to
         :param workspace: Name of the workspace to add passages to. If not provided,
@@ -752,6 +788,7 @@ class ArgillaSession:
         :raises ResourceDoesNotExistError: If the dataset or workspace does not exist
         """
         dataset = self.get_dataset(wikibase_id, workspace)
+        self._ensure_llm_prelabelled_metadata_property(dataset)
         logger.info(
             "Pushing %d labelled passages to dataset: %s",
             len(labelled_passages),
@@ -811,12 +848,17 @@ class ArgillaSession:
                     )
                 ]
 
+            metadata = self._format_metadata_keys_for_argilla(passage.metadata)
+            metadata[LLM_PRELABELLED_METADATA_KEY] = (
+                "true" if suggested_spans_and_score is not None else "false"
+            )
+
             record = Record(
                 id=str(uuid.uuid4()),
                 fields=fields,  # type: ignore
                 responses=responses,
                 suggestions=suggestions,
-                metadata=self._format_metadata_keys_for_argilla(passage.metadata),
+                metadata=metadata,
             )
             records.append(record)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import boto3
 import httpx
 import pandas as pd
 import pytest
+from argilla import Settings
 from moto import mock_aws
 
 from knowledge_graph.classifier.classifier import Classifier
@@ -500,6 +501,7 @@ def mock_dataset():
     def _create_dataset(name="Q123", records=None):
         mock_ds = MagicMock()
         mock_ds.name = name
+        mock_ds.settings = Settings()
         if records is not None:
             mock_ds.records.return_value = records
         return mock_ds

--- a/tests/test_labelling.py
+++ b/tests/test_labelling.py
@@ -14,6 +14,7 @@ from knowledge_graph.ensemble import Ensemble
 from knowledge_graph.identifiers import ClassifierID, WikibaseID
 from knowledge_graph.labelled_passage import LabelledPassage
 from knowledge_graph.labelling import (
+    LLM_PRELABELLED_METADATA_KEY,
     ArgillaSession,
     ResourceAlreadyExistsError,
     ResourceDoesNotExistError,
@@ -223,6 +224,33 @@ def test_whether_create_dataset_creates_a_new_dataset(concept):
 
                 assert result == mock_dataset
                 mock_create.assert_called_once()
+
+
+def test_whether_create_dataset_declares_the_llm_prelabelled_metadata_property(concept):
+    """New datasets can filter on the pre-labelling status from the day they're made."""
+    with patch("knowledge_graph.labelling.Argilla") as mock_argilla_class:
+        mock_client = MagicMock()
+        mock_argilla_class.return_value = mock_client
+
+        workspace = MagicMock()
+        workspace.name = "test-workspace"
+        mock_client.workspaces.return_value = workspace
+        # Mock that dataset doesn't exist initially
+        mock_client.datasets.return_value = None
+
+        with (
+            patch("knowledge_graph.labelling.Settings") as mock_settings,
+            patch("knowledge_graph.labelling.TextField"),
+            patch("knowledge_graph.labelling.SpanQuestion"),
+            patch("knowledge_graph.labelling.TaskDistribution"),
+            patch.object(Dataset, "create"),
+        ):
+            ArgillaSession().create_dataset(concept)
+
+    metadata_properties = mock_settings.call_args.kwargs["metadata"]
+    assert [prop.name for prop in metadata_properties] == [LLM_PRELABELLED_METADATA_KEY]
+    assert metadata_properties[0].options == ["true", "false"]
+    assert metadata_properties[0].visible_for_annotators
 
 
 def test_whether_create_dataset_raises_error_if_dataset_already_exists(
@@ -1088,7 +1116,6 @@ def _mock_dataset_for_suggestions(mock_argilla_client, mock_workspace, mock_data
     mock_client, _ = mock_argilla_client
     dataset = mock_dataset(name="Q123")
     dataset.records = MagicMock()
-    dataset.settings = MagicMock()
     mock_client.workspaces.return_value = mock_workspace()
     mock_client.datasets.return_value = dataset
     return dataset
@@ -1198,3 +1225,105 @@ def test_whether_an_empty_suggestion_is_attached_when_the_model_predicts_nothing
     assert suggestion.value == []
     # no spans to score, and the server rejects an empty score list
     assert suggestion.score is None
+
+
+def test_whether_a_prelabelled_record_is_marked_as_such_in_its_metadata(
+    mock_argilla_client, mock_workspace, mock_dataset
+):
+    """Annotators can filter for records an ensemble has been over."""
+    dataset = _mock_dataset_for_suggestions(
+        mock_argilla_client, mock_workspace, mock_dataset
+    )
+
+    session = ArgillaSession()
+    session.add_labelled_passages(
+        labelled_passages=[LabelledPassage(text=SUGGESTION_TEXT, spans=[])],
+        wikibase_id="Q123",
+        suggestion_model=_stub_ensemble(["Solar", "Solar", "Solar"]),
+    )
+
+    record = dataset.records.log.call_args[0][0][0]
+    assert record.metadata[LLM_PRELABELLED_METADATA_KEY] == "true"
+
+
+def test_whether_a_record_the_model_found_nothing_in_is_still_marked_as_prelabelled(
+    mock_argilla_client, mock_workspace, mock_dataset
+):
+    """The case the metadata exists for: a negative prediction, not an unseen passage."""
+    dataset = _mock_dataset_for_suggestions(
+        mock_argilla_client, mock_workspace, mock_dataset
+    )
+
+    session = ArgillaSession()
+    session.add_labelled_passages(
+        labelled_passages=[LabelledPassage(text=SUGGESTION_TEXT, spans=[])],
+        wikibase_id="Q123",
+        suggestion_model=_stub_ensemble(["nuclear", "nuclear", "nuclear"]),
+    )
+
+    record = dataset.records.log.call_args[0][0][0]
+    assert list(record.suggestions)[0].value == []
+    assert record.metadata[LLM_PRELABELLED_METADATA_KEY] == "true"
+
+
+def test_whether_a_record_is_marked_as_not_prelabelled_without_a_suggestion_model(
+    mock_argilla_client, mock_workspace, mock_dataset
+):
+    """A false value is written explicitly, rather than left as a missing key."""
+    dataset = _mock_dataset_for_suggestions(
+        mock_argilla_client, mock_workspace, mock_dataset
+    )
+
+    session = ArgillaSession()
+    session.add_labelled_passages(
+        labelled_passages=[
+            LabelledPassage(text=SUGGESTION_TEXT, spans=[], metadata={"existing": "v"})
+        ],
+        wikibase_id="Q123",
+    )
+
+    record = dataset.records.log.call_args[0][0][0]
+    assert record.metadata[LLM_PRELABELLED_METADATA_KEY] == "false"
+    # the passage's own metadata is left alone
+    assert record.metadata["existing"] == "v"
+
+
+def test_whether_pushing_declares_the_metadata_property_on_an_older_dataset(
+    mock_argilla_client, mock_workspace, mock_dataset
+):
+    """Datasets made before the property existed pick it up on the next push."""
+    dataset = _mock_dataset_for_suggestions(
+        mock_argilla_client, mock_workspace, mock_dataset
+    )
+    assert [prop.name for prop in dataset.settings.metadata] == []
+
+    session = ArgillaSession()
+    session.add_labelled_passages(
+        labelled_passages=[LabelledPassage(text=SUGGESTION_TEXT, spans=[])],
+        wikibase_id="Q123",
+    )
+
+    assert [prop.name for prop in dataset.settings.metadata] == [
+        LLM_PRELABELLED_METADATA_KEY
+    ]
+    dataset.update.assert_called_once()
+
+
+def test_whether_pushing_leaves_an_already_declared_metadata_property_alone(
+    mock_argilla_client, mock_workspace, mock_dataset
+):
+    dataset = _mock_dataset_for_suggestions(
+        mock_argilla_client, mock_workspace, mock_dataset
+    )
+    session = ArgillaSession()
+    dataset.settings.metadata.add(session._llm_prelabelled_metadata_property())
+
+    session.add_labelled_passages(
+        labelled_passages=[LabelledPassage(text=SUGGESTION_TEXT, spans=[])],
+        wikibase_id="Q123",
+    )
+
+    assert [prop.name for prop in dataset.settings.metadata] == [
+        LLM_PRELABELLED_METADATA_KEY
+    ]
+    dataset.update.assert_not_called()


### PR DESCRIPTION
I realised that when pre-labelling Argilla records with an LLM, there's no way to tell the difference between a record that hasn't been labelled and a record that has been labelled as having no spans.

This PR adds an `llm_prelabelled` boolean metadata key to every record to say whether it's been labelled or not, which can be used to sort and filter records in the Argilla UI.

Follows #1243. 