### PR TITLE
docs: add informative error to environment conflict

### DIFF
--- a/knowledge_graph/version.py
+++ b/knowledge_graph/version.py
@@ -86,9 +86,19 @@ def get_latest_model_version(
     aws_env: AwsEnv,
 ) -> Version:
     """Get the latest wandb model version for a given AWS environment from a list of artifacts."""
-    current_env_versions = [
-        Version(artifact.version)
-        for artifact in artifacts
-        if artifact.metadata.get("aws_env") == aws_env.name
-    ]
+    current_env_versions = []
+    all_envs = set()
+    for artifact in artifacts:
+        artifact_env = artifact.metadata.get("aws_env")
+        all_envs.add(artifact_env)
+        if artifact_env == aws_env.name:
+            current_env_versions.append(Version(artifact.version))
+
+    if not current_env_versions:
+        raise ValueError(
+            f"No model found in {aws_env.name}. Only found versions for: {all_envs}. "
+            "Was the model trained in the right environment? Consider moving it with: "
+            "`scripts/move_model_to_prod.py` if needed."
+        )
+
     return max(current_env_versions)

--- a/scripts/move_model_to_prod.py
+++ b/scripts/move_model_to_prod.py
@@ -170,7 +170,7 @@ def main(
         console.log(
             f"[green]✓[/green] Successfully promoted classifier from {source_env.value} to {target_env.value}"
         )
-        console.log(f"[green]✓[/green] New artifact: {artifact.name}:{next_version}")
+        console.log(f"[green]✓[/green] New artifact: {artifact.name}")
         console.log(f"[green]✓[/green] S3 location: s3://{bucket}/{key}")
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -87,3 +87,24 @@ def test_get_latest_model_version():
 
     latest_version_prod = get_latest_model_version(artifacts, AwsEnv.production)
     assert str(latest_version_prod) == "v8"
+
+
+def test_get_latest_model_version__raises():
+    class MockArtifact:
+        def __init__(self, version, aws_env):
+            self.version = version
+            self.metadata = {"aws_env": aws_env.name}
+
+    artifacts = [
+        MockArtifact("v1", AwsEnv("labs")),
+        MockArtifact("v2", AwsEnv("labs")),
+        MockArtifact("v1", AwsEnv("staging")),
+        MockArtifact("v2", AwsEnv("staging")),
+    ]
+
+    with pytest.raises(ValueError) as value_error:
+        get_latest_model_version(artifacts, AwsEnv.production)
+        assert value_error == (
+            "ValueError: No model found in production. Only found versions for: "
+            "{'labs', 'staging'}"
+        )


### PR DESCRIPTION
The previous error was inscrutable, just saying: `ValueError: max() iterable argument is empty`, this aims to make it clearer and nudge towards the common fix